### PR TITLE
Improve remove_unused_if_branch to process if expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+* enhance `remove_unused_if_branch` to process if expressions ([#77](https://github.com/seaofvoices/darklua/pull/77))
 * remove possible panic in AST parsing ([#74](https://github.com/seaofvoices/darklua/pull/74))
-* fix large AST tree parsing issue ([#73](https://github.com/seaofvoices/darklua/pull/73))
+* fix large AST parsing issue ([#73](https://github.com/seaofvoices/darklua/pull/73))
 * refactor ParserError into an opaque struct (instead of an enum) ([#71](https://github.com/seaofvoices/darklua/pull/71))
 * refactor darklua frontend ([#69](https://github.com/seaofvoices/darklua/pull/69)):
   * the `--config-path` argument of the `minify` command was removed

--- a/site/content/rules/remove_unused_if_branch.md
+++ b/site/content/rules/remove_unused_if_branch.md
@@ -2,9 +2,20 @@
 description: Removes unused if branch
 added_in: "0.3.1"
 parameters: []
+examples:
+  - content: "return if true then value else default"
+  - content: "return if false then value else default"
+  - content: |
+      if false then
+          local sum = 0
+          for _, element in ipairs(array) do
+              sum = sum + element
+          end
+          print("sum of array:", sum)
+      end
 ---
 
-When a condition in a if branch (`if condition then` or `elseif condition then`) can be evaluated to a known, the if statement is modified to remove branches that become useless.
+When a condition in a if branch (`if condition then` or `elseif condition then`) can be evaluated to a known value, the if statement (or if expression) is modified to remove branches that become useless.
 
 ```lua
 if unknown then

--- a/src/nodes/expressions/if_expression.rs
+++ b/src/nodes/expressions/if_expression.rs
@@ -96,6 +96,25 @@ impl IfExpression {
         self.branches.iter()
     }
 
+    pub fn clear_elseif_branches(&mut self) {
+        self.branches.clear();
+    }
+
+    pub fn retain_elseif_branches_mut(
+        &mut self,
+        filter: impl FnMut(&mut ElseIfExpressionBranch) -> bool,
+    ) {
+        self.branches.retain_mut(filter);
+    }
+
+    pub fn remove_branch(&mut self, index: usize) -> Option<ElseIfExpressionBranch> {
+        if index < self.branches.len() {
+            Some(self.branches.remove(index))
+        } else {
+            None
+        }
+    }
+
     #[inline]
     pub fn iter_mut_branches(&mut self) -> impl Iterator<Item = &mut ElseIfExpressionBranch> {
         self.branches.iter_mut()
@@ -164,6 +183,10 @@ impl ElseIfExpressionBranch {
     #[inline]
     pub fn mutate_result(&mut self) -> &mut Expression {
         &mut self.result
+    }
+
+    pub fn into_expressions(self) -> (Expression, Expression) {
+        (self.condition, self.result)
     }
 
     pub fn clear_comments(&mut self) {

--- a/src/nodes/expressions/if_expression.rs
+++ b/src/nodes/expressions/if_expression.rs
@@ -96,10 +96,12 @@ impl IfExpression {
         self.branches.iter()
     }
 
+    #[inline]
     pub fn clear_elseif_branches(&mut self) {
         self.branches.clear();
     }
 
+    #[inline]
     pub fn retain_elseif_branches_mut(
         &mut self,
         filter: impl FnMut(&mut ElseIfExpressionBranch) -> bool,

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -76,7 +76,7 @@ impl IfBranch {
 
     #[inline]
     pub fn take_block(&mut self) -> Block {
-        mem::replace(&mut self.block, Block::default())
+        mem::take(&mut self.block)
     }
 
     #[inline]

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use crate::nodes::{Block, Expression, Token};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -70,6 +72,11 @@ impl IfBranch {
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
+    }
+
+    #[inline]
+    pub fn take_block(&mut self) -> Block {
+        mem::replace(&mut self.block, Block::default())
     }
 
     #[inline]
@@ -255,5 +262,16 @@ impl IfStatement {
         self.branches
             .iter_mut()
             .for_each(IfBranch::clear_whitespaces);
+    }
+
+    pub fn retain_branches_mut(&mut self, filter: impl FnMut(&mut IfBranch) -> bool) -> bool {
+        self.branches.retain_mut(filter);
+        if self.branches.is_empty() {
+            // an if statement requires at least one branch
+            self.branches.push(IfBranch::new(false, Block::default()));
+            true
+        } else {
+            false
+        }
     }
 }

--- a/src/process/evaluator/mod.rs
+++ b/src/process/evaluator/mod.rs
@@ -45,6 +45,27 @@ impl Evaluator {
         }
     }
 
+    pub fn can_return_multiple_values(&self, expression: &Expression) -> bool {
+        match expression {
+            Expression::Binary(_)
+            | Expression::Call(_)
+            | Expression::Field(_)
+            | Expression::Index(_)
+            | Expression::Unary(_)
+            | Expression::VariableArguments(_) => true,
+            Expression::False(_)
+            | Expression::Function(_)
+            | Expression::Identifier(_)
+            | Expression::If(_)
+            | Expression::Nil(_)
+            | Expression::Number(_)
+            | Expression::Parenthese(_)
+            | Expression::String(_)
+            | Expression::Table(_)
+            | Expression::True(_) => false,
+        }
+    }
+
     pub fn has_side_effects(&self, expression: &Expression) -> bool {
         match expression {
             Expression::False(_)

--- a/src/rules/unused_if_branch.rs
+++ b/src/rules/unused_if_branch.rs
@@ -1,4 +1,4 @@
-use crate::nodes::{Block, DoStatement, IfStatement, Statement};
+use crate::nodes::{Block, DoStatement, Expression, IfExpression, IfStatement, Statement};
 use crate::process::{DefaultVisitor, Evaluator, NodeProcessor, NodeVisitor};
 use crate::rules::{
     Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
@@ -92,6 +92,94 @@ impl IfFilter {
 
         found_always_true_branch
     }
+
+    fn simplify_if(&self, if_expression: &mut IfExpression) -> Option<Expression> {
+        let condition_value = self.evaluator.evaluate(if_expression.get_condition());
+        match condition_value.is_truthy() {
+            Some(true) => {
+                if self
+                    .evaluator
+                    .has_side_effects(if_expression.get_condition())
+                {
+                    if_expression.clear_elseif_branches();
+                    *if_expression.mutate_else_result() = Self::result_placeholder();
+                    None
+                } else {
+                    let result = if_expression.get_result().clone();
+
+                    Some(if self.evaluator.can_return_multiple_values(&result) {
+                        result.in_parentheses()
+                    } else {
+                        result
+                    })
+                }
+            }
+            Some(false) => {
+                if self
+                    .evaluator
+                    .has_side_effects(if_expression.get_condition())
+                {
+                    *if_expression.mutate_result() = Self::result_placeholder();
+                    None
+                } else if let Some(branch) = if_expression.remove_branch(0) {
+                    let (new_condition, new_result) = branch.into_expressions();
+                    *if_expression.mutate_condition() = new_condition;
+                    *if_expression.mutate_result() = new_result;
+                    self.simplify_if(if_expression)
+                } else {
+                    let result = if_expression.get_else_result().clone();
+
+                    Some(if self.evaluator.can_return_multiple_values(&result) {
+                        result.in_parentheses()
+                    } else {
+                        result
+                    })
+                }
+            }
+            None => {
+                let mut keep_next_branches = true;
+                let mut replace_else_with = None;
+
+                if_expression.retain_elseif_branches_mut(|branch| {
+                    keep_next_branches && {
+                        let branch_condition_value =
+                            self.evaluator.evaluate(branch.get_condition());
+                        match branch_condition_value.is_truthy() {
+                            Some(true) => {
+                                keep_next_branches = false;
+
+                                if self.evaluator.has_side_effects(branch.get_condition()) {
+                                    true
+                                } else {
+                                    replace_else_with = Some(branch.get_result().clone());
+                                    false
+                                }
+                            }
+                            Some(false) => {
+                                if self.evaluator.has_side_effects(branch.get_condition()) {
+                                    *branch.mutate_result() = Self::result_placeholder();
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            None => true,
+                        }
+                    }
+                });
+
+                if !keep_next_branches {
+                    *if_expression.mutate_else_result() =
+                        replace_else_with.unwrap_or_else(Self::result_placeholder);
+                }
+                None
+            }
+        }
+    }
+
+    fn result_placeholder() -> Expression {
+        Expression::nil()
+    }
 }
 
 impl NodeProcessor for IfFilter {
@@ -111,6 +199,14 @@ impl NodeProcessor for IfFilter {
                 }
             }
         });
+    }
+
+    fn process_expression(&mut self, expression: &mut Expression) {
+        if let Expression::If(if_expression) = expression {
+            if let Some(replace_with) = self.simplify_if(if_expression) {
+                *expression = replace_with;
+            }
+        }
     }
 }
 

--- a/src/rules/unused_if_branch.rs
+++ b/src/rules/unused_if_branch.rs
@@ -4,14 +4,12 @@ use crate::rules::{
     Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
 };
 
-use std::mem;
-
 use super::verify_no_rule_properties;
 
 enum FilterResult {
     Keep,
     Remove,
-    Replace(Block),
+    Replace(Statement),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -20,77 +18,69 @@ struct IfFilter {
 }
 
 impl IfFilter {
-    fn filter(&self, statement: &mut IfStatement) -> FilterResult {
-        let found_always_true_branch = self.filter_branches(statement);
-
-        if found_always_true_branch {
-            statement.take_else_block();
+    fn simplify_if_statement(&self, if_statement: &mut IfStatement) -> FilterResult {
+        if let Some(else_block) = if_statement.get_else_block() {
+            if else_block.is_empty() {
+                if_statement.take_else_block();
+            }
         }
 
-        let branch_count = statement.branch_count();
+        let mut keep_next_branches = true;
+        let mut replace_else_with = None;
 
-        if branch_count == 0 {
-            if let Some(block) = statement.take_else_block() {
-                if block.is_empty() {
+        let is_empty = if_statement.retain_branches_mut(|branch| {
+            keep_next_branches && {
+                let branch_condition_value = self.evaluator.evaluate(branch.get_condition());
+                match branch_condition_value.is_truthy() {
+                    Some(true) => {
+                        keep_next_branches = false;
+
+                        if self.evaluator.has_side_effects(branch.get_condition()) {
+                            true
+                        } else {
+                            replace_else_with = Some(branch.take_block());
+                            false
+                        }
+                    }
+                    Some(false) => {
+                        if self.evaluator.has_side_effects(branch.get_condition()) {
+                            branch.take_block();
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    None => true,
+                }
+            }
+        });
+
+        if is_empty {
+            if let Some(block_replacer) = replace_else_with {
+                if block_replacer.is_empty() {
                     FilterResult::Remove
                 } else {
-                    FilterResult::Replace(block)
+                    FilterResult::Replace(DoStatement::new(block_replacer).into())
+                }
+            } else if let Some(else_block) = if_statement.take_else_block() {
+                if else_block.is_empty() {
+                    FilterResult::Remove
+                } else {
+                    FilterResult::Replace(DoStatement::new(else_block).into())
                 }
             } else {
                 FilterResult::Remove
             }
-        } else if found_always_true_branch && branch_count == 1 {
-            let branch = statement.mutate_branches().iter_mut().next().unwrap();
-
-            if !self.evaluator.has_side_effects(branch.get_condition()) {
-                let mut branch_block = Block::default();
-                mem::swap(branch.mutate_block(), &mut branch_block);
-
-                FilterResult::Replace(branch_block)
-            } else {
-                FilterResult::Keep
-            }
         } else {
-            FilterResult::Keep
-        }
-    }
-
-    fn filter_branches(&self, statement: &mut IfStatement) -> bool {
-        let branches = statement.mutate_branches();
-        let mut found_always_true_branch = false;
-        let mut i = 0;
-
-        while i != branches.len() {
-            if found_always_true_branch {
-                branches.remove(i);
-            } else {
-                let branch = branches.get_mut(i).unwrap();
-                let condition = branch.get_condition();
-                let is_truthy = self.evaluator.evaluate(condition).is_truthy();
-
-                if let Some(is_truthy) = is_truthy {
-                    if is_truthy {
-                        found_always_true_branch = true;
-                        i += 1;
-                    } else {
-                        let side_effects = self.evaluator.has_side_effects(condition);
-
-                        if side_effects {
-                            // only need to clear if there are side effects because it means
-                            // that we are keeping the branch just for the condition
-                            branch.mutate_block().clear();
-                            i += 1;
-                        } else {
-                            branches.remove(i);
-                        }
-                    }
+            if !keep_next_branches {
+                if let Some(block_replacer) = replace_else_with {
+                    if_statement.set_else_block(block_replacer);
                 } else {
-                    i += 1;
+                    if_statement.take_else_block();
                 }
             }
+            FilterResult::Keep
         }
-
-        found_always_true_branch
     }
 
     fn simplify_if(&self, if_expression: &mut IfExpression) -> Option<Expression> {
@@ -185,18 +175,17 @@ impl IfFilter {
 impl NodeProcessor for IfFilter {
     fn process_block(&mut self, block: &mut Block) {
         block.filter_mut_statements(|statement| {
-            let result = match statement {
-                Statement::If(if_statement) => self.filter(if_statement),
-                _ => FilterResult::Keep,
-            };
-
-            match result {
-                FilterResult::Keep => true,
-                FilterResult::Remove => false,
-                FilterResult::Replace(block) => {
-                    *statement = DoStatement::new(block).into();
-                    true
+            if let Statement::If(if_statement) = statement {
+                match self.simplify_if_statement(if_statement) {
+                    FilterResult::Keep => true,
+                    FilterResult::Remove => false,
+                    FilterResult::Replace(new_statement) => {
+                        *statement = new_statement;
+                        true
+                    }
                 }
+            } else {
+                true
             }
         });
     }

--- a/tests/rule_tests/remove_unused_if_branch.rs
+++ b/tests/rule_tests/remove_unused_if_branch.rs
@@ -7,10 +7,12 @@ test_rule!(
     falsy_branch_with_empty_else_block_is_removed("if false then else end") => "",
     two_falsy_branch_with_empty_else_block_is_removed("if false then elseif false then end") => "",
     falsy_branch_with_else_block_converts_to_do("if false then else return end") => "do return end",
+    keep_branch_and_remove_empty_else("if condition then return else end") => "if condition then return end",
     one_truthy_branch_remove_else_block("if true then break else end") => "do break end",
     remove_falsy_elseif_branch("if foo then break elseif false then end") => "if foo then break end",
+    remove_falsy_elseif_branch_and_empty_else("if foo then break elseif false then else end") => "if foo then break end",
     remove_branch_after_truthy_branch("if foo then break elseif true then return elseif foo then end")
-        => "if foo then break elseif true then return end",
+        => "if foo then break else return end",
     // if expressions
     expression_true_inline_result_branch("return if true then 'first' else 'second'") => "return 'first'",
     expression_one_inline_result_branch("return if 1 then 'first' else 'second'") => "return 'first'",

--- a/tests/rule_tests/remove_unused_if_branch.rs
+++ b/tests/rule_tests/remove_unused_if_branch.rs
@@ -10,7 +10,37 @@ test_rule!(
     one_truthy_branch_remove_else_block("if true then break else end") => "do break end",
     remove_falsy_elseif_branch("if foo then break elseif false then end") => "if foo then break end",
     remove_branch_after_truthy_branch("if foo then break elseif true then return elseif foo then end")
-        => "if foo then break elseif true then return end"
+        => "if foo then break elseif true then return end",
+    // if expressions
+    expression_true_inline_result_branch("return if true then 'first' else 'second'") => "return 'first'",
+    expression_one_inline_result_branch("return if 1 then 'first' else 'second'") => "return 'first'",
+    expression_true_inline_result_branch_with_field_expression(
+        "return if true then value.prop else 'second'"
+    ) => "return (value.prop)",
+    expression_true_inline_result_branch_with_index_expression(
+        "return if true then value['prop'] else 'second'"
+    ) => "return (value['prop'])",
+    expression_true_inline_result_branch_with_variadic_expression(
+        "return if true then ... else 'second'"
+    ) => "return (...)",
+    expression_true_inline_result_branch_with_function_call("return if true then call() else 'second'") => "return (call())",
+    expression_false_inline_else_branch("return if false then 'first' else 'second'") => "return 'second'",
+    expression_nil_inline_else_branch("return if nil then 'first' else 'second'") => "return 'second'",
+    expression_false_inline_else_branch_with_variadic_expression("return if false then 'first' else ...") => "return (...)",
+    expression_false_inline_else_branch_with_function_call("return if false then 'first' else call()") => "return (call())",
+    expression_first_elseif_is_true("return if false then 'first' elseif true then 'second' else 'third'") => "return 'second'",
+    expression_all_elseif_are_false(
+        "return if false then 'first' elseif false then 'second' elseif false then 'third' else 'fourth'"
+    ) => "return 'fourth'",
+    expression_remove_elseif_after_first_true(
+        "return if var then 1 elseif var2 then 2 elseif true then 3 elseif var4 then 4 else 5"
+    ) => "return if var then 1 elseif var2 then 2 else 3",
+    expression_if_unknown_and_first_elseif_is_true(
+        "return if var then 'first' elseif true then 'second' else 'third'"
+    ) => "return if var then 'first' else 'second'",
+    expression_if_unknown_and_single_elseif_is_false(
+        "return if var then 'first' elseif false then 'second' else 'third'"
+    ) => "return if var then 'first' else 'third'",
 );
 
 #[test]


### PR DESCRIPTION
Closes #64 

The `remove_unused_if_branch` rule was created before if expressions were supported, so the rule was not processing those.

- [x] add entry to the changelog
