### PR TITLE
Migrate to latest clap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* upgrade CLI library (mostly changes the help messages format) ([#83](https://github.com/seaofvoices/darklua/pull/83))
 * add rule to remove compount assignments ([#78](https://github.com/seaofvoices/darklua/pull/78))
 * enhance `remove_unused_if_branch` to process if expressions ([#77](https://github.com/seaofvoices/darklua/pull/77))
 * remove possible panic in AST parsing ([#74](https://github.com/seaofvoices/darklua/pull/74))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -178,29 +178,42 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "textwrap 0.16.0",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.1",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -208,6 +221,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -325,6 +347,7 @@ name = "darklua"
 version = "0.8.0"
 dependencies = [
  "assert_cmd",
+ "clap 4.1.1",
  "criterion",
  "durationfmt",
  "elsa",
@@ -341,7 +364,6 @@ dependencies = [
  "rand_distr",
  "regex",
  "serde",
- "structopt",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -427,6 +449,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -525,18 +568,24 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -601,6 +650,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +723,12 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -766,7 +843,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1132,6 +1209,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,33 +1354,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1340,15 +1407,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -1487,18 +1545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,16 +1557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"
@@ -1649,12 +1689,33 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.32.0",
+ "windows_i686_gnu 0.32.0",
+ "windows_i686_msvc 0.32.0",
+ "windows_x86_64_gnu 0.32.0",
+ "windows_x86_64_msvc 0.32.0",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1663,10 +1724,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1675,16 +1748,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/bin.rs"
 tracing = ["dep:tracing"]
 
 [dependencies]
+clap = { version = "4.1.1", features = ["derive"] }
 durationfmt = "0.1.1"
 env_logger = "0.9.0"
 log = "0.4"
-structopt = "0.3.25"
 full_moon = { version = "0.16.2", features = ["roblox"] }
 serde = { version = "1.0", features = ["derive"] }
 json5 = "0.4"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -2,16 +2,16 @@ mod cli;
 
 use std::process;
 
+use clap::Parser;
 use cli::Darklua;
 use env_logger::{
     fmt::{Color, Style, StyledValue},
     Builder,
 };
 use log::Level;
-use structopt::StructOpt;
 
 fn main() {
-    let darklua = Darklua::from_args();
+    let darklua = Darklua::parse();
 
     let filter = darklua.get_log_level_filter();
 

--- a/src/cli/minify.rs
+++ b/src/cli/minify.rs
@@ -2,21 +2,19 @@ use crate::cli::error::CliError;
 use crate::cli::utils::maybe_plural;
 use crate::cli::{CommandResult, GlobalOptions};
 
+use clap::Args;
 use darklua_core::{Configuration, GeneratorParameters, Resources};
 use std::path::PathBuf;
 use std::time::Instant;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Options {
     /// Path to the lua file to minify.
-    #[structopt(parse(from_os_str))]
     input_path: PathBuf,
     /// Where to output the result.
-    #[structopt(parse(from_os_str))]
     output_path: PathBuf,
     /// The maximum number of characters that should be written on a line.
-    #[structopt(long)]
+    #[arg(long)]
     column_span: Option<usize>,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,17 +3,17 @@ pub mod minify;
 pub mod process;
 pub mod utils;
 
+use clap::{Args, Parser, Subcommand};
 use log::LevelFilter;
-use structopt::StructOpt;
 
 use self::error::CliError;
 
 type CommandResult = Result<(), CliError>;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct GlobalOptions {
     /// Sets verbosity level (can be specified multiple times)
-    #[structopt(long, short, global(true), parse(from_occurrences))]
+    #[arg(long, short, global(true), action = clap::ArgAction::Count)]
     verbose: u8,
 }
 
@@ -28,7 +28,7 @@ impl GlobalOptions {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     /// Minify lua files without applying any transformation
     Minify(minify::Options),
@@ -49,17 +49,17 @@ impl Command {
     }
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "darklua")]
+#[derive(Debug, Parser)]
+#[command(name = "darklua", about, version, propagate_version = true)]
 /// Transform Lua scripts
 ///
 /// For specific help about each command, run `darklua <command> --help`
 ///
 /// Site: https://darklua.com
 pub struct Darklua {
-    #[structopt(flatten)]
+    #[command(flatten)]
     global_options: GlobalOptions,
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 

--- a/src/cli/process.rs
+++ b/src/cli/process.rs
@@ -2,26 +2,24 @@ use crate::cli::error::CliError;
 use crate::cli::utils::maybe_plural;
 use crate::cli::{CommandResult, GlobalOptions};
 
+use clap::Args;
 use darklua_core::{GeneratorParameters, Resources};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Options {
     /// Path to the lua file to process.
-    #[structopt(parse(from_os_str))]
     input_path: PathBuf,
     /// Where to output the result.
-    #[structopt(parse(from_os_str))]
     output_path: PathBuf,
     /// Choose a specific configuration file.
-    #[structopt(long, short, alias = "config-path")]
+    #[arg(long, short, alias = "config-path")]
     config: Option<PathBuf>,
     /// Choose how Lua code is formatted ('dense', 'readable' or 'retain-lines').
     /// This will override the format given by the configuration file.
-    #[structopt(long)]
+    #[arg(long)]
     format: Option<LuaFormat>,
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -184,6 +184,13 @@ fn snapshot_help_command() {
 }
 
 #[test]
+fn snapshot_short_help_command() {
+    Context::default()
+        .arg("-h")
+        .snapshot_command("short_help_command");
+}
+
+#[test]
 fn snapshot_process_help_command() {
     Context::default()
         .arg("process")

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -2,23 +2,29 @@
 source: tests/cli.rs
 expression: content
 ---
-darklua 0.8.0
 Transform Lua scripts
 
 For specific help about each command, run `darklua <command> --help`
 
 Site: https://darklua.com
 
-USAGE:
-    darklua [FLAGS] <SUBCOMMAND>
+Usage: darklua [OPTIONS] <COMMAND>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    Sets verbosity level (can be specified multiple times)
+Commands:
+  minify
+          Minify lua files without applying any transformation
+  process
+          Process lua files with rules
+  help
+          Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    help       Prints this message or the help of the given subcommand(s)
-    minify     Minify lua files without applying any transformation
-    process    Process lua files with rules
+Options:
+  -v, --verbose...
+          Sets verbosity level (can be specified multiple times)
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 

--- a/tests/snapshots/minify_help_command.snap
+++ b/tests/snapshots/minify_help_command.snap
@@ -2,21 +2,17 @@
 source: tests/cli.rs
 expression: content
 ---
-darklua-minify 0.8.0
 Minify lua files without applying any transformation
 
-USAGE:
-    darklua minify [FLAGS] [OPTIONS] <input-path> <output-path>
+Usage: darklua minify [OPTIONS] <INPUT_PATH> <OUTPUT_PATH>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    Sets verbosity level (can be specified multiple times)
+Arguments:
+  <INPUT_PATH>   Path to the lua file to minify
+  <OUTPUT_PATH>  Where to output the result
 
-OPTIONS:
-        --column-span <column-span>    The maximum number of characters that should be written on a line
-
-ARGS:
-    <input-path>     Path to the lua file to minify
-    <output-path>    Where to output the result
+Options:
+      --column-span <COLUMN_SPAN>  The maximum number of characters that should be written on a line
+  -v, --verbose...                 Sets verbosity level (can be specified multiple times)
+  -h, --help                       Print help
+  -V, --version                    Print version
 

--- a/tests/snapshots/process_help_command.snap
+++ b/tests/snapshots/process_help_command.snap
@@ -2,39 +2,32 @@
 source: tests/cli.rs
 expression: content
 ---
-darklua-process 0.8.0
 Process lua files with rules
 
-Configure the code transformation using a configuration file. If no configuration is passed, darklua will attempt to
-read `.darklua.json` or `darklua.json5` from the working directory.
+Configure the code transformation using a configuration file. If no configuration is passed, darklua will attempt to read `.darklua.json` or `darklua.json5` from the working directory.
 
-USAGE:
-    darklua process [FLAGS] [OPTIONS] <input-path> <output-path>
+Usage: darklua process [OPTIONS] <INPUT_PATH> <OUTPUT_PATH>
 
-FLAGS:
-    -h, --help       
-            Prints help information
+Arguments:
+  <INPUT_PATH>
+          Path to the lua file to process
 
-    -V, --version    
-            Prints version information
+  <OUTPUT_PATH>
+          Where to output the result
 
-    -v, --verbose    
-            Sets verbosity level (can be specified multiple times)
+Options:
+  -c, --config <CONFIG>
+          Choose a specific configuration file
 
+  -v, --verbose...
+          Sets verbosity level (can be specified multiple times)
 
-OPTIONS:
-    -c, --config <config>    
-            Choose a specific configuration file
+      --format <FORMAT>
+          Choose how Lua code is formatted ('dense', 'readable' or 'retain-lines'). This will override the format given by the configuration file
 
-        --format <format>    
-            Choose how Lua code is formatted ('dense', 'readable' or 'retain-lines'). This will override the format
-            given by the configuration file
+  -h, --help
+          Print help (see a summary with '-h')
 
-ARGS:
-    <input-path>     
-            Path to the lua file to process
-
-    <output-path>    
-            Where to output the result
-
+  -V, --version
+          Print version
 

--- a/tests/snapshots/short_help_command.snap
+++ b/tests/snapshots/short_help_command.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli.rs
+expression: content
+---
+Transform Lua scripts
+
+Usage: darklua [OPTIONS] <COMMAND>
+
+Commands:
+  minify   Minify lua files without applying any transformation
+  process  Process lua files with rules
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Sets verbosity level (can be specified multiple times)
+  -h, --help        Print help (see more with '--help')
+  -V, --version     Print version
+


### PR DESCRIPTION
Closes #81 

Get rid of structopt (which is in maintenance mode) to clap derive instead.

- [x] add entry to the changelog
