### PR TITLE
Use ubuntu latest runners for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
             artifact-name: darklua-windows-x86_64
             cargo-target: x86_64-pc-windows-msvc
 
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             artifact-name: darklua-linux-x86_64
             cargo-target: x86_64-unknown-linux-gnu
 
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             artifact-name: darklua-linux-aarch64
             cargo-target: aarch64-unknown-linux-gnu
             linker: gcc-aarch64-linux-gnu


### PR DESCRIPTION
The latest run for the release workflow is currently pending because it's requiring an unavailable runner version. To fix that, the workflow just need to use the ubuntu latest runners.