### PR TITLE
add stacker feature to full-moon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * fix number parsing to support underscores before `x` in hexadecimal number and before `b` in binary numbers ([#103](https://github.com/seaofvoices/darklua/pull/103))
 * add bundling with path require mode ([#97](https://github.com/seaofvoices/darklua/pull/97))
 * upgrade full-moon parser to 0.18.1 ([#100](https://github.com/seaofvoices/darklua/pull/100))
+* enable stacker feature on full-moon to avoid stack overflows on large input ([#109](https://github.com/seaofvoices/darklua/pull/109))
 
 ## 0.9.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
  "paste",
  "serde",
  "smol_str",
+ "stacker",
 ]
 
 [[package]]
@@ -1170,6 +1171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1471,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "4.1.1", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.7.0"
 env_logger = "0.9.0"
-full_moon = { version = "0.18.1", features = ["roblox"] }
+full_moon = { version = "0.18.1", features = ["roblox","stacker"] }
 json5 = "0.4"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
darklua has issues / frequent errors operating on source files compiled by flamework & roblox-ts. Per a suggestion by kampfkarren, enabling the stacker feature for full-moon fixes these issues.