### PR TITLE
Escape extended ascii characters with backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix dense and readable string generator to escape extended ascii using backslashes ([#111](https://github.com/seaofvoices/darklua/pull/111))
 * fix number parsing to support underscore after decimal point (like `0._123`) ([#110](https://github.com/seaofvoices/darklua/pull/110))
 * add rule to convert require modes (from paths to Roblox instances) ([#107](https://github.com/seaofvoices/darklua/pull/107))
 * fix number parsing to support underscores before `x` in hexadecimal number and before `b` in binary numbers ([#103](https://github.com/seaofvoices/darklua/pull/103))

--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -215,7 +215,7 @@ fn escape(character: char) -> String {
         '\u{B}' => "\\v".to_owned(),
         '\u{C}' => "\\f".to_owned(),
         _ => {
-            if character.is_ascii() {
+            if (character as u32) < 256 {
                 format!("\\{}", character as u8)
             } else {
                 format!("\\u{{{:x}}}", character as u32)
@@ -351,7 +351,8 @@ mod test {
             double_quote("\"") => "'\"'",
             null("\0") => "'\\0'",
             escape("\u{1B}") => "'\\27'",
-            unicode("\u{10FFFF}") => "'\\u{10ffff}'",
+            extended_ascii("\u{C3}") => "'\\195'",
+            unicode("\u{25C1}") => "'\\u{25c1}'",
             im_cool("I'm cool") => "\"I'm cool\"",
             ends_with_closing_bracket("oof]") => "'oof]'",
             multiline_ends_with_closing_bracket("oof\noof]") => "'oof\\noof]'",


### PR DESCRIPTION
Closes #104 

Instead of escaping the characters with a unicode escape, which is available for Luau and Lua >= 5.3, use backslashes.

- [x] add entry to the changelog
