### PR TITLE
installation: add section about 3rd-party packages

### DIFF
--- a/site/content/docs/installation/index.md
+++ b/site/content/docs/installation/index.md
@@ -32,3 +32,9 @@ If you want to use the lastest darklua available, install it using the git url:
 ```
 cargo install --git https://github.com/seaofvoices/darklua.git
 ```
+
+## Other package managers
+
+darklua is available in some third-party package managers. These packages are primarily supported by the community.
+
+[![Packaging status via Repology](https://repology.org/badge/vertical-allrepos/darklua.svg)](https://repology.org/project/darklua/versions)


### PR DESCRIPTION
I made a Nixpkgs package for darklua. Others might also make packages, so I took initiative and made this section in the docs. It uses [Repology](https://repology.org/)'s badge.

- [ ] ~~add entry to the changelog~~ This is a documentation change, I don't think a changelog entry is necessary. Please correct me if I am wrong.
