### PR TITLE
Fix empty AST with trivia tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* fix empty AST that contains comment or spacing tokens ([#132](https://github.com/seaofvoices/darklua/pull/132))
+* fix lost comment or spacing tokens in empty ASTs ([#132](https://github.com/seaofvoices/darklua/pull/132))
 * add rule to remove Luau types ([#130](https://github.com/seaofvoices/darklua/pull/130))
 * add support for Luau types ([#129](https://github.com/seaofvoices/darklua/pull/129))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix empty AST that contains comment or spacing tokens ([#132](https://github.com/seaofvoices/darklua/pull/132))
 * add rule to remove Luau types ([#130](https://github.com/seaofvoices/darklua/pull/130))
 * add support for Luau types ([#129](https://github.com/seaofvoices/darklua/pull/129))
 

--- a/src/generator/token_based.rs
+++ b/src/generator/token_based.rs
@@ -60,26 +60,28 @@ impl<'a> TokenBasedLuaGenerator<'a> {
 
         let content = token.read(self.original_code);
 
-        if self.currently_commenting {
-            self.uncomment();
-        }
-
-        if let Some(line_number) = token.get_line_number() {
-            while line_number > self.current_line {
-                self.output.push('\n');
-                self.current_line += 1;
+        if !content.is_empty() {
+            if self.currently_commenting {
+                self.uncomment();
             }
-        }
 
-        if space_check {
-            if let Some(next_character) = content.chars().next() {
-                if self.needs_space(next_character) {
-                    self.output.push(' ');
+            if let Some(line_number) = token.get_line_number() {
+                while line_number > self.current_line {
+                    self.output.push('\n');
+                    self.current_line += 1;
                 }
             }
-        }
 
-        self.push_str(content);
+            if space_check {
+                if let Some(next_character) = content.chars().next() {
+                    if self.needs_space(next_character) {
+                        self.output.push(' ');
+                    }
+                }
+            }
+
+            self.push_str(content);
+        }
 
         for trivia in token.iter_trailing_trivia() {
             self.write_trivia(trivia);
@@ -105,6 +107,10 @@ impl<'a> TokenBasedLuaGenerator<'a> {
 
         if let Some(statement) = block.get_last_statement() {
             self.write_last_statement(statement);
+        }
+
+        if let Some(token) = &tokens.final_token {
+            self.write_token(token);
         }
     }
 
@@ -1110,6 +1116,7 @@ impl<'a> TokenBasedLuaGenerator<'a> {
         BlockTokens {
             semicolons: Vec::new(),
             last_semicolon: None,
+            final_token: None,
         }
     }
 

--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -15,6 +15,9 @@ impl BlockTokens {
         if let Some(last_semicolon) = &mut self.last_semicolon {
             last_semicolon.clear_comments();
         }
+        if let Some(final_token) = &mut self.final_token {
+            final_token.clear_comments();
+        }
     }
 
     pub fn clear_whitespaces(&mut self) {
@@ -23,6 +26,9 @@ impl BlockTokens {
         }
         if let Some(last_semicolon) = &mut self.last_semicolon {
             last_semicolon.clear_whitespaces();
+        }
+        if let Some(final_token) = &mut self.final_token {
+            final_token.clear_whitespaces();
         }
     }
 
@@ -33,6 +39,9 @@ impl BlockTokens {
         if let Some(last_semicolon) = &mut self.last_semicolon {
             last_semicolon.replace_referenced_tokens(code);
         }
+        if let Some(final_token) = &mut self.final_token {
+            final_token.replace_referenced_tokens(code);
+        }
     }
 
     pub(crate) fn shift_token_line(&mut self, amount: usize) {
@@ -41,6 +50,9 @@ impl BlockTokens {
         }
         if let Some(last_semicolon) = &mut self.last_semicolon {
             last_semicolon.shift_token_line(amount);
+        }
+        if let Some(final_token) = &mut self.final_token {
+            final_token.shift_token_line(amount);
         }
     }
 }

--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -4,6 +4,7 @@ use crate::nodes::{LastStatement, ReturnStatement, Statement, Token};
 pub struct BlockTokens {
     pub semicolons: Vec<Option<Token>>,
     pub last_semicolon: Option<Token>,
+    pub final_token: Option<Token>,
 }
 
 impl BlockTokens {
@@ -73,6 +74,11 @@ impl Block {
     #[inline]
     pub fn get_tokens(&self) -> Option<&BlockTokens> {
         self.tokens.as_ref().map(|tokens| tokens.as_ref())
+    }
+
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut BlockTokens> {
+        self.tokens.as_mut().map(|tokens| tokens.as_mut())
     }
 
     pub fn push_statement<T: Into<Statement>>(&mut self, statement: T) {
@@ -428,7 +434,8 @@ mod test {
             block.get_tokens(),
             Some(&BlockTokens {
                 semicolons: vec![None],
-                last_semicolon: None
+                last_semicolon: None,
+                final_token: None,
             })
         );
     }
@@ -440,6 +447,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: vec![Some(Token::from_content(";"))],
                 last_semicolon: None,
+                final_token: None,
             });
         block.clear();
 
@@ -453,6 +461,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: Vec::new(),
                 last_semicolon: Some(Token::from_content(";")),
+                final_token: None,
             });
         block.clear();
 
@@ -466,6 +475,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: vec![Some(Token::from_content(";"))],
                 last_semicolon: None,
+                final_token: None,
             });
         block.set_statements(Vec::new());
 
@@ -479,6 +489,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: Vec::new(),
                 last_semicolon: Some(Token::from_content(";")),
+                final_token: None,
             });
 
         assert_eq!(
@@ -497,6 +508,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: vec![Some(Token::from_content(";"))],
                 last_semicolon: None,
+                final_token: None,
             });
 
         block.filter_statements(|_statement| false);
@@ -506,6 +518,7 @@ mod test {
             Block::default().with_tokens(BlockTokens {
                 semicolons: Vec::new(),
                 last_semicolon: None,
+                final_token: None,
             })
         );
     }
@@ -518,6 +531,7 @@ mod test {
             .with_tokens(BlockTokens {
                 semicolons: vec![Some(Token::from_content(";"))],
                 last_semicolon: None,
+                final_token: None,
             });
 
         block.filter_mut_statements(|_statement| false);
@@ -527,6 +541,7 @@ mod test {
             Block::default().with_tokens(BlockTokens {
                 semicolons: Vec::new(),
                 last_semicolon: None,
+                final_token: None,
             })
         );
     }

--- a/src/nodes/snapshots/darklua_core__nodes__block__test__insert_statement_after_statement_upper_bound_with_tokens.snap
+++ b/src/nodes/snapshots/darklua_core__nodes__block__test__insert_statement_after_statement_upper_bound_with_tokens.snap
@@ -13,6 +13,7 @@ Block {
                         BlockTokens {
                             semicolons: [],
                             last_semicolon: None,
+                            final_token: None,
                         },
                     ),
                 },
@@ -81,6 +82,7 @@ Block {
                 None,
             ],
             last_semicolon: None,
+            final_token: None,
         },
     ),
 }

--- a/src/nodes/snapshots/darklua_core__nodes__block__test__insert_statement_at_index_0_with_tokens.snap
+++ b/src/nodes/snapshots/darklua_core__nodes__block__test__insert_statement_at_index_0_with_tokens.snap
@@ -26,6 +26,7 @@ Block {
                         BlockTokens {
                             semicolons: [],
                             last_semicolon: None,
+                            final_token: None,
                         },
                     ),
                 },
@@ -81,6 +82,7 @@ Block {
                 ),
             ],
             last_semicolon: None,
+            final_token: None,
         },
     ),
 }

--- a/src/nodes/token.rs
+++ b/src/nodes/token.rs
@@ -145,6 +145,11 @@ impl Token {
     }
 
     #[inline]
+    pub fn has_trivia(&self) -> bool {
+        !self.leading_trivia.is_empty() || !self.trailing_trivia.is_empty()
+    }
+
+    #[inline]
     pub fn push_leading_trivia(&mut self, trivia: Trivia) {
         self.leading_trivia.push(trivia);
     }


### PR DESCRIPTION
When converting an empty AST with comments or spaces, this information was previously lost. Now, it is retained in the `final_token` block tokens.

- [x] add entry to the changelog
