### PR TITLE
Add rule to append text comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* add rule to append text comments ([#141](https://github.com/seaofvoices/darklua/pull/141))
+
 ## 0.11.3
 
 * fix undeclared modules variable when bundling ([#151](https://github.com/seaofvoices/darklua/pull/151))

--- a/site/content/rules/append_text_comment.md
+++ b/site/content/rules/append_text_comment.md
@@ -1,0 +1,24 @@
+---
+description: Append a comment at the start or end of a file
+added_in: "unreleased"
+parameters:
+  - name: text
+    type: string
+    description: The string to use inside the comment (required if `file` is not defined)
+  - name: file
+    type: string
+    description: A path to a file to be used as the comment content (required if `text` is not defined)
+  - name: location
+    default: "start"
+    type: '"start" or "end"'
+    description: The location where to add the comment
+examples:
+  - rules: "[{ rule: 'append_text_comment', text: 'hello!' }]"
+    content: print('Print from module')
+  - rules: "[{ rule: 'append_text_comment', text: 'hello!', location: 'end' }]"
+    content: print('Print from module')
+---
+
+Use this rule to automatically insert a comment at the start or end of a file. This rule can be useful if you want to insert your license in each file.
+
+**Note:** make sure to avoid using the `remove_comments` rule _after_ this rule in the process sequence, otherwise you will be removing your brand new comment.

--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -200,6 +200,16 @@ impl Block {
         self.statements.iter_mut()
     }
 
+    #[inline]
+    pub fn first_statement(&self) -> Option<&Statement> {
+        self.statements.first()
+    }
+
+    #[inline]
+    pub fn first_mut_statement(&mut self) -> Option<&mut Statement> {
+        self.statements.first_mut()
+    }
+
     pub fn take_statements(&mut self) -> Vec<Statement> {
         if let Some(tokens) = &mut self.tokens {
             tokens.semicolons.clear();

--- a/src/nodes/expressions/parenthese.rs
+++ b/src/nodes/expressions/parenthese.rs
@@ -72,6 +72,11 @@ impl ParentheseExpression {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut ParentheseTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn clear_comments(&mut self) {
         if let Some(tokens) = &mut self.tokens {
             tokens.clear_comments();

--- a/src/nodes/identifier.rs
+++ b/src/nodes/identifier.rs
@@ -36,6 +36,11 @@ impl Identifier {
     }
 
     #[inline]
+    pub fn mutate_token(&mut self) -> Option<&mut Token> {
+        self.token.as_mut()
+    }
+
+    #[inline]
     pub fn get_name(&self) -> &String {
         &self.name
     }

--- a/src/nodes/statements/assign.rs
+++ b/src/nodes/statements/assign.rs
@@ -92,6 +92,11 @@ impl AssignStatement {
     }
 
     #[inline]
+    pub fn iter_mut_variables(&mut self) -> impl Iterator<Item = &mut Variable> {
+        self.variables.iter_mut()
+    }
+
+    #[inline]
     pub fn last_value(&self) -> Option<&Expression> {
         self.values.last()
     }

--- a/src/nodes/statements/function.rs
+++ b/src/nodes/statements/function.rs
@@ -239,7 +239,12 @@ impl FunctionStatement {
 
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionBodyTokens> {
-        self.tokens.as_ref().map(|tokens| tokens.as_ref())
+        self.tokens.as_deref()
+    }
+
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut FunctionBodyTokens> {
+        self.tokens.as_deref_mut()
     }
 
     pub fn with_parameter(mut self, parameter: impl Into<TypedIdentifier>) -> Self {

--- a/src/nodes/statements/generic_for.rs
+++ b/src/nodes/statements/generic_for.rs
@@ -100,6 +100,11 @@ impl GenericForStatement {
     }
 
     #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut GenericForTokens> {
+        self.tokens.as_mut()
+    }
+
+    #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -204,6 +204,11 @@ impl IfStatement {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut IfStatementTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn with_branch(mut self, branch: IfBranch) -> Self {
         self.branches.push(branch);
         self

--- a/src/nodes/statements/last_statement.rs
+++ b/src/nodes/statements/last_statement.rs
@@ -107,6 +107,11 @@ impl ReturnStatement {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut ReturnTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn clear_comments(&mut self) {
         if let Some(tokens) = &mut self.tokens {
             tokens.clear_comments();

--- a/src/nodes/statements/local_assign.rs
+++ b/src/nodes/statements/local_assign.rs
@@ -99,6 +99,11 @@ impl LocalAssignStatement {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut LocalAssignTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn with_variable<S: Into<TypedIdentifier>>(mut self, variable: S) -> Self {
         self.variables.push(variable.into());
         self

--- a/src/nodes/statements/local_function.rs
+++ b/src/nodes/statements/local_function.rs
@@ -101,7 +101,12 @@ impl LocalFunctionStatement {
 
     #[inline]
     pub fn get_tokens(&self) -> Option<&LocalFunctionTokens> {
-        self.tokens.as_ref().map(|tokens| tokens.as_ref())
+        self.tokens.as_deref()
+    }
+
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut LocalFunctionTokens> {
+        self.tokens.as_deref_mut()
     }
 
     pub fn with_parameter(mut self, parameter: impl Into<TypedIdentifier>) -> Self {

--- a/src/nodes/statements/numeric_for.rs
+++ b/src/nodes/statements/numeric_for.rs
@@ -105,6 +105,11 @@ impl NumericForStatement {
     }
 
     #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut NumericForTokens> {
+        self.tokens.as_mut()
+    }
+
+    #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }

--- a/src/nodes/statements/repeat_statement.rs
+++ b/src/nodes/statements/repeat_statement.rs
@@ -79,6 +79,11 @@ impl RepeatStatement {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut RepeatTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn clear_comments(&mut self) {
         if let Some(tokens) = &mut self.tokens {
             tokens.clear_comments();

--- a/src/nodes/statements/while_statement.rs
+++ b/src/nodes/statements/while_statement.rs
@@ -84,6 +84,11 @@ impl WhileStatement {
         self.tokens.as_ref()
     }
 
+    #[inline]
+    pub fn mutate_tokens(&mut self) -> Option<&mut WhileTokens> {
+        self.tokens.as_mut()
+    }
+
     pub fn clear_comments(&mut self) {
         if let Some(tokens) = &mut self.tokens {
             tokens.clear_comments();

--- a/src/rules/append_text_comment.rs
+++ b/src/rules/append_text_comment.rs
@@ -1,0 +1,550 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use crate::nodes::{
+    Block, BlockTokens, DoTokens, FunctionBodyTokens, GenericForTokens, Identifier,
+    IfStatementTokens, LastStatement, LocalAssignTokens, LocalFunctionTokens, NumericForTokens,
+    ParentheseExpression, ParentheseTokens, Prefix, RepeatTokens, ReturnTokens, Statement, Token,
+    TriviaKind, TypeDeclarationTokens, Variable, WhileTokens,
+};
+use crate::rules::{
+    verify_property_collisions, verify_required_any_properties, Context, Rule, RuleConfiguration,
+    RuleConfigurationError, RuleProcessResult, RuleProperties,
+};
+
+use super::{FlawlessRule, ShiftTokenLine};
+
+pub const APPEND_TEXT_COMMENT_RULE_NAME: &str = "append_text_comment";
+
+/// A rule to append a comment at the beginning or the end of each file.
+#[derive(Debug, Default)]
+pub struct AppendTextComment {
+    text_value: OnceLock<Result<String, String>>,
+    text_content: TextContent,
+    location: AppendLocation,
+}
+
+impl AppendTextComment {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self {
+            text_value: Default::default(),
+            text_content: TextContent::Value(value.into()),
+            location: Default::default(),
+        }
+    }
+
+    pub fn from_file_content(file_path: impl Into<PathBuf>) -> Self {
+        Self {
+            text_value: Default::default(),
+            text_content: TextContent::FilePath(file_path.into()),
+            location: Default::default(),
+        }
+    }
+
+    pub fn at_end(mut self) -> Self {
+        self.location = AppendLocation::End;
+        self
+    }
+
+    fn text(&self, project_path: &Path) -> Result<String, String> {
+        self.text_value
+            .get_or_init(|| {
+                match &self.text_content {
+                    TextContent::None => Err("".to_owned()),
+                    TextContent::Value(value) => Ok(value.clone()),
+                    TextContent::FilePath(file_path) => {
+                        fs::read_to_string(project_path.join(file_path)).map_err(|err| {
+                            format!("unable to read file `{}`: {}", file_path.display(), err)
+                        })
+                    }
+                }
+                .map(|content| {
+                    let content = content.trim();
+                    if content.is_empty() {
+                        "".to_owned()
+                    } else if content.contains('\n') {
+                        let mut equal_count = 0;
+
+                        let close_comment = loop {
+                            let close_comment = format!("]{}]", "=".repeat(equal_count));
+                            if !content.contains(&close_comment) {
+                                break close_comment;
+                            }
+                            equal_count += 1;
+                        };
+
+                        format!(
+                            "--[{}[\ncontent\n{}",
+                            "=".repeat(equal_count),
+                            close_comment
+                        )
+                    } else {
+                        format!("-- {}", content)
+                    }
+                })
+            })
+            .clone()
+    }
+}
+
+impl Rule for AppendTextComment {
+    fn process(&self, block: &mut Block, context: &Context) -> RuleProcessResult {
+        let text = self.text(context.project_location())?;
+
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        let shift_lines = text.lines().count();
+        ShiftTokenLine::new(shift_lines).flawless_process(block, context);
+
+        match self.location {
+            AppendLocation::Start => {
+                if let Some(statement) = block.first_mut_statement() {
+                    match statement {
+                        Statement::Assign(assign_statement) => {
+                            let variable = assign_statement
+                                .iter_mut_variables()
+                                .next()
+                                .ok_or("an assign statement must have at least one variable")?;
+                            self.location
+                                .append_comment(variable_get_first_token(variable), text);
+                        }
+                        Statement::Do(do_statement) => {
+                            if let Some(tokens) = do_statement.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#do, text);
+                            } else {
+                                let mut token = Token::from_content("do");
+                                self.location.append_comment(&mut token, text);
+
+                                do_statement.set_tokens(DoTokens {
+                                    r#do: token,
+                                    end: Token::from_content("end"),
+                                });
+                            }
+                        }
+                        Statement::Call(call) => {
+                            self.location
+                                .append_comment(prefix_get_first_token(call.mutate_prefix()), text);
+                        }
+                        Statement::CompoundAssign(compound_assign) => {
+                            self.location.append_comment(
+                                variable_get_first_token(compound_assign.mutate_variable()),
+                                text,
+                            );
+                        }
+                        Statement::Function(function) => {
+                            if let Some(tokens) = function.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.function, text);
+                            } else {
+                                let mut token = Token::from_content("function");
+                                self.location.append_comment(&mut token, text);
+
+                                function.set_tokens(FunctionBodyTokens {
+                                    function: token,
+                                    opening_parenthese: Token::from_content("("),
+                                    closing_parenthese: Token::from_content(")"),
+                                    end: Token::from_content("end"),
+                                    parameter_commas: Vec::new(),
+                                    variable_arguments: None,
+                                    variable_arguments_colon: None,
+                                    return_type_colon: None,
+                                });
+                            }
+                        }
+                        Statement::GenericFor(generic_for) => {
+                            if let Some(tokens) = generic_for.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#for, text);
+                            } else {
+                                let mut token = Token::from_content("for");
+                                self.location.append_comment(&mut token, text);
+
+                                generic_for.set_tokens(GenericForTokens {
+                                    r#for: token,
+                                    r#in: Token::from_content("in"),
+                                    r#do: Token::from_content("do"),
+                                    end: Token::from_content("end"),
+                                    identifier_commas: Vec::new(),
+                                    value_commas: Vec::new(),
+                                });
+                            }
+                        }
+                        Statement::If(if_statement) => {
+                            if let Some(tokens) = if_statement.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#if, text);
+                            } else {
+                                let mut token = Token::from_content("if");
+                                self.location.append_comment(&mut token, text);
+
+                                if_statement.set_tokens(IfStatementTokens {
+                                    r#if: token,
+                                    then: Token::from_content("then"),
+                                    end: Token::from_content("end"),
+                                    r#else: None,
+                                });
+                            }
+                        }
+                        Statement::LocalAssign(local_assign) => {
+                            if let Some(tokens) = local_assign.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.local, text);
+                            } else {
+                                let mut token = Token::from_content("local");
+                                self.location.append_comment(&mut token, text);
+
+                                local_assign.set_tokens(LocalAssignTokens {
+                                    local: token,
+                                    equal: None,
+                                    variable_commas: Vec::new(),
+                                    value_commas: Vec::new(),
+                                });
+                            }
+                        }
+                        Statement::LocalFunction(local_function) => {
+                            if let Some(tokens) = local_function.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.local, text);
+                            } else {
+                                let mut token = Token::from_content("local");
+                                self.location.append_comment(&mut token, text);
+
+                                local_function.set_tokens(LocalFunctionTokens {
+                                    local: token,
+                                    function_body: FunctionBodyTokens {
+                                        function: Token::from_content("function"),
+                                        opening_parenthese: Token::from_content("("),
+                                        closing_parenthese: Token::from_content(")"),
+                                        end: Token::from_content("end"),
+                                        parameter_commas: Vec::new(),
+                                        variable_arguments: None,
+                                        variable_arguments_colon: None,
+                                        return_type_colon: None,
+                                    },
+                                });
+                            }
+                        }
+                        Statement::NumericFor(numeric_for) => {
+                            if let Some(tokens) = numeric_for.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#for, text);
+                            } else {
+                                let mut token = Token::from_content("for");
+                                self.location.append_comment(&mut token, text);
+
+                                numeric_for.set_tokens(NumericForTokens {
+                                    r#for: token,
+                                    equal: Token::from_content("="),
+                                    r#do: Token::from_content("do"),
+                                    end: Token::from_content("end"),
+                                    end_comma: Token::from_content(","),
+                                    step_comma: None,
+                                });
+                            }
+                        }
+                        Statement::Repeat(repeat) => {
+                            if let Some(tokens) = repeat.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.repeat, text);
+                            } else {
+                                let mut token = Token::from_content("repeat");
+                                self.location.append_comment(&mut token, text);
+
+                                repeat.set_tokens(RepeatTokens {
+                                    repeat: token,
+                                    until: Token::from_content("until"),
+                                });
+                            }
+                        }
+                        Statement::While(while_statement) => {
+                            if let Some(tokens) = while_statement.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#while, text);
+                            } else {
+                                let mut token = Token::from_content("while");
+                                self.location.append_comment(&mut token, text);
+
+                                while_statement.set_tokens(WhileTokens {
+                                    r#while: token,
+                                    r#do: Token::from_content("do"),
+                                    end: Token::from_content("end"),
+                                });
+                            }
+                        }
+                        Statement::TypeDeclaration(type_declaration) => {
+                            let is_exported = type_declaration.is_exported();
+                            if let Some(tokens) = type_declaration.mutate_tokens() {
+                                if is_exported {
+                                    self.location.append_comment(
+                                        tokens
+                                            .export
+                                            .get_or_insert_with(|| Token::from_content("export")),
+                                        text,
+                                    );
+                                } else {
+                                    self.location.append_comment(&mut tokens.r#type, text);
+                                }
+                            } else if is_exported {
+                                let mut token = Token::from_content("export");
+                                self.location.append_comment(&mut token, text);
+
+                                type_declaration.set_tokens(TypeDeclarationTokens {
+                                    r#type: Token::from_content("type"),
+                                    equal: Token::from_content("="),
+                                    export: Some(token),
+                                });
+                            } else {
+                                let mut token = Token::from_content("type");
+                                self.location.append_comment(&mut token, text);
+
+                                type_declaration.set_tokens(TypeDeclarationTokens {
+                                    r#type: token,
+                                    equal: Token::from_content("="),
+                                    export: None,
+                                });
+                            }
+                        }
+                    }
+                } else if let Some(statement) = block.mutate_last_statement() {
+                    match statement {
+                        LastStatement::Break(token) => {
+                            self.location.append_comment(
+                                token.get_or_insert_with(|| Token::from_content("break")),
+                                text,
+                            );
+                        }
+                        LastStatement::Continue(token) => {
+                            self.location.append_comment(
+                                token.get_or_insert_with(|| Token::from_content("continue")),
+                                text,
+                            );
+                        }
+                        LastStatement::Return(return_statement) => {
+                            if let Some(tokens) = return_statement.mutate_tokens() {
+                                self.location.append_comment(&mut tokens.r#return, text);
+                            } else {
+                                let mut token = Token::from_content("return");
+                                self.location.append_comment(&mut token, text);
+
+                                return_statement.set_tokens(ReturnTokens {
+                                    r#return: token,
+                                    commas: Vec::new(),
+                                });
+                            }
+                        }
+                    }
+                } else {
+                    self.location.write_to_block(block, text);
+                }
+            }
+            AppendLocation::End => {
+                self.location.write_to_block(block, text);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn variable_get_first_token(variable: &mut Variable) -> &mut Token {
+    match variable {
+        Variable::Identifier(identifier) => identifier_get_first_token(identifier),
+        Variable::Field(field_expression) => {
+            prefix_get_first_token(field_expression.mutate_prefix())
+        }
+        Variable::Index(index_expression) => {
+            prefix_get_first_token(index_expression.mutate_prefix())
+        }
+    }
+}
+
+fn prefix_get_first_token(prefix: &mut Prefix) -> &mut Token {
+    let mut current = prefix;
+    loop {
+        match current {
+            Prefix::Call(call) => {
+                current = call.mutate_prefix();
+            }
+            Prefix::Field(field_expression) => {
+                current = field_expression.mutate_prefix();
+            }
+            Prefix::Index(index_expression) => {
+                current = index_expression.mutate_prefix();
+            }
+            Prefix::Identifier(identifier) => break identifier_get_first_token(identifier),
+            Prefix::Parenthese(parenthese_expression) => {
+                break parentheses_get_first_token(parenthese_expression)
+            }
+        }
+    }
+}
+
+fn identifier_get_first_token(identifier: &mut Identifier) -> &mut Token {
+    if identifier.get_token().is_none() {
+        let name = identifier.get_name().to_owned();
+        identifier.set_token(Token::from_content(name));
+    }
+    identifier.mutate_token().unwrap()
+}
+
+fn parentheses_get_first_token(parentheses: &mut ParentheseExpression) -> &mut Token {
+    if parentheses.get_tokens().is_none() {
+        parentheses.set_tokens(ParentheseTokens {
+            left_parenthese: Token::from_content("("),
+            right_parenthese: Token::from_content(")"),
+        });
+    }
+    &mut parentheses.mutate_tokens().unwrap().left_parenthese
+}
+
+impl RuleConfiguration for AppendTextComment {
+    fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
+        verify_required_any_properties(&properties, &["text", "file"])?;
+        verify_property_collisions(&properties, &["text", "file"])?;
+
+        for (key, value) in properties {
+            match key.as_str() {
+                "text" => {
+                    self.text_content = TextContent::Value(value.expect_string(&key)?);
+                }
+                "file" => {
+                    self.text_content =
+                        TextContent::FilePath(PathBuf::from(value.expect_string(&key)?));
+                }
+                "location" => {
+                    self.location = match value.expect_string(&key)?.as_str() {
+                        "start" => AppendLocation::Start,
+                        "end" => AppendLocation::End,
+                        unexpected => {
+                            return Err(RuleConfigurationError::UnexpectedValue {
+                                property: "location".to_owned(),
+                                message: format!(
+                                    "invalid value `{}` (must be `start` or `end`)",
+                                    unexpected
+                                ),
+                            })
+                        }
+                    };
+                }
+                _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_name(&self) -> &'static str {
+        APPEND_TEXT_COMMENT_RULE_NAME
+    }
+
+    fn serialize_to_properties(&self) -> RuleProperties {
+        let mut properties = RuleProperties::new();
+
+        match self.location {
+            AppendLocation::Start => {}
+            AppendLocation::End => {
+                properties.insert("location".to_owned(), "end".into());
+            }
+        }
+
+        match &self.text_content {
+            TextContent::None => {}
+            TextContent::Value(value) => {
+                properties.insert("text".to_owned(), value.into());
+            }
+            TextContent::FilePath(file_path) => {
+                properties.insert(
+                    "file".to_owned(),
+                    file_path.to_string_lossy().to_string().into(),
+                );
+            }
+        }
+
+        properties
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum TextContent {
+    None,
+    Value(String),
+    FilePath(PathBuf),
+}
+
+impl Default for TextContent {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum AppendLocation {
+    Start,
+    End,
+}
+
+impl AppendLocation {
+    fn write_to_block(&self, block: &mut Block, comment: String) {
+        if let Some(tokens) = block.mutate_tokens() {
+            let final_token = tokens
+                .final_token
+                .get_or_insert_with(|| Token::from_content(""));
+            self.append_comment(final_token, comment);
+        } else {
+            let mut token = Token::from_content("");
+            self.append_comment(&mut token, comment);
+
+            block.set_tokens(BlockTokens {
+                semicolons: Vec::new(),
+                last_semicolon: None,
+                final_token: Some(token),
+            });
+        }
+    }
+
+    fn append_comment(&self, token: &mut Token, comment: String) {
+        match self {
+            AppendLocation::Start => {
+                token.push_leading_trivia(TriviaKind::Comment.with_content(comment));
+            }
+            AppendLocation::End => {
+                token.push_trailing_trivia(TriviaKind::Comment.with_content(comment));
+            }
+        }
+    }
+}
+
+impl Default for AppendLocation {
+    fn default() -> Self {
+        Self::Start
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::rules::Rule;
+
+    use insta::assert_json_snapshot;
+
+    #[test]
+    fn serialize_rule_with_text() {
+        let rule: Box<dyn Rule> = Box::new(AppendTextComment::new("content"));
+
+        assert_json_snapshot!("append_text_comment_with_text", rule);
+    }
+
+    #[test]
+    fn serialize_rule_with_text_at_end() {
+        let rule: Box<dyn Rule> = Box::new(AppendTextComment::new("content").at_end());
+
+        assert_json_snapshot!("append_text_comment_with_text_at_end", rule);
+    }
+
+    #[test]
+    fn configure_with_extra_field_error() {
+        let result = json5::from_str::<Box<dyn Rule>>(
+            r#"{
+            rule: 'append_text_comment',
+            text: '',
+            prop: "something",
+        }"#,
+        );
+        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+    }
+}

--- a/src/rules/configuration_error.rs
+++ b/src/rules/configuration_error.rs
@@ -8,6 +8,8 @@ pub enum RuleConfigurationError {
     UnexpectedProperty(String),
     /// When a rule has a required property. The string should be the field name.
     MissingProperty(String),
+    /// When a rule must define at least one property in a given set.
+    MissingAnyProperty(Vec<String>),
     /// When a property is associated with something else than an expected boolean. The string is
     /// the property name.
     BooleanExpected(String),
@@ -62,6 +64,11 @@ impl fmt::Display for RuleConfigurationError {
         match self {
             UnexpectedProperty(property) => write!(f, "unexpected field '{}'", property),
             MissingProperty(property) => write!(f, "missing required field '{}'", property),
+            MissingAnyProperty(properties) => write!(
+                f,
+                "missing one field from {}",
+                enumerate_properties(properties)
+            ),
             BooleanExpected(property) => {
                 write!(f, "boolean value expected for field '{}'", property)
             }
@@ -82,7 +89,7 @@ impl fmt::Display for RuleConfigurationError {
             }
             PropertyCollision(properties) => write!(
                 f,
-                "the properties {} cannot be defined together",
+                "the fields {} cannot be defined together",
                 enumerate_properties(properties)
             ),
             InternalUsageOnly(rule_name) => {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,5 +1,6 @@
 //! A module that contains the different rules that mutates a Lua block.
 
+mod append_text_comment;
 pub mod bundle;
 mod call_parens;
 mod compute_expression;
@@ -25,6 +26,7 @@ mod shift_token_line;
 mod unused_if_branch;
 mod unused_while;
 
+pub use append_text_comment::*;
 pub use call_parens::*;
 pub use compute_expression::*;
 pub use configuration_error::RuleConfigurationError;
@@ -207,6 +209,7 @@ pub fn get_default_rules() -> Vec<Box<dyn Rule>> {
 
 pub fn get_all_rule_names() -> Vec<&'static str> {
     vec![
+        APPEND_TEXT_COMMENT_RULE_NAME,
         COMPUTE_EXPRESSIONS_RULE_NAME,
         CONVERT_INDEX_TO_FIELD_RULE_NAME,
         CONVERT_LOCAL_FUNCTION_TO_ASSIGN_RULE_NAME,
@@ -233,6 +236,7 @@ impl FromStr for Box<dyn Rule> {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         let rule: Box<dyn Rule> = match string {
+            APPEND_TEXT_COMMENT_RULE_NAME => Box::<AppendTextComment>::default(),
             COMPUTE_EXPRESSIONS_RULE_NAME => Box::<ComputeExpression>::default(),
             CONVERT_INDEX_TO_FIELD_RULE_NAME => Box::<ConvertIndexToField>::default(),
             CONVERT_LOCAL_FUNCTION_TO_ASSIGN_RULE_NAME => {
@@ -372,6 +376,19 @@ fn verify_required_properties(
         }
     }
     Ok(())
+}
+
+fn verify_required_any_properties(
+    properties: &RuleProperties,
+    names: &[&str],
+) -> Result<(), RuleConfigurationError> {
+    if names.iter().any(|name| properties.contains_key(*name)) {
+        Ok(())
+    } else {
+        Err(RuleConfigurationError::MissingAnyProperty(
+            names.iter().map(ToString::to_string).collect(),
+        ))
+    }
 }
 
 fn verify_property_collisions(

--- a/src/rules/snapshots/darklua_core__rules__append_text_comment__test__append_text_comment_with_text.snap
+++ b/src/rules/snapshots/darklua_core__rules__append_text_comment__test__append_text_comment_with_text.snap
@@ -1,0 +1,8 @@
+---
+source: src/rules/append_text_comment.rs
+expression: rule
+---
+{
+  "rule": "append_text_comment",
+  "text": "content"
+}

--- a/src/rules/snapshots/darklua_core__rules__append_text_comment__test__append_text_comment_with_text_at_end.snap
+++ b/src/rules/snapshots/darklua_core__rules__append_text_comment__test__append_text_comment_with_text_at_end.snap
@@ -1,0 +1,9 @@
+---
+source: src/rules/append_text_comment.rs
+expression: rule
+---
+{
+  "rule": "append_text_comment",
+  "location": "end",
+  "text": "content"
+}

--- a/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
+++ b/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
@@ -3,6 +3,7 @@ source: src/rules/mod.rs
 expression: rule_names
 ---
 [
+  "append_text_comment",
   "compute_expression",
   "convert_index_to_field",
   "convert_local_function_to_assign",

--- a/tests/ast_fuzzer/mod.rs
+++ b/tests/ast_fuzzer/mod.rs
@@ -559,7 +559,6 @@ impl AstFuzzer {
                         2 => {
                             self.budget.take_expression();
                             self.push_work(AstFuzzerWork::MakeParenthesePrefix);
-                            // todo: maybe we need a depth for prefixes too?
                             self.fuzz_nested_expression(0);
                         }
                         3 => {

--- a/tests/rule_tests/append_text_comment.rs
+++ b/tests/rule_tests/append_text_comment.rs
@@ -1,0 +1,73 @@
+use darklua_core::rules::Rule;
+
+test_rule_with_tokens!(
+    append_text_comment_start,
+    json5::from_str::<Box<dyn Rule>>(r#"{
+        rule: 'append_text_comment',
+        text: 'hello',
+    }"#).unwrap(),
+    empty_function("do end") => "-- hello\ndo end",
+    local_assign("local a") => "-- hello\nlocal a",
+    local_assign_with_value("local var = true") => "-- hello\nlocal var = true",
+    assign_variable("var = true") => "-- hello\nvar = true",
+    function_call("fn()") => "-- hello\nfn()",
+    function_call_field("module.fn()") => "-- hello\nmodule.fn()",
+    function_call_method("object:fn()") => "-- hello\nobject:fn()",
+    compound_assign("var += 1") => "-- hello\nvar += 1",
+    function_statement("function fn() end") => "-- hello\nfunction fn() end",
+    generic_statement("for k, v in {} do end") => "-- hello\nfor k, v in {} do end",
+    if_statement("if condition then end") => "-- hello\nif condition then end",
+    local_function("local function fn() end") => "-- hello\nlocal function fn() end",
+    numeric_for_statement("for i = 1, 10 do end") => "-- hello\nfor i = 1, 10 do end",
+    repeat_statement("repeat until condition") => "-- hello\nrepeat until condition",
+    while_statement("while condition do end") => "-- hello\nwhile condition do end",
+    type_declaration("type Name = string") => "-- hello\ntype Name = string",
+    exported_type_declaration("export type Name = string") => "-- hello\nexport type Name = string",
+    break_statement("break") => "-- hello\nbreak",
+    continue_statement("continue") => "-- hello\ncontinue",
+    empty_return_statement("return") => "-- hello\nreturn",
+    return_one_value_statement("return 1") => "-- hello\nreturn 1",
+);
+
+test_rule_without_effects!(
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'append_text_comment',
+        text: '',
+    }"#
+    )
+    .unwrap(),
+    before_local_function("local function foo() foo() end"),
+    before_empty_ast(""),
+);
+
+test_rule_without_effects!(
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'append_text_comment',
+        text: '',
+        location: 'end',
+    }"#
+    )
+    .unwrap(),
+    after_local_function("local function foo() end"),
+    after_empty_ast(""),
+);
+
+#[test]
+fn deserialize_from_object_notation() {
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'append_text_comment',
+        text: 'content',
+    }"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn deserialize_from_string_fails() {
+    let err = json5::from_str::<Box<dyn Rule>>(r#"'append_text_comment'"#).unwrap_err();
+
+    pretty_assertions::assert_eq!("missing one field from `text` and `file`", err.to_string())
+}

--- a/tests/rule_tests/compute_expression.rs
+++ b/tests/rule_tests/compute_expression.rs
@@ -36,7 +36,7 @@ test_rule!(
         => "return nil",
 );
 
-test_rule_wihout_effects!(if_expression_unknown_condition(
+test_rule_without_effects!(if_expression_unknown_condition(
     "return if condition then func() else func2()"
 ),);
 

--- a/tests/rule_tests/convert_index_to_field.rs
+++ b/tests/rule_tests/convert_index_to_field.rs
@@ -19,7 +19,7 @@ test_rule!(
         => "return { 'one', 'two', a = true, b = false, c = 0, [{}] = {} }",
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     ConvertIndexToField::default(),
     key_is_empty_string("return var[\"\"]"),
     key_starts_with_space("return var[' bar']"),

--- a/tests/rule_tests/filter_early_return.rs
+++ b/tests/rule_tests/filter_early_return.rs
@@ -16,7 +16,7 @@ test_rule!(
     ) => "if condition then do return 1 end end return 3",
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     FilterAfterEarlyReturn::default(),
     return_nil("return nil"),
     return_in_condition("if condition then return 'ok' end return nil"),

--- a/tests/rule_tests/group_local_assignment.rs
+++ b/tests/rule_tests/group_local_assignment.rs
@@ -10,7 +10,7 @@ test_rule!(
     local_with_no_values_are_set_to_nil("local a local b = true local c") => "local a, b, c = nil, true, nil"
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     GroupLocalAssignment::default(),
     two_local_using_the_other("local foo = 1 local bar = foo"),
     multiple_return_values("local a, b = call() local c = 0")

--- a/tests/rule_tests/inject_value.rs
+++ b/tests/rule_tests/inject_value.rs
@@ -46,7 +46,7 @@ test_rule!(
     inject_negative_integer_from_global_table("return _G.foo + 1") => "return -1 + 1",
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     InjectGlobalValue::nil("foo"),
     does_not_override_local_variable("local foo return foo"),
     does_not_inline_if_global_table_is_redefined("local _G return _G.foo"),

--- a/tests/rule_tests/mod.rs
+++ b/tests/rule_tests/mod.rs
@@ -69,6 +69,79 @@ macro_rules! test_rule_with_generator {
     };
 }
 
+macro_rules! test_rule_with_tokens {
+    (
+        $rule_name:ident,
+        $rule:expr,
+        resources = $resources:expr,
+        test_file_name = $test_file_name:literal,
+        $($name:ident ($input:literal) => $output:literal),* $(,)?
+    ) => {
+        paste::paste! {
+
+        mod [<$rule_name _with_token_based_generator>] {
+            use super::*;
+
+        $(
+            test_rule_with_generator!(
+                $rule,
+                $resources,
+                |input| darklua_core::generator::TokenBasedLuaGenerator::new(input),
+                darklua_core::Parser::default().preserve_tokens(),
+                true,
+                $test_file_name,
+                $name,
+                $input,
+                $output
+            );
+        )*
+
+        }
+
+        }
+    };
+
+    (
+        $rule_name:ident,
+        $rule:expr,
+        resources = $resources:expr,
+        $($name:ident ($input:literal) => $output:literal),* $(,)?
+    ) => {
+        test_rule_with_tokens!(
+            $rule_name,
+            $rule,
+            resources = $resources,
+            test_file_name = "src/test.lua",
+            $( $name ($input) => $output, )*
+        );
+    };
+
+    (
+        $rule_name:ident,
+        $rule:expr,
+        test_file_name = $test_file_name:literal,
+        $($name:ident ($input:literal) => $output:literal),* $(,)?
+    ) => {
+        test_rule_with_tokens!(
+            $rule_name,
+            $rule,
+            resources = darklua_core::Resources::from_memory(),
+            test_file_name = $test_file_name,
+            $( $name ($input) => $output, )*
+        );
+    };
+
+    ($rule_name:ident, $rule:expr, $($name:ident ($input:literal) => $output:literal),* $(,)?) => {
+        test_rule_with_tokens!(
+            $rule_name,
+            $rule,
+            resources = darklua_core::Resources::from_memory(),
+            test_file_name = "src/test.lua",
+            $( $name ($input) => $output, )*
+        );
+    };
+}
+
 macro_rules! test_rule {
     (
         $rule_name:ident,
@@ -176,7 +249,7 @@ macro_rules! test_rule {
     };
 }
 
-macro_rules! test_rule_wihout_effects {
+macro_rules! test_rule_without_effects {
     ($rule:expr, $($name:ident ($input:literal)),* $(,)?) => {
         $(
             #[test]
@@ -210,6 +283,7 @@ macro_rules! test_rule_wihout_effects {
     };
 }
 
+mod append_text_comment;
 mod compute_expression;
 mod convert_index_to_field;
 mod convert_require;

--- a/tests/rule_tests/no_local_function.rs
+++ b/tests/rule_tests/no_local_function.rs
@@ -11,7 +11,7 @@ test_rule!(
     name_in_parameters("local function foo(foo) return foo end") => "local foo = function(foo) return foo end"
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     ConvertLocalFunctionToAssign::default(),
     two_local_using_the_other("local function foo() foo() end")
 );

--- a/tests/rule_tests/remove_call_parens.rs
+++ b/tests/rule_tests/remove_call_parens.rs
@@ -9,7 +9,7 @@ test_rule!(
     call_expression_with_empty_table("return foo({})") => "return foo{}"
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     RemoveFunctionCallParens::default(),
     two_strings("foo('bar', 'baz')"),
     two_tables("foo({}, {})"),

--- a/tests/rule_tests/remove_nil_declaration.rs
+++ b/tests/rule_tests/remove_nil_declaration.rs
@@ -22,7 +22,7 @@ test_rule!(
     assign_to_call_and_true_and_variable("local a = call(), true, var") => "local a = call()",
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     RemoveNilDeclaration::default(),
     assign_to_true("local a = true"),
     assign_to_nil_and_extra_call("local a = nil, call()"),

--- a/tests/rule_tests/remove_unused_while.rs
+++ b/tests/rule_tests/remove_unused_while.rs
@@ -8,7 +8,7 @@ test_rule!(
     while_with_block("while false do print('hello') end") => ""
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     RemoveUnusedWhile::default(),
     while_with_true_condition("while true do end")
 );

--- a/tests/rule_tests/rename_variables.rs
+++ b/tests/rule_tests/rename_variables.rs
@@ -76,7 +76,7 @@ test_rule!(
     recycle_previous_identifiers("do local foo end local foo") => "do local a end local a",
 );
 
-test_rule_wihout_effects!(
+test_rule_without_effects!(
     RenameVariables::default(),
     local_function_name("local function foo() end"),
     does_not_rename_functions("local function foo() end return foo()"),


### PR DESCRIPTION
Closes #122 

This PR adds a new rule that generates a comment at the start or the end of each file. The rule can be configured to take the comment content from the rule configuration or from a file.

For example, to create a comment from the rule configuration itself:

```json5
{
  rule: "append_text_comment",
  text: "comment content",
}
```

Or to create a comment from a file:

```json5
{
  rule: "append_text_comment",
  file: "path/to/file.txt",
}
```

This rule can be configured to append at the start (default) or the end of each file:

```json5
{
  rule: "append_text_comment",
  text: "comment content",
  location: "end", // or default is "start"
}
```

- [x] add rule docs
- [x] add entry to the changelog