### PR TITLE
Fix bundling to remove token references right after parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -47,7 +47,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create tag
         run: |
@@ -99,7 +99,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release_ref }}
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: site
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Verify code format
         run: cargo fmt -- --check
@@ -89,7 +89,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix bundling to avoid token reference removal errors ([#146](https://github.com/seaofvoices/darklua/pull/146))
 * fix `remove_types` rule to handle type cast of expressions that could return multiple values ([#142](https://github.com/seaofvoices/darklua/pull/142))
 
 ## 0.11.1

--- a/src/rules/bundle/path_require_mode/mod.rs
+++ b/src/rules/bundle/path_require_mode/mod.rs
@@ -207,19 +207,8 @@ impl<'a, 'b, 'code, 'resources> RequirePathProcessor<'a, 'b, 'code, 'resources> 
                         parser_timer.duration_label()
                     );
 
-                    let current_source = mem::replace(&mut self.source, path.to_path_buf());
-
-                    let apply_processor_timer = Timer::now();
-                    DefaultVisitor::visit_block(&mut block, self);
-                    log::debug!(
-                        "processed `{}` into bundle in {}",
-                        path.display(),
-                        apply_processor_timer.duration_label()
-                    );
-
-                    self.source = current_source;
-
                     if self.options.parser().is_preserving_tokens() {
+                        log::trace!("replacing token references of {}", path.display());
                         let context = ContextBuilder::new(path, self.resources, &content).build();
                         // run `replace_referenced_tokens` rule to avoid generating invalid code
                         // when using the token-based generator
@@ -235,6 +224,20 @@ impl<'a, 'b, 'code, 'resources> RequirePathProcessor<'a, 'b, 'code, 'resources> 
                             apply_replace_tokens_timer.duration_label()
                         );
                     }
+
+                    let current_source = mem::replace(&mut self.source, path.to_path_buf());
+
+                    let apply_processor_timer = Timer::now();
+                    DefaultVisitor::visit_block(&mut block, self);
+
+                    log::debug!(
+                        "processed `{}` into bundle in {}",
+                        path.display(),
+                        apply_processor_timer.duration_label()
+                    );
+
+                    self.source = current_source;
+
                     Ok(RequiredResource::Block(block))
                 }
                 "json" | "json5" => {

--- a/src/rules/replace_referenced_tokens.rs
+++ b/src/rules/replace_referenced_tokens.rs
@@ -313,4 +313,11 @@ mod test {
         let code = include_str!("../../tests/fuzzed_test_cases/c.lua");
         test_code(code);
     }
+
+
+    #[test]
+    fn test_teardown_join() {
+        let code = include_str!("../../tests/fuzzed_test_cases/teardown-join.lua");
+        test_code(code);
+    }
 }

--- a/src/rules/replace_referenced_tokens.rs
+++ b/src/rules/replace_referenced_tokens.rs
@@ -313,11 +313,4 @@ mod test {
         let code = include_str!("../../tests/fuzzed_test_cases/c.lua");
         test_code(code);
     }
-
-
-    #[test]
-    fn test_teardown_join() {
-        let code = include_str!("../../tests/fuzzed_test_cases/teardown-join.lua");
-        test_code(code);
-    }
 }


### PR DESCRIPTION
Closes #145 

This change shifts the removal of token references to be immediately after parsing instead of being after applying the block into the bundled file.

- [x] add entry to the changelog
