### PR TITLE
Refactor bundling to use cached function calls to load modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix bundling to handle modules with early return calls. This change also makes the bundled code preserve the module require ordering ([#147](https://github.com/seaofvoices/darklua/pull/147))
 * fix bundling to avoid token reference removal errors ([#146](https://github.com/seaofvoices/darklua/pull/146))
 * fix `remove_types` rule to handle type cast of expressions that could return multiple values ([#142](https://github.com/seaofvoices/darklua/pull/142))
 

--- a/src/nodes/expressions/table.rs
+++ b/src/nodes/expressions/table.rs
@@ -1,4 +1,9 @@
-use crate::nodes::{Expression, Identifier, Token};
+use crate::{
+    nodes::{Expression, Identifier, Token},
+    process::utils::is_valid_identifier,
+};
+
+use super::StringExpression;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableFieldEntry {
@@ -198,6 +203,26 @@ pub enum TableEntry {
 }
 
 impl TableEntry {
+    /// Creates a field entry if the provided key is a valid identifier, otherwise it
+    /// creates an index entry.
+    pub fn from_string_key_and_value(key: impl Into<String>, value: impl Into<Expression>) -> Self {
+        let key = key.into();
+        let value = value.into();
+        if is_valid_identifier(&key) {
+            Self::Field(TableFieldEntry {
+                field: Identifier::new(key),
+                value,
+                token: None,
+            })
+        } else {
+            Self::Index(TableIndexEntry {
+                key: Expression::String(StringExpression::from_value(key)),
+                value,
+                tokens: None,
+            })
+        }
+    }
+
     pub fn clear_comments(&mut self) {
         match self {
             TableEntry::Field(entry) => entry.clear_comments(),

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -181,7 +181,7 @@ impl IfStatement {
         }
     }
 
-    pub fn create<E: Into<Expression>, B: Into<Block>>(condition: E, block: B) -> Self {
+    pub fn create(condition: impl Into<Expression>, block: impl Into<Block>) -> Self {
         Self {
             branches: vec![IfBranch::new(condition, block)],
             else_block: None,
@@ -209,10 +209,10 @@ impl IfStatement {
         self
     }
 
-    pub fn with_new_branch<E: Into<Expression>, B: Into<Block>>(
+    pub fn with_new_branch(
         mut self,
-        condition: E,
-        block: B,
+        condition: impl Into<Expression>,
+        block: impl Into<Block>,
     ) -> Self {
         self.branches.push(IfBranch::new(condition, block));
         self
@@ -258,7 +258,7 @@ impl IfStatement {
     }
 
     #[inline]
-    pub fn push_new_branch<E: Into<Expression>, B: Into<Block>>(&mut self, condition: E, block: B) {
+    pub fn push_new_branch(&mut self, condition: impl Into<Expression>, block: impl Into<Block>) {
         self.branches
             .push(IfBranch::new(condition.into(), block.into()));
     }
@@ -279,7 +279,7 @@ impl IfStatement {
     }
 
     #[inline]
-    pub fn set_else_block<B: Into<Block>>(&mut self, block: B) {
+    pub fn set_else_block(&mut self, block: impl Into<Block>) {
         self.else_block = Some(block.into());
     }
 

--- a/src/nodes/types/type_field.rs
+++ b/src/nodes/types/type_field.rs
@@ -51,7 +51,6 @@ impl TypeField {
 
     pub fn clear_comments(&mut self) {
         self.namespace.clear_comments();
-        self.name.clear_comments();
         if let Some(token) = &mut self.token {
             token.clear_comments();
         }
@@ -59,7 +58,6 @@ impl TypeField {
 
     pub fn clear_whitespaces(&mut self) {
         self.namespace.clear_whitespaces();
-        self.name.clear_whitespaces();
         if let Some(token) = &mut self.token {
             token.clear_whitespaces();
         }
@@ -67,7 +65,6 @@ impl TypeField {
 
     pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
         self.namespace.replace_referenced_tokens(code);
-        self.name.replace_referenced_tokens(code);
         if let Some(token) = &mut self.token {
             token.replace_referenced_tokens(code);
         }
@@ -75,7 +72,6 @@ impl TypeField {
 
     pub(crate) fn shift_token_line(&mut self, amount: usize) {
         self.namespace.shift_token_line(amount);
-        self.name.shift_token_line(amount);
         if let Some(token) = &mut self.token {
             token.shift_token_line(amount);
         }

--- a/src/rules/bundle/path_require_mode/mod.rs
+++ b/src/rules/bundle/path_require_mode/mod.rs
@@ -343,6 +343,24 @@ pub(crate) fn process_block(
     options: &BundleOptions,
     path_require_mode: &PathRequireMode,
 ) -> Result<(), String> {
+    if options.parser().is_preserving_tokens() {
+        log::trace!(
+            "replacing token references of {}",
+            context.current_path().display()
+        );
+        let replace_tokens = ReplaceReferencedTokens::default();
+
+        let apply_replace_tokens_timer = Timer::now();
+
+        replace_tokens.flawless_process(block, context);
+
+        log::trace!(
+            "replaced token references for `{}` in {}",
+            context.current_path().display(),
+            apply_replace_tokens_timer.duration_label()
+        );
+    }
+
     let mut processor = RequirePathProcessor::new(context, options, path_require_mode);
     ScopeVisitor::visit_block(block, &mut processor);
     processor.apply(block, context)

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_override_require.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_override_require.snap
@@ -2,13 +2,26 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = 1
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return 1
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 local require = function() end
 local v = require('v')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_json_file_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_json_file_with_object.snap
@@ -2,11 +2,24 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = {value = true}
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return {value = true}
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file.snap
@@ -2,11 +2,24 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = true
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return true
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_after_declaration.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_after_declaration.snap
@@ -2,12 +2,25 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = true
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return true
+    end
 end
 
 local const = 1
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_nested.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_nested.snap
@@ -2,16 +2,29 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = 2
-end
-do
-    local constant = __DARKLUA_BUNDLE_MODULES.a
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return 2
+    end
+    function __DARKLUA_BUNDLE_MODULES.b()
+        local constant = __DARKLUA_BUNDLE_MODULES.load('a')
 
-    __DARKLUA_BUNDLE_MODULES.b = constant + constant
+        return constant + constant
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.b
+local value = __DARKLUA_BUNDLE_MODULES.load('b')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice.snap
@@ -2,30 +2,43 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    print('load constant module')
+    function __DARKLUA_BUNDLE_MODULES.a()
+        print('load constant module')
 
-    __DARKLUA_BUNDLE_MODULES.a = 2
+        return 2
+    end
+    function __DARKLUA_BUNDLE_MODULES.b()
+        print('load value a')
+
+        local constant_a = __DARKLUA_BUNDLE_MODULES.load('a')
+
+        return constant_a
+    end
+    function __DARKLUA_BUNDLE_MODULES.c()
+        print('load value b')
+
+        local constant_b = __DARKLUA_BUNDLE_MODULES.load('a')
+
+        return constant_b
+    end
 end
-do
-    print('load value a')
 
-    local constant_a = __DARKLUA_BUNDLE_MODULES.a
-
-    __DARKLUA_BUNDLE_MODULES.b = constant_a
-end
-do
-    print('load value b')
-
-    local constant_b = __DARKLUA_BUNDLE_MODULES.a
-
-    __DARKLUA_BUNDLE_MODULES.c = constant_b
-end
-
-local value_a = __DARKLUA_BUNDLE_MODULES.b
-local value_b = __DARKLUA_BUNDLE_MODULES.c
+local value_a = __DARKLUA_BUNDLE_MODULES.load('b')
+local value_b = __DARKLUA_BUNDLE_MODULES.load('c')
 
 print(value_a + value_b)
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice_with_different_paths.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice_with_different_paths.snap
@@ -2,30 +2,43 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    print('load constant module')
+    function __DARKLUA_BUNDLE_MODULES.a()
+        print('load constant module')
 
-    __DARKLUA_BUNDLE_MODULES.a = 2
+        return 2
+    end
+    function __DARKLUA_BUNDLE_MODULES.b()
+        print('load value a')
+
+        local constant_a = __DARKLUA_BUNDLE_MODULES.load('a')
+
+        return constant_a
+    end
+    function __DARKLUA_BUNDLE_MODULES.c()
+        print('load value b')
+
+        local constant_b = __DARKLUA_BUNDLE_MODULES.load('a')
+
+        return constant_b
+    end
 end
-do
-    print('load value a')
 
-    local constant_a = __DARKLUA_BUNDLE_MODULES.a
-
-    __DARKLUA_BUNDLE_MODULES.b = constant_a
-end
-do
-    print('load value b')
-
-    local constant_b = __DARKLUA_BUNDLE_MODULES.a
-
-    __DARKLUA_BUNDLE_MODULES.c = constant_b
-end
-
-local value_a = __DARKLUA_BUNDLE_MODULES.b
-local value_b = __DARKLUA_BUNDLE_MODULES.c
+local value_a = __DARKLUA_BUNDLE_MODULES.load('b')
+local value_b = __DARKLUA_BUNDLE_MODULES.load('c')
 
 print(value_a + value_b)
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_field_expression.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_field_expression.snap
@@ -2,13 +2,26 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = {
-        value = 'oof',
-    }
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return {
+            value = 'oof',
+        }
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a.value
+local value = __DARKLUA_BUNDLE_MODULES.load('a').value
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_statement.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_statement.snap
@@ -2,14 +2,26 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    print('run')
+    function __DARKLUA_BUNDLE_MODULES.a()
+        print('run')
 
-    __DARKLUA_BUNDLE_MODULES.a = nil
+        return nil
+    end
 end
-do
-    local _ = __DARKLUA_BUNDLE_MODULES.a
-end
+
+__DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_small_bundle_case.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_small_bundle_case.snap
@@ -2,16 +2,16 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES={}do local function initialize()
+local __DARKLUA_BUNDLE_MODULES={cache={}, load=function(m)if not __DARKLUA_BUNDLE_MODULES.cache[m]then __DARKLUA_BUNDLE_MODULES.cache[m]={c=__DARKLUA_BUNDLE_MODULES[m]()}end return __DARKLUA_BUNDLE_MODULES.cache[m].c end}do function __DARKLUA_BUNDLE_MODULES.a()local function initialize()
 end
 
-__DARKLUA_BUNDLE_MODULES.a=initialize
-end do
+return initialize
+end function __DARKLUA_BUNDLE_MODULES.b()
 local function generateNumber()
     return math.random(1, 9999)
 end
 
-__DARKLUA_BUNDLE_MODULES.b={
+return {
     zero = 0,
     one = 1,
     hex = 0x10,
@@ -20,18 +20,18 @@ __DARKLUA_BUNDLE_MODULES.b={
     number2 = generateNumber(),
     number3 = generateNumber(),
 }
-end do
+end function __DARKLUA_BUNDLE_MODULES.c()
 local function format(value)
     return '[' .. tostring(value) .. ']'
 end
 
-__DARKLUA_BUNDLE_MODULES.c=format -- comment after returning format function
-end
-local initialize = __DARKLUA_BUNDLE_MODULES.a -- import initialize module
+return format -- comment after returning format function
+end end
+local initialize = __DARKLUA_BUNDLE_MODULES.load('a') -- import initialize module
 
-local value = __DARKLUA_BUNDLE_MODULES.b -- import value module
+local value = __DARKLUA_BUNDLE_MODULES.load('b') -- import value module
 
-local format = __DARKLUA_BUNDLE_MODULES.c --[[ import format module ]]
+local format = __DARKLUA_BUNDLE_MODULES.load('c') --[[ import format module ]]
 
 print(format(value.number1 + value.number2))
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_toml_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_toml_with_object.snap
@@ -2,14 +2,27 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = {
-        name = 'darklua',
-        value = 10,
-    }
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return {
+            name = 'darklua',
+            value = 10,
+        }
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_txt_file.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_txt_file.snap
@@ -2,11 +2,24 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = 'Hello from txt file!\n\nThis is written on another line.\n'
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return 'Hello from txt file!\n\nThis is written on another line.\n'
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yaml_with_array.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yaml_with_array.snap
@@ -2,11 +2,24 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = {0, 100}
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return {0, 100}
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yml_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yml_with_object.snap
@@ -2,17 +2,30 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {}
+local __DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
 
 do
-    __DARKLUA_BUNDLE_MODULES.a = {
-        name = 'darklua',
-        data = {
-            bool = true,
-            numbers = {0, 100},
-        },
-    }
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return {
+            name = 'darklua',
+            data = {
+                bool = true,
+                numbers = {0, 100},
+            },
+        }
+    end
 end
 
-local value = __DARKLUA_BUNDLE_MODULES.a
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
 


### PR DESCRIPTION
Closes #144 

To fix the issue, the bundler will generate functions to load each modules, instead of generating simple do blocks.

- [x] add entry to the changelog
