### PR TITLE
Fix bundled code bug where the modules identifier is undeclared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* fix undeclared modules variable when bundling ([#151](https://github.com/seaofvoices/darklua/pull/151))
+
 ## 0.11.2
 
 * fix bundling to handle modules with early return calls. This change also makes the bundled code preserve the module require ordering ([#147](https://github.com/seaofvoices/darklua/pull/147))

--- a/src/rules/bundle/path_require_mode/module_definitions.rs
+++ b/src/rules/bundle/path_require_mode/module_definitions.rs
@@ -167,7 +167,11 @@ impl BuildModuleDefinitions {
         let modules_table = self.build_modules_table();
         block.insert_statement(
             0,
-            LocalAssignStatement::from_variable(self.modules_identifier).with_value(modules_table),
+            AssignStatement::from_variable(modules_identifier, modules_table),
+        );
+        block.insert_statement(
+            0,
+            LocalAssignStatement::from_variable(self.modules_identifier),
         );
     }
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_override_require.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_override_require.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_json_file_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_json_file_with_object.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_after_declaration.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_after_declaration.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_nested.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_nested.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice_with_different_paths.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_twice_with_different_paths.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_field_expression.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_field_expression.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_statement.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_with_statement.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_small_bundle_case.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_small_bundle_case.snap
@@ -2,7 +2,7 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES={cache={}, load=function(m)if not __DARKLUA_BUNDLE_MODULES.cache[m]then __DARKLUA_BUNDLE_MODULES.cache[m]={c=__DARKLUA_BUNDLE_MODULES[m]()}end return __DARKLUA_BUNDLE_MODULES.cache[m].c end}do function __DARKLUA_BUNDLE_MODULES.a()local function initialize()
+local __DARKLUA_BUNDLE_MODULES __DARKLUA_BUNDLE_MODULES={cache={}, load=function(m)if not __DARKLUA_BUNDLE_MODULES.cache[m]then __DARKLUA_BUNDLE_MODULES.cache[m]={c=__DARKLUA_BUNDLE_MODULES[m]()}end return __DARKLUA_BUNDLE_MODULES.cache[m].c end}do function __DARKLUA_BUNDLE_MODULES.a()local function initialize()
 end
 
 return initialize

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_toml_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_toml_with_object.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_txt_file.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_txt_file.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yaml_with_array.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yaml_with_array.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yml_with_object.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_yml_with_object.snap
@@ -2,7 +2,9 @@
 source: tests/bundle.rs
 expression: main
 ---
-local __DARKLUA_BUNDLE_MODULES = {
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
     cache = {},
     load = function(m)
         if not __DARKLUA_BUNDLE_MODULES.cache[m] then


### PR DESCRIPTION
The generated code when bundling is broken and the modules identifier is not declared when running through the load function.

- [x] add entry to the changelog
