### PR TITLE
Add rule to remove assert calls

### DIFF
--- a/site/content/rules/remove_assertions.md
+++ b/site/content/rules/remove_assertions.md
@@ -1,0 +1,13 @@
+---
+description: Removes call to the assert function
+added_in: "unreleased"
+parameters:
+  - name: preserve_arguments_side_effects
+    type: boolean
+    description: Defines how darklua handle arguments passed to the function. If true, darklua will inspect each argument and preserve any potential side effects. When false, darklua will not perform any verification and simply erase any arguments passed.
+    default: true
+examples:
+  - content: assert(condition, 'condition is incorrect!')
+---
+
+This rule removes all function calls to `assert`.

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -13,6 +13,7 @@ mod group_local;
 mod inject_value;
 mod method_def;
 mod no_local_function;
+mod remove_assertions;
 mod remove_call_match;
 mod remove_comments;
 mod remove_compound_assign;
@@ -41,6 +42,7 @@ pub use group_local::*;
 pub use inject_value::*;
 pub use method_def::*;
 pub use no_local_function::*;
+pub use remove_assertions::*;
 pub use remove_comments::*;
 pub use remove_compound_assign::*;
 pub use remove_debug_profiling::*;
@@ -222,6 +224,7 @@ pub fn get_all_rule_names() -> Vec<&'static str> {
         FILTER_AFTER_EARLY_RETURN_RULE_NAME,
         GROUP_LOCAL_ASSIGNMENT_RULE_NAME,
         INJECT_GLOBAL_VALUE_RULE_NAME,
+        REMOVE_ASSERTIONS_RULE_NAME,
         REMOVE_COMMENTS_RULE_NAME,
         REMOVE_COMPOUND_ASSIGNMENT_RULE_NAME,
         REMOVE_DEBUG_PROFILING_RULE_NAME,
@@ -253,6 +256,7 @@ impl FromStr for Box<dyn Rule> {
             FILTER_AFTER_EARLY_RETURN_RULE_NAME => Box::<FilterAfterEarlyReturn>::default(),
             GROUP_LOCAL_ASSIGNMENT_RULE_NAME => Box::<GroupLocalAssignment>::default(),
             INJECT_GLOBAL_VALUE_RULE_NAME => Box::<InjectGlobalValue>::default(),
+            REMOVE_ASSERTIONS_RULE_NAME => Box::<RemoveAssertions>::default(),
             REMOVE_COMMENTS_RULE_NAME => Box::<RemoveComments>::default(),
             REMOVE_COMPOUND_ASSIGNMENT_RULE_NAME => Box::<RemoveCompoundAssignment>::default(),
             REMOVE_DEBUG_PROFILING_RULE_NAME => Box::<RemoveDebugProfiling>::default(),

--- a/src/rules/remove_assertions.rs
+++ b/src/rules/remove_assertions.rs
@@ -1,0 +1,112 @@
+use crate::nodes::{Block, Prefix};
+use crate::process::{IdentifierTracker, NodeVisitor, ScopeVisitor};
+use crate::rules::{
+    Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
+};
+
+use super::remove_call_match::RemoveFunctionCallProcessor;
+
+const ASSERT_FUNCTION_NAME: &str = "assert";
+
+pub const REMOVE_ASSERTIONS_RULE_NAME: &str = "remove_assertions";
+
+/// A rule that removes `assert` calls.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RemoveAssertions {
+    preserve_args_side_effects: bool,
+}
+
+impl Default for RemoveAssertions {
+    fn default() -> Self {
+        Self {
+            preserve_args_side_effects: true,
+        }
+    }
+}
+
+fn should_remove_call(identifiers: &IdentifierTracker, prefix: &Prefix) -> bool {
+    if identifiers.is_identifier_used(ASSERT_FUNCTION_NAME) {
+        return false;
+    }
+
+    match prefix {
+        Prefix::Identifier(identifier) => identifier.get_name() == ASSERT_FUNCTION_NAME,
+        _ => false,
+    }
+}
+
+impl FlawlessRule for RemoveAssertions {
+    fn flawless_process(&self, block: &mut Block, _: &Context) {
+        let mut processor =
+            RemoveFunctionCallProcessor::new(self.preserve_args_side_effects, should_remove_call);
+        ScopeVisitor::visit_block(block, &mut processor);
+    }
+}
+
+impl RuleConfiguration for RemoveAssertions {
+    fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
+        for (key, value) in properties {
+            match key.as_str() {
+                "preserve_arguments_side_effects" => {
+                    self.preserve_args_side_effects = value.expect_bool(&key)?;
+                }
+                _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_name(&self) -> &'static str {
+        REMOVE_ASSERTIONS_RULE_NAME
+    }
+
+    fn serialize_to_properties(&self) -> RuleProperties {
+        let mut properties = RuleProperties::new();
+
+        if !self.preserve_args_side_effects {
+            properties.insert("preserve_arguments_side_effects".to_owned(), false.into());
+        }
+
+        properties
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::rules::Rule;
+
+    use insta::assert_json_snapshot;
+
+    fn new_rule() -> RemoveAssertions {
+        RemoveAssertions::default()
+    }
+
+    #[test]
+    fn serialize_default_rule() {
+        let rule: Box<dyn Rule> = Box::new(new_rule());
+
+        assert_json_snapshot!("default_remove_assertions", rule);
+    }
+
+    #[test]
+    fn serialize_rule_without_side_effects() {
+        let rule: Box<dyn Rule> = Box::new(RemoveAssertions {
+            preserve_args_side_effects: false,
+        });
+
+        assert_json_snapshot!("remove_assertions_without_side_effects", rule);
+    }
+
+    #[test]
+    fn configure_with_extra_field_error() {
+        let result = json5::from_str::<Box<dyn Rule>>(
+            r#"{
+            rule: 'remove_assertions',
+            prop: "something",
+        }"#,
+        );
+        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+    }
+}

--- a/src/rules/snapshots/darklua_core__rules__remove_assertions__test__default_remove_assertions.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_assertions__test__default_remove_assertions.snap
@@ -1,0 +1,5 @@
+---
+source: src/rules/remove_assertions.rs
+expression: rule
+---
+"remove_assertions"

--- a/src/rules/snapshots/darklua_core__rules__remove_assertions__test__remove_assertions_without_side_effects.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_assertions__test__remove_assertions_without_side_effects.snap
@@ -1,0 +1,8 @@
+---
+source: src/rules/remove_assertions.rs
+expression: rule
+---
+{
+  "rule": "remove_assertions",
+  "preserve_arguments_side_effects": false
+}

--- a/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
+++ b/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
@@ -11,6 +11,7 @@ expression: rule_names
   "filter_after_early_return",
   "group_local_assignment",
   "inject_global_value",
+  "remove_assertions",
   "remove_comments",
   "remove_compound_assignment",
   "remove_debug_profiling",

--- a/tests/rule_tests/mod.rs
+++ b/tests/rule_tests/mod.rs
@@ -291,6 +291,7 @@ mod filter_early_return;
 mod group_local_assignment;
 mod inject_value;
 mod no_local_function;
+mod remove_assertions;
 mod remove_call_parens;
 mod remove_comments;
 mod remove_compound_assignment;

--- a/tests/rule_tests/remove_assertions.rs
+++ b/tests/rule_tests/remove_assertions.rs
@@ -1,0 +1,45 @@
+use darklua_core::rules::{RemoveAssertions, Rule};
+
+test_rule!(
+    remove_debug_profiling,
+    RemoveAssertions::default(),
+    remove_variable_condition("assert(condition)") => "do end",
+    remove_variable_condition_with_message("assert(condition, 'message')") => "do end",
+    remove_function_call_condition("assert(validate(value))") => "do local _ = validate(value) end",
+    remove_variable_condition_with_function_call_message("assert(condition, formatter(condition))") => "do local _ = formatter(condition) end",
+);
+
+test_rule!(
+    remove_debug_profiling_without_side_effects,
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'remove_assertions',
+        preserve_arguments_side_effects: false,
+    }"#,
+    )
+    .unwrap(),
+    remove_variable_condition("assert(condition)") => "do end",
+    remove_variable_condition_with_message("assert(condition, 'message')") => "do end",
+    remove_function_call_condition("assert(validate(value))") => "do end",
+    remove_variable_condition_with_function_call_message("assert(condition, formatter(condition))") => "do end",
+);
+
+test_rule_without_effects!(
+    RemoveAssertions::default(),
+    assert_function_used("local function assert() end assert('label')"),
+);
+
+#[test]
+fn deserialize_from_object_notation() {
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'remove_assertions',
+    }"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn deserialize_from_string() {
+    json5::from_str::<Box<dyn Rule>>("'remove_assertions'").unwrap();
+}


### PR DESCRIPTION
Closes #2 

Add a new rule `remove_assertions` that remove calls to the `assert` global functions

- [ ] add entry to the changelog
