### PR TITLE
Add convert data command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* add `convert` command to convert data files (`json`, `json5`, `yaml` and `toml`) into Lua modules ([#178](https://github.com/seaofvoices/darklua/pull/178))
 * remove previously generated files between process runs in watch mode ([#177](https://github.com/seaofvoices/darklua/pull/177))
 * fix `remove_compound_assignment` rule to avoid copying variable tokens ([#176](https://github.com/seaofvoices/darklua/pull/176))
 * add get link button to [try-it](https://darklua.com/try-it/) page ([#175](https://github.com/seaofvoices/darklua/pull/175))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -412,6 +412,7 @@ dependencies = [
 name = "darklua"
 version = "0.12.1"
 dependencies = [
+ "anstyle",
  "assert_cmd",
  "clap",
  "criterion",
@@ -514,16 +515,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -867,9 +878,9 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "logos"
@@ -1570,15 +1581,6 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,14 @@ tracing = ["dep:tracing"]
 stacker = ["full_moon/stacker"]
 
 [dependencies]
+anstyle = "1.0.6"
 clap = { version = "4.5.1", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.9.0"
-env_logger = "0.10.2"
+env_logger = "0.11.3"
 full_moon = { version = "0.19.0", features = ["roblox"] }
 json5 = "0.4.1"
-log = "0.4.20"
+log = "0.4.21"
 pathdiff = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"

--- a/site/content/docs/getting-started/index.md
+++ b/site/content/docs/getting-started/index.md
@@ -47,6 +47,19 @@ darklua process src processed-src --config ./path/config.json
 darklua process src processed-src -c ./path/config.json
 ```
 
+### Convert
+
+This command takes a data file and converts it to a Lua file. If no output path is provided, the Lua code will be printed to the console.
+
+The supported data formats are: `json`, `json5`, `yaml` or `toml`.
+
+```
+darklua convert <input-path> [output-path]
+
+optional arguments:
+  -f, --format {json, yaml, toml}
+```
+
 ### Minify
 
 This command reads Lua code and reformats it to reduce the size of the code, measured in total bytes. The input path can be a single file name or a directory name. Given a directory, darklua will find all Lua files under that directory and output them following the same hierarchy.

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -2,12 +2,10 @@ mod cli;
 
 use std::process;
 
+use anstyle::{AnsiColor, Color, Style};
 use clap::Parser;
 use cli::Darklua;
-use env_logger::{
-    fmt::{Color, Style, StyledValue},
-    Builder,
-};
+use env_logger::Builder;
 use log::Level;
 
 fn main() {
@@ -30,20 +28,21 @@ fn formatted_logger() -> Builder {
     builder.format(|f, record| {
         use std::io::Write;
 
-        let mut style = f.style();
-        let level = colored_level(&mut style, record.level());
+        let level = record.level();
+        let (style, text) = colored_level(level);
 
-        writeln!(f, " {} > {}", level, record.args(),)
+        writeln!(f, " {style}{text}{style:#} > {}", record.args())
     });
     builder
 }
 
-fn colored_level(style: &mut Style, level: Level) -> StyledValue<&'static str> {
-    match level {
-        Level::Trace => style.set_color(Color::Magenta).value("TRACE"),
-        Level::Debug => style.set_color(Color::Blue).value("DEBUG"),
-        Level::Info => style.set_color(Color::Green).value("INFO"),
-        Level::Warn => style.set_color(Color::Yellow).value("WARN"),
-        Level::Error => style.set_color(Color::Red).value("ERROR"),
-    }
+fn colored_level(level: Level) -> (Style, &'static str) {
+    let (color, text) = match level {
+        Level::Trace => (AnsiColor::Magenta, "TRACE"),
+        Level::Debug => (AnsiColor::Blue, "DEBUG"),
+        Level::Info => (AnsiColor::Green, "INFO"),
+        Level::Warn => (AnsiColor::Yellow, "WARN"),
+        Level::Error => (AnsiColor::Red, "ERROR"),
+    };
+    (Style::new().fg_color(Some(Color::Ansi(color))), text)
 }

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -1,0 +1,122 @@
+use crate::cli::{CommandResult, GlobalOptions};
+
+use anstyle::Style;
+use clap::Args;
+use darklua_core::{DarkluaError, Resources};
+use std::{ffi::OsStr, path::PathBuf, str::FromStr, time::Instant};
+
+use super::error::CliError;
+
+#[derive(Debug, Args)]
+pub struct Options {
+    /// Data file to convert to Lua
+    input: PathBuf,
+    /// Path where to write the Lua file
+    output: Option<PathBuf>,
+    /// Data format
+    #[arg(short, long)]
+    format: Option<DataFormat>,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum DataFormat {
+    Json,
+    Yaml,
+    Toml,
+}
+
+impl FromStr for DataFormat {
+    type Err = String;
+
+    fn from_str(format: &str) -> Result<Self, Self::Err> {
+        match format {
+            "json" | "json5" => Ok(Self::Json),
+            "yml" | "yaml" => Ok(Self::Yaml),
+            "toml" => Ok(Self::Toml),
+            _ => Err(format!(
+                "invalid data format '{}' (possible options are: 'json', 'json5', 'yml' or 'toml'",
+                format
+            )),
+        }
+    }
+}
+
+impl DataFormat {
+    fn from_extension(extension: &str) -> Option<Self> {
+        match extension {
+            "json" | "json5" => Some(Self::Json),
+            "yml" | "yaml" => Some(Self::Yaml),
+            "toml" => Some(Self::Toml),
+            _ => None,
+        }
+    }
+}
+
+pub fn run(options: &Options, _: &GlobalOptions) -> CommandResult {
+    convert_data(options).map_err(|err| {
+        eprintln!("an error happened: {}", err);
+        CliError::new(1)
+    })
+}
+
+fn convert_data(options: &Options) -> Result<(), DarkluaError> {
+    let resources = Resources::from_file_system();
+
+    let input = resources.get(&options.input).map_err(DarkluaError::from)?;
+
+    let format = options
+        .format
+        .ok_or_else(|| DarkluaError::custom("unable to find data format"))
+        .or_else(|_| {
+            options
+                .input
+                .extension()
+                .and_then(OsStr::to_str)
+                .ok_or_else(|| {
+                    DarkluaError::custom(
+                        "unable to find data format because the file has no extension",
+                    )
+                })
+                .and_then(|extension| {
+                    DataFormat::from_extension(extension)
+                        .ok_or_else(|| DarkluaError::custom(format!("extension '{}'", extension)))
+                })
+        })?;
+
+    log::debug!("use data format '{:?}'", format);
+
+    let convert_start_time = Instant::now();
+
+    let lua_code = match format {
+        DataFormat::Json => darklua_core::convert_data(
+            json5::from_str::<serde_json::Value>(&input).map_err(DarkluaError::from)?,
+        ),
+        DataFormat::Yaml => darklua_core::convert_data(
+            serde_yaml::from_str::<serde_yaml::Value>(&input).map_err(DarkluaError::from)?,
+        ),
+        DataFormat::Toml => darklua_core::convert_data(
+            toml::from_str::<toml::Value>(&input).map_err(DarkluaError::from)?,
+        ),
+    }?;
+
+    let convert_duration = durationfmt::to_string(convert_start_time.elapsed());
+
+    let success_style = Style::new()
+        .fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Green)))
+        .dimmed();
+    let dim_style = Style::new().dimmed();
+
+    eprintln!(
+        "{success_style}successfully converted {}{success_style:#} {dim_style}(in {}){dim_style:#}",
+        options.input.display(),
+        convert_duration
+    );
+
+    Ok(if let Some(output) = &options.output {
+        resources
+            .write(output, &lua_code)
+            .map_err(DarkluaError::from)?;
+    } else {
+        println!("{}", lua_code);
+    })
+}

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -103,11 +103,13 @@ fn convert_data(options: &Options) -> Result<(), DarkluaError> {
         convert_duration
     );
 
-    Ok(if let Some(output) = &options.output {
+    if let Some(output) = &options.output {
         resources
             .write(output, &lua_code)
             .map_err(DarkluaError::from)?;
     } else {
         println!("{}", lua_code);
-    })
+    }
+
+    Ok(())
 }

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -13,7 +13,7 @@ pub struct Options {
     input: PathBuf,
     /// Path where to write the Lua file
     output: Option<PathBuf>,
-    /// Data format
+    /// Data format ('json', 'yaml' or 'toml')
     #[arg(short, long)]
     format: Option<DataFormat>,
 }

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -34,20 +34,9 @@ impl FromStr for DataFormat {
             "yml" | "yaml" => Ok(Self::Yaml),
             "toml" => Ok(Self::Toml),
             _ => Err(format!(
-                "invalid data format '{}' (possible options are: 'json', 'json5', 'yml' or 'toml'",
+                "invalid data format '{}' (possible options are: 'json', 'json5', 'yml' or 'toml')",
                 format
             )),
-        }
-    }
-}
-
-impl DataFormat {
-    fn from_extension(extension: &str) -> Option<Self> {
-        match extension {
-            "json" | "json5" => Some(Self::Json),
-            "yml" | "yaml" => Some(Self::Yaml),
-            "toml" => Some(Self::Toml),
-            _ => None,
         }
     }
 }
@@ -73,13 +62,15 @@ fn convert_data(options: &Options) -> Result<(), DarkluaError> {
                 .extension()
                 .and_then(OsStr::to_str)
                 .ok_or_else(|| {
-                    DarkluaError::custom(
-                        "unable to find data format because the file has no extension",
-                    )
+                    DarkluaError::custom(format!(
+                        "unable to find data format because the input file '{}' has no extension. Specify the data format using the '--format' option",
+                        options.input.display()
+                    ))
                 })
                 .and_then(|extension| {
-                    DataFormat::from_extension(extension)
-                        .ok_or_else(|| DarkluaError::custom(format!("extension '{}'", extension)))
+                    DataFormat::from_str(extension).map_err(|err| {
+                        DarkluaError::custom( format!("{} [unrecognized file extension]", err))
+                    })
                 })
         })?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod convert;
 pub mod error;
 pub mod minify;
 pub mod process;
@@ -38,6 +39,8 @@ pub enum Command {
     /// If no configuration is passed, darklua will attempt to read
     /// `.darklua.json` or `darklua.json5` from the working directory.
     Process(process::Options),
+    /// Convert a data file [json, json5, yaml, toml] into a Lua file
+    Convert(convert::Options),
 }
 
 impl Command {
@@ -45,6 +48,7 @@ impl Command {
         match self {
             Command::Minify(options) => minify::run(options, global_options),
             Command::Process(options) => process::run(options, global_options),
+            Command::Convert(options) => convert::run(options, global_options),
         }
     }
 }

--- a/src/frontend/error.rs
+++ b/src/frontend/error.rs
@@ -7,10 +7,7 @@ use std::{
     path::PathBuf,
 };
 
-use crate::{
-    rules::{bundle::LuaSerializerError, Rule},
-    ParserError,
-};
+use crate::{process::LuaSerializerError, rules::Rule, ParserError};
 
 use super::{
     resources::ResourceError,

--- a/src/frontend/error.rs
+++ b/src/frontend/error.rs
@@ -220,7 +220,7 @@ impl DarkluaError {
         })
     }
 
-    pub(crate) fn custom(message: impl Into<Cow<'static, str>>) -> Self {
+    pub fn custom(message: impl Into<Cow<'static, str>>) -> Self {
         Self::new(ErrorKind::Custom {
             message: message.into(),
         })

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -33,11 +33,7 @@ pub fn process(resources: &Resources, options: Options) -> ProcessResult {
 }
 
 /// Convert serializable data into a Lua module
-pub fn convert_data<'a, T, E>(value: T) -> Result<String, DarkluaError>
-where
-    T: Serialize,
-    E: Into<DarkluaError>,
-{
+pub fn convert_data<'a>(value: impl Serialize) -> Result<String, DarkluaError> {
     let expression = to_expression(&value).map_err(DarkluaError::from)?;
 
     let block = Block::default()

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -15,15 +15,37 @@ pub use error::{DarkluaError, DarkluaResult};
 pub use options::Options;
 pub use process_result::ProcessResult;
 pub use resources::Resources;
+use serde::Serialize;
 use work_item::WorkItem;
 use worker::Worker;
 
-use crate::utils::normalize_path;
+use crate::{
+    generator::{DenseLuaGenerator, LuaGenerator},
+    nodes::{Block, ReturnStatement},
+    process::to_expression,
+    utils::normalize_path,
+};
 
 pub fn process(resources: &Resources, options: Options) -> ProcessResult {
     match private_process(resources, options) {
         Ok(result) | Err(result) => result,
     }
+}
+
+/// Convert serializable data into a Lua module
+pub fn convert_data<'a, T, E>(value: T) -> Result<String, DarkluaError>
+where
+    T: Serialize,
+    E: Into<DarkluaError>,
+{
+    let expression = to_expression(&value).map_err(DarkluaError::from)?;
+
+    let block = Block::default()
+        .with_last_statement(ReturnStatement::default().with_expression(expression));
+
+    let mut generator = DenseLuaGenerator::default();
+    generator.write_block(&block);
+    Ok(generator.into_string())
 }
 
 fn private_process(

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -33,7 +33,7 @@ pub fn process(resources: &Resources, options: Options) -> ProcessResult {
 }
 
 /// Convert serializable data into a Lua module
-pub fn convert_data<'a>(value: impl Serialize) -> Result<String, DarkluaError> {
+pub fn convert_data(value: impl Serialize) -> Result<String, DarkluaError> {
     let expression = to_expression(&value).map_err(DarkluaError::from)?;
 
     let block = Block::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,7 @@ pub mod process;
 pub mod rules;
 mod utils;
 
-pub use frontend::{process, Configuration, DarkluaError, GeneratorParameters, Options, Resources};
+pub use frontend::{
+    convert_data, process, Configuration, DarkluaError, GeneratorParameters, Options, Resources,
+};
 pub use parser::{Parser, ParserError};

--- a/src/process/expression_serializer.rs
+++ b/src/process/expression_serializer.rs
@@ -2,11 +2,9 @@ use std::{borrow::Cow, fmt};
 
 use serde::{ser, Serialize};
 
-// By convention, the public API of a Serde serializer is one or more `to_abc`
-// functions such as `to_string`, `to_bytes`, or `to_writer` depending on what
-// Rust types the serializer is able to produce as output.
-//
-// This basic serializer supports only `to_string`.
+type Result<T> = std::result::Result<T, LuaSerializerError>;
+
+/// Convert serializable data into a Lua Expression
 pub(crate) fn to_expression<T>(value: &T) -> Result<Expression>
 where
     T: Serialize,
@@ -59,8 +57,6 @@ impl fmt::Display for LuaSerializerError {
 }
 
 impl std::error::Error for LuaSerializerError {}
-
-type Result<T> = std::result::Result<T, LuaSerializerError>;
 
 use crate::{
     nodes::{

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -1,6 +1,7 @@
 //! Defines how rules can process and mutate Lua nodes.
 
 mod evaluator;
+mod expression_serializer;
 #[cfg(test)]
 mod node_counter;
 mod node_processor;
@@ -10,6 +11,7 @@ pub(crate) mod utils;
 mod visitors;
 
 pub use evaluator::*;
+pub(crate) use expression_serializer::*;
 #[cfg(test)]
 pub use node_counter::NodeCounter;
 pub use node_processor::NodeProcessor;

--- a/src/rules/bundle/mod.rs
+++ b/src/rules/bundle/mod.rs
@@ -1,4 +1,3 @@
-mod expression_serializer;
 pub(crate) mod path_require_mode;
 mod require_mode;
 
@@ -9,8 +8,6 @@ use crate::rules::{
     Context, Rule, RuleConfiguration, RuleConfigurationError, RuleProcessResult, RuleProperties,
 };
 use crate::Parser;
-
-pub(crate) use expression_serializer::LuaSerializerError;
 
 pub use require_mode::BundleRequireMode;
 use wax::Pattern;

--- a/src/rules/bundle/path_require_mode/mod.rs
+++ b/src/rules/bundle/path_require_mode/mod.rs
@@ -14,7 +14,9 @@ use crate::nodes::{
     Block, DoStatement, Expression, FunctionCall, LocalAssignStatement, Prefix, Statement,
     StringExpression,
 };
-use crate::process::{DefaultVisitor, IdentifierTracker, NodeProcessor, NodeVisitor, ScopeVisitor};
+use crate::process::{
+    to_expression, DefaultVisitor, IdentifierTracker, NodeProcessor, NodeVisitor, ScopeVisitor,
+};
 use crate::rules::require::{
     is_require_call, match_path_require_call, PathRequireMode, RequirePathLocator,
 };
@@ -24,7 +26,6 @@ use crate::rules::{
 use crate::utils::Timer;
 use crate::{DarkluaError, Resources};
 
-use super::expression_serializer::to_expression;
 use super::BundleOptions;
 
 pub(crate) enum RequiredResource {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -196,6 +196,14 @@ fn snapshot_minify_help_command() {
 }
 
 #[test]
+fn snapshot_convert_help_command() {
+    Context::default()
+        .arg("convert")
+        .arg("--help")
+        .snapshot_command("convert_help_command");
+}
+
+#[test]
 fn run_minify_command() {
     Context::default()
         .write_file("src/init.lua", "return 1 + 1\n")
@@ -314,4 +322,40 @@ fn run_process_single_file_custom_config_command_deprecated_config_path() {
         .replace_duration_labels()
         .snapshot_command("run_process_single_file_custom_config")
         .snapshot_file("run_process_custom_config_command_out", "out.lua");
+}
+
+#[test]
+fn run_convert_command_on_json_file_with_output() {
+    Context::default()
+        .write_file("data.json", "{ \"property\": true }")
+        .arg("convert")
+        .arg("data.json")
+        .arg("out.lua")
+        .replace_duration_labels()
+        .snapshot_command("run_convert_command_on_json_file_with_output")
+        .snapshot_file("run_convert_command_on_json_file_out", "out.lua");
+}
+
+#[test]
+fn run_convert_command_on_json_without_extension_file_with_output() {
+    Context::default()
+        .write_file("data", "{ \"property\": true }")
+        .arg("convert")
+        .arg("data")
+        .arg("out.lua")
+        .arg("--format")
+        .arg("json")
+        .replace_duration_labels()
+        .snapshot_command("run_convert_command_on_json_without_extension_file_with_output")
+        .snapshot_file("run_convert_command_on_json_file_out", "out.lua");
+}
+
+#[test]
+fn run_convert_command_on_json_file() {
+    Context::default()
+        .write_file("data.json", "{ \"property\": true }")
+        .arg("convert")
+        .arg("data.json")
+        .replace_duration_labels()
+        .snapshot_command("run_convert_command_on_json_file_stdout");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -359,3 +359,25 @@ fn run_convert_command_on_json_file() {
         .replace_duration_labels()
         .snapshot_command("run_convert_command_on_json_file_stdout");
 }
+
+#[test]
+fn run_convert_command_errors_when_no_extension_and_no_format() {
+    Context::default()
+        .write_file("data", "{ \"property\": true }")
+        .arg("convert")
+        .arg("data")
+        .arg("out.lua")
+        .replace_duration_labels()
+        .snapshot_command("run_convert_command_errors_when_no_extension_and_no_format");
+}
+
+#[test]
+fn run_convert_command_errors_when_unrecognized_extension() {
+    Context::default()
+        .write_file("data.yoyo", "{ \"property\": true }")
+        .arg("convert")
+        .arg("data.yoyo")
+        .arg("out.lua")
+        .replace_duration_labels()
+        .snapshot_command("run_convert_command_errors_when_unrecognized_extension");
+}

--- a/tests/snapshots/convert_help_command.snap
+++ b/tests/snapshots/convert_help_command.snap
@@ -11,7 +11,7 @@ Arguments:
   [OUTPUT]  Path where to write the Lua file
 
 Options:
-  -f, --format <FORMAT>  Data format
+  -f, --format <FORMAT>  Data format ('json', 'yaml' or 'toml')
   -v, --verbose...       Sets verbosity level (can be specified multiple times)
   -h, --help             Print help
   -V, --version          Print version

--- a/tests/snapshots/convert_help_command.snap
+++ b/tests/snapshots/convert_help_command.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli.rs
+expression: content
+---
+Convert a data file [json, json5, yaml, toml] into a Lua file
+
+Usage: darklua convert [OPTIONS] <INPUT> [OUTPUT]
+
+Arguments:
+  <INPUT>   Data file to convert to Lua
+  [OUTPUT]  Path where to write the Lua file
+
+Options:
+  -f, --format <FORMAT>  Data format
+  -v, --verbose...       Sets verbosity level (can be specified multiple times)
+  -h, --help             Print help
+  -V, --version          Print version
+

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -13,6 +13,7 @@ Usage: darklua [OPTIONS] <COMMAND>
 Commands:
   minify   Minify lua files without applying any transformation
   process  Process lua files with rules
+  convert  Convert a data file [json, json5, yaml, toml] into a Lua file
   help     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/snapshots/run_convert_command_errors_when_no_extension_and_no_format.snap
+++ b/tests/snapshots/run_convert_command_errors_when_no_extension_and_no_format.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+---
+an error happened: unable to find data format because the input file 'data' has no extension. Specify the data format using the '--format' option
+

--- a/tests/snapshots/run_convert_command_errors_when_unrecognized_extension.snap
+++ b/tests/snapshots/run_convert_command_errors_when_unrecognized_extension.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+---
+an error happened: invalid data format 'yoyo' (possible options are: 'json', 'json5', 'yml' or 'toml') [unrecognized file extension]
+

--- a/tests/snapshots/run_convert_command_on_json_file_out.snap
+++ b/tests/snapshots/run_convert_command_on_json_file_out.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli.rs
+expression: content
+---
+return{property=true}

--- a/tests/snapshots/run_convert_command_on_json_file_stdout.snap
+++ b/tests/snapshots/run_convert_command_on_json_file_stdout.snap
@@ -1,0 +1,8 @@
+---
+source: tests/cli.rs
+expression: content
+---
+return{property=true}
+
+[2m[32msuccessfully converted data.json[0m [2m(in {{DURATION}})[0m
+

--- a/tests/snapshots/run_convert_command_on_json_file_with_output.snap
+++ b/tests/snapshots/run_convert_command_on_json_file_with_output.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+---
+[2m[32msuccessfully converted data.json[0m [2m(in {{DURATION}})[0m
+

--- a/tests/snapshots/run_convert_command_on_json_without_extension_file_with_output.snap
+++ b/tests/snapshots/run_convert_command_on_json_without_extension_file_with_output.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: content
+---
+[2m[32msuccessfully converted data[0m [2m(in {{DURATION}})[0m
+

--- a/tests/snapshots/short_help_command.snap
+++ b/tests/snapshots/short_help_command.snap
@@ -9,6 +9,7 @@ Usage: darklua [OPTIONS] <COMMAND>
 Commands:
   minify   Minify lua files without applying any transformation
   process  Process lua files with rules
+  convert  Convert a data file [json, json5, yaml, toml] into a Lua file
   help     Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
Closes #139 

This PR add a new `convert` command to darklua to convert data files (`json`, `yaml` or `toml`) into a Lua module.

- [x] add entry to the changelog
- [x] update docs
