### PR TITLE
Fix `remove_unused_variable` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* fix `remove_unused_variable` rule ([#192](https://github.com/seaofvoices/darklua/pull/192))
+
 ## 0.13.0
 
 * add `convert` command to convert data files (`json`, `json5`, `yaml` and `toml`) into Lua modules ([#178](https://github.com/seaofvoices/darklua/pull/178))

--- a/site/content/docs/installation/index.md
+++ b/site/content/docs/installation/index.md
@@ -10,7 +10,7 @@ order: 1
 If you are already using [Foreman](https://github.com/Roblox/foreman), then installing darklua is as simple as adding this line in the `foreman.toml` file:
 
 ```toml
-darklua = { github = "seaofvoices/darklua", version = "=0.12.0" }
+darklua = { github = "seaofvoices/darklua", version = "=0.13.0" }
 ```
 
 ## Download a Release

--- a/src/nodes/expressions/type_cast.rs
+++ b/src/nodes/expressions/type_cast.rs
@@ -24,6 +24,10 @@ impl TypeCastExpression {
         &mut self.expression
     }
 
+    pub fn into_inner_expression(self) -> Expression {
+        *self.expression
+    }
+
     pub fn get_type(&self) -> &Type {
         &self.r#type
     }

--- a/src/nodes/statements/repeat_statement.rs
+++ b/src/nodes/statements/repeat_statement.rs
@@ -64,6 +64,11 @@ impl RepeatStatement {
         &mut self.condition
     }
 
+    #[inline]
+    pub(crate) fn mutate_block_and_condition(&mut self) -> (&mut Block, &mut Expression) {
+        (&mut self.block, &mut self.condition)
+    }
+
     pub fn with_tokens(mut self, tokens: RepeatTokens) -> Self {
         self.tokens = Some(tokens);
         self

--- a/src/process/node_processor.rs
+++ b/src/process/node_processor.rs
@@ -4,6 +4,7 @@ use crate::nodes::*;
 /// perform mutations.
 pub trait NodeProcessor {
     fn process_block(&mut self, _: &mut Block) {}
+    fn process_scope(&mut self, _block: &mut Block, _extra: Option<&mut Expression>) {}
     fn process_statement(&mut self, _: &mut Statement) {}
 
     fn process_function_call(&mut self, _: &mut FunctionCall) {}

--- a/src/process/processors/find_usage.rs
+++ b/src/process/processors/find_usage.rs
@@ -1,7 +1,7 @@
 use std::ops;
 
 use crate::{
-    nodes::Identifier,
+    nodes::{Identifier, TypeField},
     process::{IdentifierTracker, NodeProcessor},
 };
 
@@ -39,12 +39,20 @@ impl<'a> FindUsage<'a> {
     pub fn has_found_usage(&self) -> bool {
         self.usage_found
     }
+
+    fn verify_identifier(&mut self, variable: &Identifier) {
+        if !self.usage_found && variable.get_name() == self.variable {
+            self.usage_found = !self.is_identifier_used(self.variable);
+        }
+    }
 }
 
 impl<'a> NodeProcessor for FindUsage<'a> {
     fn process_variable_expression(&mut self, variable: &mut Identifier) {
-        if !self.usage_found && variable.get_name() == self.variable {
-            self.usage_found = !self.is_identifier_used(self.variable);
-        }
+        self.verify_identifier(variable);
+    }
+
+    fn process_type_field(&mut self, type_field: &mut TypeField) {
+        self.verify_identifier(type_field.get_namespace());
     }
 }

--- a/src/process/scope_visitor.rs
+++ b/src/process/scope_visitor.rs
@@ -93,6 +93,8 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
             .iter_mut()
             .for_each(|parameter| scope.insert(parameter.mutate_name()));
 
+        scope.process_scope(function.mutate_block(), None);
+
         Self::visit_block(function.mutate_block(), scope);
         scope.pop();
     }
@@ -125,6 +127,8 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
             .iter_mut()
             .for_each(|parameter| scope.insert(parameter.mutate_name()));
 
+        scope.process_scope(statement.mutate_block(), None);
+
         Self::visit_block(statement.mutate_block(), scope);
         scope.pop();
     }
@@ -155,6 +159,8 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
             .iter_mut()
             .for_each(|parameter| scope.insert(parameter.mutate_name()));
 
+        scope.process_scope(statement.mutate_block(), None);
+
         Self::visit_block(statement.mutate_block(), scope);
         scope.pop();
     }
@@ -177,6 +183,8 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
             Self::visit_type(r#type, scope);
         }
 
+        scope.process_scope(statement.mutate_block(), None);
+
         Self::visit_block(statement.mutate_block(), scope);
     }
 
@@ -197,6 +205,8 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
         scope.push();
         scope.insert(statement.mutate_identifier().mutate_name());
 
+        scope.process_scope(statement.mutate_block(), None);
+
         Self::visit_block(statement.mutate_block(), scope);
         scope.pop();
     }
@@ -205,6 +215,9 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
         scope.process_repeat_statement(statement);
 
         scope.push();
+
+        let (block, condition) = statement.mutate_block_and_condition();
+        scope.process_scope(block, Some(condition));
 
         Self::visit_block_without_push(statement.mutate_block(), scope);
         Self::visit_expression(statement.mutate_condition(), scope);

--- a/tests/rule_tests/remove_unused_variable.rs
+++ b/tests/rule_tests/remove_unused_variable.rs
@@ -53,6 +53,9 @@ test_rule!(
     ) => "do local a print(a) end",
     remove_variable_before_call_statement("local x call()") => "call()",
     remove_two_variables_before_call_statement("local x local y call()") => "call()",
+    remove_unused_variable_but_keep_require_side_effect("local _requireZero = require('./requireZero.roblox.lua')") => "require('./requireZero.roblox.lua')",
+    remove_unused_variable_but_keep_require_side_effect_in_parens("local _requireZero = (require('./requireZero.roblox.lua'))") => "require('./requireZero.roblox.lua')",
+    remove_unused_variable_but_keep_require_side_effect_in_parens_with_type_cast("local _requireZero = (require('./requireZero.roblox.lua') :: any)") => "require('./requireZero.roblox.lua')",
     // remove variables that are used more than once, but never read
     // remove_if_only_assigned("local a = true a = false") => "",
     // remove_if_only_field_assigned("local a = {} a.foo = false") => "",
@@ -90,6 +93,9 @@ test_rule_without_effects!(
     ),
     keep_if_variable_is_used_in_index_assignment("local a, b = {}, true a[b] = false return a"),
     keep_variable_in_repeat_condition("repeat local x = true until x"),
+    keep_variable_used_in_for_loop("local x, y = {}, {} function y.toString() end for k,v in y do x[k] = v end return { x = x }"),
+    keep_variable_used_in_returned_table_entry("local x = {} return { x = x }"),
+    keep_variable_used_in_type_declaration("local x = require('./m') export type X = x.X return {}"),
 );
 
 #[test]

--- a/tests/rule_tests/remove_unused_variable.rs
+++ b/tests/rule_tests/remove_unused_variable.rs
@@ -51,6 +51,8 @@ test_rule!(
     remove_variable_if_shadowed_undeclared_variable_is_used(
         "local a = true do local a print(a) end"
     ) => "do local a print(a) end",
+    remove_variable_before_call_statement("local x call()") => "call()",
+    remove_two_variables_before_call_statement("local x local y call()") => "call()",
     // remove variables that are used more than once, but never read
     // remove_if_only_assigned("local a = true a = false") => "",
     // remove_if_only_field_assigned("local a = {} a.foo = false") => "",
@@ -87,6 +89,7 @@ test_rule_without_effects!(
         "local a = {} local function b() print() return a end b().a = true"
     ),
     keep_if_variable_is_used_in_index_assignment("local a, b = {}, true a[b] = false return a"),
+    keep_variable_in_repeat_condition("repeat local x = true until x"),
 );
 
 #[test]


### PR DESCRIPTION
Closes #182
Closes #186 
Closes #187 

These changes fixes the `remove_unused_variable` rule by removing the variables in the right order and fixing the scoping issue with repeat statements.

- [x] add entry to the changelog
