### PR TITLE
Add parameter to skip comments with the `remove_comments` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* add `except` parameter to skip comments when using the `remove_comments` rule ([#194](https://github.com/seaofvoices/darklua/pull/194))
 * fix generators that creates spaces when writing field expressions, function statements and field-types ([#193](https://github.com/seaofvoices/darklua/pull/193))
 
 ## 0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -19,50 +19,51 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -78,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
 dependencies = [
  "anstyle",
- "bstr 1.7.0",
+ "bstr 1.9.1",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -88,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "beef"
@@ -106,9 +107,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -141,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata 0.4.6",
@@ -152,15 +153,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
-version = "0.6.4"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "cast"
@@ -170,12 +171,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
@@ -197,9 +195,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -208,15 +206,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -224,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -246,14 +244,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -264,20 +262,20 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -308,9 +306,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -327,7 +325,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -348,51 +346,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -502,9 +497,9 @@ checksum = "232860130f75128af6852aef5105ee3813539258f2ce74d0f0ec2dca9b69e22d"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elsa"
@@ -552,9 +547,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -562,20 +557,20 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "filetime"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -624,11 +619,12 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+checksum = "186014d53bc231d0090ef8d6f03e0920c54d85a5ed22f4f2f74315ec56cf83fb"
 dependencies = [
  "cc",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "rustversion",
@@ -647,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -658,9 +654,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -670,9 +670,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -682,9 +682,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "humantime"
@@ -729,12 +729,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.36.1"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
 dependencies = [
  "console",
  "lazy_static",
@@ -769,19 +769,24 @@ dependencies = [
  "regex",
  "serde",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -793,19 +798,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "joinery"
@@ -879,9 +875,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -914,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "loom"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e045d70ddfbc984eacfa964ded019534e8f6cbf36f6410aee0ed5cefa5a9175"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if 1.0.0",
  "generator",
@@ -936,18 +932,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "minimal-lexical"
@@ -957,9 +944,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -973,7 +960,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "cfg-if 1.0.0",
  "cfg_aliases",
  "libc",
@@ -1021,7 +1008,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1057,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -1085,9 +1072,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -1097,9 +1084,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pest"
-version = "2.7.5"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1108,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.5"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1118,22 +1105,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.5"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.5"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -1142,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "plotters"
@@ -1191,13 +1178,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -1229,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1247,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1296,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1306,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1316,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -1332,7 +1318,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1352,7 +1338,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1363,9 +1349,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustc_version"
@@ -1378,11 +1364,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1391,15 +1377,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -1417,22 +1403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
@@ -1448,20 +1428,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1470,20 +1450,20 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -1512,15 +1492,15 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"
@@ -1552,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1569,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1598,29 +1578,29 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -1638,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1650,20 +1630,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1689,7 +1669,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
 ]
 
 [[package]]
@@ -1755,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client-sys"
-version = "0.21.2"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb915ea3af048554640d76dd6f1492589a6401a41a30d789b983c1ec280455a"
+checksum = "9d104d610dfa9dd154535102cc9c6164ae1fa37842bc2d9e83f9ac82b0ae0882"
 dependencies = [
  "cc",
 ]
@@ -1788,9 +1768,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1821,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1856,7 +1836,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
  "wasm-bindgen-shared",
 ]
 
@@ -1878,7 +1858,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.64",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1897,7 +1877,7 @@ checksum = "06c7a3bac6110ac062b7b422a442b7ee23e07209e2784a036654cab1e71bbafc"
 dependencies = [
  "bstr 0.2.17",
  "const_format",
- "itertools 0.10.5",
+ "itertools",
  "nom",
  "nom-supreme",
  "pori",
@@ -1935,11 +1915,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1950,20 +1930,31 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-core",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-core"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1981,22 +1972,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2016,24 +1992,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2043,15 +2014,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2061,15 +2026,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2079,15 +2038,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2097,15 +2056,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2115,15 +2068,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2133,15 +2080,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2151,26 +2092,17 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
@@ -439,6 +439,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "rand_distr",
+ "regex",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1324,13 +1325,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -1345,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ full_moon = { version = "0.19.0", features = ["roblox"] }
 json5 = "0.4.1"
 log = "0.4.21"
 pathdiff = "0.2.1"
+regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"
 serde_yaml = "0.9.32"

--- a/site/content/rules/remove_comments.md
+++ b/site/content/rules/remove_comments.md
@@ -5,7 +5,7 @@ parameters:
   - name: except
     added_in: "unreleased"
     type: string array
-    description: A list of regex that
+    description: Comments matching any of the given regular expressions will be kept
 examples:
   - content: "return nil -- this is a comment"
 ---

--- a/site/content/rules/remove_comments.md
+++ b/site/content/rules/remove_comments.md
@@ -16,7 +16,7 @@ The `except` parameter is useful to avoid removing specific comments like `--!na
 
 ```json5
 {
-  rule: 'remove_comments',
-  except: ['^--!']
+  rule: "remove_comments",
+  except: ["^--!"],
 }
 ```

--- a/site/content/rules/remove_comments.md
+++ b/site/content/rules/remove_comments.md
@@ -1,9 +1,22 @@
 ---
 description: Removes comments
 added_in: "0.7.0"
-parameters: []
+parameters:
+  - name: except
+    added_in: "unreleased"
+    type: string array
+    description: A list of regex that
 examples:
   - content: "return nil -- this is a comment"
 ---
 
 It is important to note that when generating code with the `dense` or `readable` generator (e.g. `darklua process src --format dense`), the comments will already be removed. The only way to retain comments is to use the `retain_lines` format and avoid this rule.
+
+The `except` parameter is useful to avoid removing specific comments like `--!native` (which trigger native compilation of modules when using Luau on Roblox). For example, to avoid removing all comments starting with `--!`:
+
+```json5
+{
+  rule: 'remove_comments',
+  except: ['^--!']
+}
+```

--- a/src/nodes/arguments.rs
+++ b/src/nodes/arguments.rs
@@ -10,33 +10,10 @@ pub struct TupleArgumentsTokens {
 }
 
 impl TupleArgumentsTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_parenthese.clear_comments();
-        self.closing_parenthese.clear_comments();
-        self.commas.iter_mut().for_each(Token::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_parenthese.clear_whitespaces();
-        self.closing_parenthese.clear_whitespaces();
-        self.commas.iter_mut().for_each(Token::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_parenthese.replace_referenced_tokens(code);
-        self.closing_parenthese.replace_referenced_tokens(code);
-        self.commas
-            .iter_mut()
-            .for_each(|token| token.replace_referenced_tokens(code));
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_parenthese.shift_token_line(amount);
-        self.closing_parenthese.shift_token_line(amount);
-        self.commas
-            .iter_mut()
-            .for_each(|token| token.shift_token_line(amount));
-    }
+    super::impl_token_fns!(
+        target = [opening_parenthese, closing_parenthese]
+        iter = [commas]
+    );
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -98,29 +75,7 @@ impl TupleArguments {
         self.values.iter_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 impl From<Arguments> for TupleArguments {
@@ -186,6 +141,13 @@ impl Arguments {
     pub(crate) fn shift_token_line(&mut self, amount: usize) {
         match self {
             Arguments::Tuple(tuple) => tuple.shift_token_line(amount),
+            Arguments::String(_) | Arguments::Table(_) => {}
+        }
+    }
+
+    pub(crate) fn filter_comments(&mut self, filter: impl Fn(&super::Trivia) -> bool) {
+        match self {
+            Arguments::Tuple(tuple) => tuple.filter_comments(filter),
             Arguments::String(_) | Arguments::Table(_) => {}
         }
     }

--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -8,53 +8,10 @@ pub struct BlockTokens {
 }
 
 impl BlockTokens {
-    pub fn clear_comments(&mut self) {
-        for semicolon in self.semicolons.iter_mut().flatten() {
-            semicolon.clear_comments();
-        }
-        if let Some(last_semicolon) = &mut self.last_semicolon {
-            last_semicolon.clear_comments();
-        }
-        if let Some(final_token) = &mut self.final_token {
-            final_token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        for semicolon in self.semicolons.iter_mut().flatten() {
-            semicolon.clear_whitespaces();
-        }
-        if let Some(last_semicolon) = &mut self.last_semicolon {
-            last_semicolon.clear_whitespaces();
-        }
-        if let Some(final_token) = &mut self.final_token {
-            final_token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for semicolon in self.semicolons.iter_mut().flatten() {
-            semicolon.replace_referenced_tokens(code);
-        }
-        if let Some(last_semicolon) = &mut self.last_semicolon {
-            last_semicolon.replace_referenced_tokens(code);
-        }
-        if let Some(final_token) = &mut self.final_token {
-            final_token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for semicolon in self.semicolons.iter_mut().flatten() {
-            semicolon.shift_token_line(amount);
-        }
-        if let Some(last_semicolon) = &mut self.last_semicolon {
-            last_semicolon.shift_token_line(amount);
-        }
-        if let Some(final_token) = &mut self.final_token {
-            final_token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        iter = [last_semicolon, final_token]
+        iter_flatten = [semicolons]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -265,29 +222,7 @@ impl Block {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 impl Default for Block {

--- a/src/nodes/expressions/binary.rs
+++ b/src/nodes/expressions/binary.rs
@@ -261,29 +261,7 @@ impl BinaryExpression {
         self.operator
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[cfg(test)]

--- a/src/nodes/expressions/field.rs
+++ b/src/nodes/expressions/field.rs
@@ -48,31 +48,8 @@ impl FieldExpression {
         &mut self.prefix
     }
 
-    pub fn clear_comments(&mut self) {
-        self.field.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.field.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.field.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.field.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [field]
+        iter = [token]
+    );
 }

--- a/src/nodes/expressions/function.rs
+++ b/src/nodes/expressions/function.rs
@@ -204,7 +204,5 @@ impl FunctionExpression {
         }
     }
 
-    super::impl_token_fns!(
-        iter = [parameters, generic_parameters, tokens]
-    );
+    super::impl_token_fns!(iter = [parameters, generic_parameters, tokens]);
 }

--- a/src/nodes/expressions/function.rs
+++ b/src/nodes/expressions/function.rs
@@ -204,51 +204,7 @@ impl FunctionExpression {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_comments);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_comments();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_whitespaces);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_whitespaces();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for parameter in self.parameters.iter_mut() {
-            parameter.replace_referenced_tokens(code);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for parameter in self.parameters.iter_mut() {
-            parameter.shift_token_line(amount);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        iter = [parameters, generic_parameters, tokens]
+    );
 }

--- a/src/nodes/expressions/if_expression.rs
+++ b/src/nodes/expressions/if_expression.rs
@@ -122,41 +122,9 @@ impl IfExpression {
         self.branches.iter_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        self.branches
-            .iter_mut()
-            .for_each(ElseIfExpressionBranch::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        self.branches
-            .iter_mut()
-            .for_each(ElseIfExpressionBranch::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        for branch in self.branches.iter_mut() {
-            branch.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        for branch in self.branches.iter_mut() {
-            branch.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        iter = [tokens, branches]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -209,29 +177,7 @@ impl ElseIfExpressionBranch {
         (self.condition, self.result)
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -242,29 +188,7 @@ pub struct IfExpressionTokens {
 }
 
 impl IfExpressionTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#if.clear_comments();
-        self.then.clear_comments();
-        self.r#else.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#if.clear_whitespaces();
-        self.then.clear_whitespaces();
-        self.r#else.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#if.replace_referenced_tokens(code);
-        self.then.replace_referenced_tokens(code);
-        self.r#else.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#if.shift_token_line(amount);
-        self.then.shift_token_line(amount);
-        self.r#else.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [r#if, then, r#else]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -274,23 +198,5 @@ pub struct ElseIfExpressionBranchTokens {
 }
 
 impl ElseIfExpressionBranchTokens {
-    pub fn clear_comments(&mut self) {
-        self.elseif.clear_comments();
-        self.then.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.elseif.clear_whitespaces();
-        self.then.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.elseif.replace_referenced_tokens(code);
-        self.then.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.elseif.shift_token_line(amount);
-        self.then.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [elseif, then]);
 }

--- a/src/nodes/expressions/if_expression.rs
+++ b/src/nodes/expressions/if_expression.rs
@@ -122,9 +122,7 @@ impl IfExpression {
         self.branches.iter_mut()
     }
 
-    super::impl_token_fns!(
-        iter = [tokens, branches]
-    );
+    super::impl_token_fns!(iter = [tokens, branches]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/nodes/expressions/index.rs
+++ b/src/nodes/expressions/index.rs
@@ -7,25 +7,7 @@ pub struct IndexExpressionTokens {
 }
 
 impl IndexExpressionTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_bracket.clear_comments();
-        self.closing_bracket.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_bracket.clear_whitespaces();
-        self.closing_bracket.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_bracket.replace_referenced_tokens(code);
-        self.closing_bracket.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_bracket.shift_token_line(amount);
-        self.closing_bracket.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [opening_bracket, closing_bracket]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -79,27 +61,5 @@ impl IndexExpression {
         &mut self.index
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/expressions/interpolated_string.rs
+++ b/src/nodes/expressions/interpolated_string.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-use crate::nodes::{StringError, Token};
+use crate::nodes::{StringError, Token, Trivia};
 
 use super::{string_utils, Expression};
 
@@ -54,29 +54,7 @@ impl StringSegment {
         self.value.is_empty()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -114,29 +92,7 @@ impl ValueSegment {
         &mut self.value
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -146,25 +102,7 @@ pub struct ValueSegmentTokens {
 }
 
 impl ValueSegmentTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_brace.clear_comments();
-        self.closing_brace.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_brace.clear_whitespaces();
-        self.closing_brace.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_brace.replace_referenced_tokens(code);
-        self.closing_brace.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_brace.shift_token_line(amount);
-        self.closing_brace.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [opening_brace, closing_brace]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -199,6 +137,13 @@ impl InterpolationSegment {
         match self {
             InterpolationSegment::String(segment) => segment.shift_token_line(amount),
             InterpolationSegment::Value(segment) => segment.shift_token_line(amount),
+        }
+    }
+
+    pub(crate) fn filter_comments(&mut self, filter: impl Fn(&Trivia) -> bool) {
+        match self {
+            InterpolationSegment::String(segment) => segment.filter_comments(filter),
+            InterpolationSegment::Value(segment) => segment.filter_comments(filter),
         }
     }
 }
@@ -275,41 +220,7 @@ impl InterpolatedStringExpression {
         self.tokens = Some(tokens);
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        for segment in &mut self.segments {
-            segment.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        for segment in &mut self.segments {
-            segment.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        for segment in &mut self.segments {
-            segment.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        for segment in &mut self.segments {
-            segment.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens, segments]);
 
     pub fn iter_segments(&self) -> impl Iterator<Item = &InterpolationSegment> {
         self.segments.iter()
@@ -368,25 +279,7 @@ pub struct InterpolatedStringTokens {
 }
 
 impl InterpolatedStringTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_tick.clear_comments();
-        self.closing_tick.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_tick.clear_whitespaces();
-        self.closing_tick.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_tick.replace_referenced_tokens(code);
-        self.closing_tick.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_tick.shift_token_line(amount);
-        self.closing_tick.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [opening_tick, closing_tick]);
 }
 
 #[cfg(test)]

--- a/src/nodes/expressions/mod.rs
+++ b/src/nodes/expressions/mod.rs
@@ -30,6 +30,8 @@ pub use unary::*;
 
 use crate::nodes::{FunctionCall, Identifier, Token, Variable};
 
+use super::impl_token_fns;
+
 use std::num::FpCategory;
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/nodes/expressions/number.rs
+++ b/src/nodes/expressions/number.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::str::FromStr;
 
-use crate::nodes::Token;
+use crate::nodes::{Token, Trivia};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DecimalNumber {
@@ -69,29 +69,7 @@ impl DecimalNumber {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -165,29 +143,7 @@ impl HexNumber {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -239,29 +195,7 @@ impl BinaryNumber {
         self.value
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -344,6 +278,14 @@ impl NumberExpression {
             NumberExpression::Decimal(number) => number.shift_token_line(amount),
             NumberExpression::Hex(number) => number.shift_token_line(amount),
             NumberExpression::Binary(number) => number.shift_token_line(amount),
+        }
+    }
+
+    pub(crate) fn filter_comments(&mut self, filter: impl Fn(&Trivia) -> bool) {
+        match self {
+            NumberExpression::Decimal(number) => number.filter_comments(filter),
+            NumberExpression::Hex(number) => number.filter_comments(filter),
+            NumberExpression::Binary(number) => number.filter_comments(filter),
         }
     }
 }

--- a/src/nodes/expressions/parenthese.rs
+++ b/src/nodes/expressions/parenthese.rs
@@ -7,25 +7,7 @@ pub struct ParentheseTokens {
 }
 
 impl ParentheseTokens {
-    pub fn clear_comments(&mut self) {
-        self.left_parenthese.clear_comments();
-        self.right_parenthese.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.left_parenthese.clear_whitespaces();
-        self.right_parenthese.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.left_parenthese.replace_referenced_tokens(code);
-        self.right_parenthese.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.left_parenthese.shift_token_line(amount);
-        self.right_parenthese.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [left_parenthese, right_parenthese]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,27 +59,5 @@ impl ParentheseExpression {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/expressions/string.rs
+++ b/src/nodes/expressions/string.rs
@@ -131,29 +131,7 @@ impl StringExpression {
         })
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[cfg(test)]

--- a/src/nodes/expressions/type_cast.rs
+++ b/src/nodes/expressions/type_cast.rs
@@ -57,29 +57,7 @@ impl TypeCastExpression {
         )
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[cfg(test)]

--- a/src/nodes/expressions/unary.rs
+++ b/src/nodes/expressions/unary.rs
@@ -63,27 +63,5 @@ impl UnaryExpression {
         self.operator
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }

--- a/src/nodes/function_body.rs
+++ b/src/nodes/function_body.rs
@@ -238,36 +238,13 @@ pub struct FunctionBodyTokens {
 }
 
 impl FunctionBodyTokens {
-    fn for_each_token(&mut self, callback: impl Fn(&mut Token)) {
-        callback(&mut self.function);
-        callback(&mut self.opening_parenthese);
-        callback(&mut self.closing_parenthese);
-        callback(&mut self.end);
-        if let Some(variable_arguments) = &mut self.variable_arguments {
-            callback(variable_arguments);
-        }
-        if let Some(variable_arguments_colon) = &mut self.variable_arguments_colon {
-            callback(variable_arguments_colon);
-        }
-        if let Some(return_type_colon) = &mut self.return_type_colon {
-            callback(return_type_colon);
-        }
-        self.parameter_commas.iter_mut().for_each(callback);
-    }
-
-    pub fn clear_comments(&mut self) {
-        self.for_each_token(Token::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.for_each_token(Token::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.for_each_token(|token| token.replace_referenced_tokens(code));
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.for_each_token(|token| token.shift_token_line(amount));
-    }
+    super::impl_token_fns!(
+        target = [function, opening_parenthese, closing_parenthese, end]
+        iter = [
+            variable_arguments,
+            variable_arguments_colon,
+            return_type_colon,
+            parameter_commas,
+        ]
+    );
 }

--- a/src/nodes/function_call.rs
+++ b/src/nodes/function_call.rs
@@ -6,29 +6,7 @@ pub struct FunctionCallTokens {
 }
 
 impl FunctionCallTokens {
-    pub fn clear_comments(&mut self) {
-        if let Some(colon) = &mut self.colon {
-            colon.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(colon) = &mut self.colon {
-            colon.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(colon) = &mut self.colon {
-            colon.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(colon) = &mut self.colon {
-            colon.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [colon]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -137,39 +115,5 @@ impl FunctionCall {
         &mut self.prefix
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        if let Some(method) = &mut self.method {
-            method.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        if let Some(method) = &mut self.method {
-            method.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        if let Some(method) = &mut self.method {
-            method.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        if let Some(method) = &mut self.method {
-            method.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens, method]);
 }

--- a/src/nodes/identifier.rs
+++ b/src/nodes/identifier.rs
@@ -64,29 +64,7 @@ impl Identifier {
         self.name
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 impl<IntoString: Into<String>> From<IntoString> for Identifier {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -23,3 +23,124 @@ pub use token::*;
 pub use typed_identifier::*;
 pub use types::*;
 pub use variable::*;
+
+macro_rules! impl_token_fns {
+    (
+        target = [ $( $field:ident ),* $(,)? ]
+        $(iter = [ $( $iter_field:ident),* $(,)? ])?
+        $(iter_flatten = [ $( $iter_flatten_field:ident),* $(,)? ])?
+    ) => {
+        pub fn clear_comments(&mut self) {
+            $(
+                self.$field.clear_comments();
+            )*
+            $($(
+                    for token in self.$iter_field.iter_mut() {
+                        token.clear_comments();
+                    }
+            )*)?
+            $($(
+                    for token in self.$iter_flatten_field.iter_mut().flatten() {
+                        token.clear_comments();
+                    }
+            )*)?
+        }
+
+        pub fn clear_whitespaces(&mut self) {
+            $(
+                self.$field.clear_whitespaces();
+            )*
+            $($(
+                for token in self.$iter_field.iter_mut() {
+                    token.clear_whitespaces();
+                }
+            )*)?
+            $($(
+                for token in self.$iter_flatten_field.iter_mut().flatten() {
+                    token.clear_whitespaces();
+                }
+            )*)?
+        }
+
+        pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
+            $(
+                self.$field.replace_referenced_tokens(code);
+            )*
+            $($(
+                for token in self.$iter_field.iter_mut() {
+                    token.replace_referenced_tokens(code);
+                }
+            )*)?
+            $($(
+                for token in self.$iter_flatten_field.iter_mut().flatten() {
+                    token.replace_referenced_tokens(code);
+                }
+            )*)?
+        }
+
+        pub(crate) fn shift_token_line(&mut self, amount: usize) {
+            $(
+                self.$field.shift_token_line(amount);
+            )*
+            $($(
+                for token in self.$iter_field.iter_mut() {
+                    token.shift_token_line(amount);
+                }
+            )*)?
+            $($(
+                for token in self.$iter_flatten_field.iter_mut().flatten() {
+                    token.shift_token_line(amount);
+                }
+            )*)?
+        }
+
+        pub(crate) fn filter_comments(&mut self, filter: impl Fn(&crate::nodes::Trivia) -> bool) {
+            $(
+                self.$field.filter_comments(&filter);
+            )*
+            $($(
+                for token in self.$iter_field.iter_mut() {
+                    token.filter_comments(&filter);
+                }
+            )*)?
+            $($(
+                for token in self.$iter_flatten_field.iter_mut().flatten() {
+                    token.filter_comments(&filter);
+                }
+            )*)?
+        }
+    };
+
+    (
+        iter = [$($field:ident),*]
+        iter_flatten = [$($flatten_field:ident),*]
+    ) => {
+        $crate::nodes::impl_token_fns!(
+            target = []
+            iter = [ $($field,)* ]
+            iter_flatten = [ $($flatten_field,)* ]
+        );
+    };
+
+    (
+        iter = [$($field:ident),*]
+    ) => {
+        $crate::nodes::impl_token_fns!(
+            target = []
+            iter = [ $($field,)* ]
+            iter_flatten = []
+        );
+    };
+
+    (
+        iter_flatten = [$($field:ident),*]
+    ) => {
+        $crate::nodes::impl_token_fns!(
+            target = []
+            iter = []
+            iter_flatten = [ $($field,)* ]
+        );
+    };
+}
+
+pub(crate) use impl_token_fns;

--- a/src/nodes/statements/assign.rs
+++ b/src/nodes/statements/assign.rs
@@ -8,43 +8,10 @@ pub struct AssignTokens {
 }
 
 impl AssignTokens {
-    pub fn clear_comments(&mut self) {
-        self.equal.clear_comments();
-        self.variable_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-            .for_each(Token::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.equal.clear_whitespaces();
-        self.variable_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-            .for_each(Token::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.equal.replace_referenced_tokens(code);
-        for comma in self
-            .variable_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-        {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    fn shift_token_line(&mut self, amount: usize) {
-        self.equal.shift_token_line(amount);
-        for comma in self
-            .variable_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-        {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [equal]
+        iter = [variable_commas, value_commas]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -141,27 +108,5 @@ impl AssignStatement {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/statements/compound_assign.rs
+++ b/src/nodes/statements/compound_assign.rs
@@ -45,6 +45,10 @@ pub struct CompoundAssignTokens {
     pub operator: Token,
 }
 
+impl CompoundAssignTokens {
+    super::impl_token_fns!(target = [operator]);
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompoundAssignStatement {
     operator: CompoundOperator,
@@ -112,27 +116,5 @@ impl CompoundAssignStatement {
         &mut self.value
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.operator.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.operator.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.operator.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.operator.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/statements/do_statement.rs
+++ b/src/nodes/statements/do_statement.rs
@@ -7,25 +7,7 @@ pub struct DoTokens {
 }
 
 impl DoTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#do.clear_comments();
-        self.end.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#do.clear_whitespaces();
-        self.end.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#do.replace_referenced_tokens(code);
-        self.end.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#do.shift_token_line(amount);
-        self.end.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [r#do, end]);
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -72,27 +54,5 @@ impl DoStatement {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/statements/function.rs
+++ b/src/nodes/statements/function.rs
@@ -10,37 +10,7 @@ pub struct FunctionNameTokens {
 }
 
 impl FunctionNameTokens {
-    pub fn clear_comments(&mut self) {
-        self.periods.iter_mut().for_each(Token::clear_comments);
-        if let Some(token) = &mut self.colon {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.periods.iter_mut().for_each(Token::clear_whitespaces);
-        if let Some(token) = &mut self.colon {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for token in self.periods.iter_mut() {
-            token.replace_referenced_tokens(code);
-        }
-        if let Some(token) = &mut self.colon {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for token in self.periods.iter_mut() {
-            token.shift_token_line(amount);
-        }
-        if let Some(token) = &mut self.colon {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [periods, colon]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -139,53 +109,7 @@ impl FunctionName {
         &mut self.name
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        for field in self.field_names.iter_mut() {
-            field.clear_comments();
-        }
-        if let Some(method) = &mut self.method {
-            method.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        for field in self.field_names.iter_mut() {
-            field.clear_whitespaces();
-        }
-        if let Some(method) = &mut self.method {
-            method.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        for field in self.field_names.iter_mut() {
-            field.replace_referenced_tokens(code);
-        }
-        if let Some(method) = &mut self.method {
-            method.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        for field in self.field_names.iter_mut() {
-            field.shift_token_line(amount);
-        }
-        if let Some(method) = &mut self.method {
-            method.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens, field_names, method]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -401,55 +325,8 @@ impl FunctionStatement {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        self.name.clear_comments();
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_comments);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_comments();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.name.clear_whitespaces();
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_whitespaces);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_whitespaces();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.name.replace_referenced_tokens(code);
-        for parameter in self.parameters.iter_mut() {
-            parameter.replace_referenced_tokens(code);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.name.shift_token_line(amount);
-        for parameter in self.parameters.iter_mut() {
-            parameter.shift_token_line(amount);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [name]
+        iter = [parameters, generic_parameters, tokens]
+    );
 }

--- a/src/nodes/statements/generic_for.rs
+++ b/src/nodes/statements/generic_for.rs
@@ -11,55 +11,10 @@ pub struct GenericForTokens {
 }
 
 impl GenericForTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#for.clear_comments();
-        self.r#in.clear_comments();
-        self.r#do.clear_comments();
-        self.end.clear_comments();
-        self.identifier_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-            .for_each(Token::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#for.clear_whitespaces();
-        self.r#in.clear_whitespaces();
-        self.r#do.clear_whitespaces();
-        self.end.clear_whitespaces();
-        self.identifier_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-            .for_each(Token::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#for.replace_referenced_tokens(code);
-        self.r#in.replace_referenced_tokens(code);
-        self.r#do.replace_referenced_tokens(code);
-        self.end.replace_referenced_tokens(code);
-        for comma in self
-            .identifier_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-        {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#for.shift_token_line(amount);
-        self.r#in.shift_token_line(amount);
-        self.r#do.shift_token_line(amount);
-        self.end.shift_token_line(amount);
-        for comma in self
-            .identifier_commas
-            .iter_mut()
-            .chain(self.value_commas.iter_mut())
-        {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [r#for, r#in, r#do, end]
+        iter = [identifier_commas, value_commas]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -160,39 +115,5 @@ impl GenericForStatement {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        self.identifiers
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        self.identifiers
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        for identifier in self.identifiers.iter_mut() {
-            identifier.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        for identifier in self.identifiers.iter_mut() {
-            identifier.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens, identifiers]);
 }

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -9,25 +9,7 @@ pub struct IfBranchTokens {
 }
 
 impl IfBranchTokens {
-    pub fn clear_comments(&mut self) {
-        self.elseif.clear_comments();
-        self.then.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.elseif.clear_whitespaces();
-        self.then.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.elseif.replace_referenced_tokens(code);
-        self.then.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.elseif.shift_token_line(amount);
-        self.then.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [elseif, then]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -94,29 +76,7 @@ impl IfBranch {
         &mut self.condition
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -128,41 +88,10 @@ pub struct IfStatementTokens {
 }
 
 impl IfStatementTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#if.clear_comments();
-        self.then.clear_comments();
-        self.end.clear_comments();
-        if let Some(token) = &mut self.r#else {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#if.clear_whitespaces();
-        self.then.clear_whitespaces();
-        self.end.clear_whitespaces();
-        if let Some(token) = &mut self.r#else {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#if.replace_referenced_tokens(code);
-        self.then.replace_referenced_tokens(code);
-        self.end.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.r#else {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#if.shift_token_line(amount);
-        self.then.shift_token_line(amount);
-        self.end.shift_token_line(amount);
-        if let Some(token) = &mut self.r#else {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [r#if, then, end]
+        iter = [r#else]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -293,40 +222,6 @@ impl IfStatement {
         self.else_block.take()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        self.branches.iter_mut().for_each(IfBranch::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        self.branches
-            .iter_mut()
-            .for_each(IfBranch::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        for branch in self.branches.iter_mut() {
-            branch.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        for branch in self.branches.iter_mut() {
-            branch.shift_token_line(amount);
-        }
-    }
-
     pub fn retain_branches_mut(&mut self, filter: impl FnMut(&mut IfBranch) -> bool) -> bool {
         self.branches.retain_mut(filter);
         if self.branches.is_empty() {
@@ -337,4 +232,6 @@ impl IfStatement {
             false
         }
     }
+
+    super::impl_token_fns!(iter = [tokens, branches]);
 }

--- a/src/nodes/statements/last_statement.rs
+++ b/src/nodes/statements/last_statement.rs
@@ -7,29 +7,10 @@ pub struct ReturnTokens {
 }
 
 impl ReturnTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#return.clear_comments();
-        self.commas.iter_mut().for_each(Token::clear_comments);
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#return.clear_whitespaces();
-        self.commas.iter_mut().for_each(Token::clear_whitespaces);
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#return.replace_referenced_tokens(code);
-        for comma in self.commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#return.shift_token_line(amount);
-        for comma in self.commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [r#return]
+        iter = [commas]
+    );
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -112,29 +93,7 @@ impl ReturnStatement {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/nodes/statements/local_assign.rs
+++ b/src/nodes/statements/local_assign.rs
@@ -9,55 +9,10 @@ pub struct LocalAssignTokens {
 }
 
 impl LocalAssignTokens {
-    pub fn clear_comments(&mut self) {
-        self.local.clear_comments();
-        self.variable_commas
-            .iter_mut()
-            .for_each(Token::clear_comments);
-        self.value_commas.iter_mut().for_each(Token::clear_comments);
-        if let Some(token) = &mut self.equal {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.local.clear_whitespaces();
-        self.variable_commas
-            .iter_mut()
-            .for_each(Token::clear_whitespaces);
-        self.value_commas
-            .iter_mut()
-            .for_each(Token::clear_whitespaces);
-        if let Some(token) = &mut self.equal {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.local.replace_referenced_tokens(code);
-        for comma in self.variable_commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-        for comma in self.value_commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-        if let Some(token) = &mut self.equal {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.local.shift_token_line(amount);
-        for comma in self.variable_commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-        for comma in self.value_commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-        if let Some(token) = &mut self.equal {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [local]
+        iter = [variable_commas, value_commas, equal]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -264,41 +219,7 @@ impl LocalAssignStatement {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        self.variables
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_comments);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.variables
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_whitespaces);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for variable in self.variables.iter_mut() {
-            variable.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for variable in self.variables.iter_mut() {
-            variable.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [variables, tokens]);
 }
 
 #[cfg(test)]

--- a/src/nodes/statements/local_function.rs
+++ b/src/nodes/statements/local_function.rs
@@ -10,25 +10,7 @@ pub struct LocalFunctionTokens {
 }
 
 impl LocalFunctionTokens {
-    pub fn clear_comments(&mut self) {
-        self.local.clear_comments();
-        self.function_body.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.local.clear_whitespaces();
-        self.function_body.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.local.replace_referenced_tokens(code);
-        self.function_body.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.local.shift_token_line(amount);
-        self.function_body.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [local, function_body]);
 }
 
 impl std::ops::Deref for LocalFunctionTokens {
@@ -263,57 +245,10 @@ impl LocalFunctionStatement {
         }
     }
 
-    pub fn clear_comments(&mut self) {
-        self.identifier.clear_comments();
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_comments);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_comments();
-        }
-        if let Some(tokens) = self.tokens.as_mut() {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.identifier.clear_whitespaces();
-        self.parameters
-            .iter_mut()
-            .for_each(TypedIdentifier::clear_whitespaces);
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_whitespaces();
-        }
-        if let Some(tokens) = self.tokens.as_mut() {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.identifier.replace_referenced_tokens(code);
-        for parameter in self.parameters.iter_mut() {
-            parameter.replace_referenced_tokens(code);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = self.tokens.as_mut() {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.identifier.shift_token_line(amount);
-        for parameter in self.parameters.iter_mut() {
-            parameter.shift_token_line(amount);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [identifier]
+        iter = [parameters, generic_parameters, tokens]
+    );
 }
 
 #[cfg(test)]

--- a/src/nodes/statements/mod.rs
+++ b/src/nodes/statements/mod.rs
@@ -28,6 +28,8 @@ pub use while_statement::*;
 
 use crate::nodes::FunctionCall;
 
+use super::impl_token_fns;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Statement {
     Assign(AssignStatement),

--- a/src/nodes/statements/numeric_for.rs
+++ b/src/nodes/statements/numeric_for.rs
@@ -11,49 +11,10 @@ pub struct NumericForTokens {
 }
 
 impl NumericForTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#for.clear_comments();
-        self.equal.clear_comments();
-        self.r#do.clear_comments();
-        self.end.clear_comments();
-        self.end_comma.clear_comments();
-        if let Some(token) = &mut self.step_comma {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#for.clear_whitespaces();
-        self.equal.clear_whitespaces();
-        self.r#do.clear_whitespaces();
-        self.end.clear_whitespaces();
-        self.end_comma.clear_whitespaces();
-        if let Some(token) = &mut self.step_comma {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#for.replace_referenced_tokens(code);
-        self.equal.replace_referenced_tokens(code);
-        self.r#do.replace_referenced_tokens(code);
-        self.end.replace_referenced_tokens(code);
-        self.end_comma.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.step_comma {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#for.shift_token_line(amount);
-        self.equal.shift_token_line(amount);
-        self.r#do.shift_token_line(amount);
-        self.end.shift_token_line(amount);
-        self.end_comma.shift_token_line(amount);
-        if let Some(token) = &mut self.step_comma {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [r#for, equal, r#do, end, end_comma]
+        iter = [step_comma]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -168,31 +129,5 @@ impl NumericForStatement {
         self.identifier.remove_type();
     }
 
-    pub fn clear_comments(&mut self) {
-        self.identifier.clear_comments();
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.identifier.clear_whitespaces();
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.identifier.replace_referenced_tokens(code);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.identifier.shift_token_line(amount);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(target = [identifier] iter = [tokens]);
 }

--- a/src/nodes/statements/repeat_statement.rs
+++ b/src/nodes/statements/repeat_statement.rs
@@ -7,25 +7,7 @@ pub struct RepeatTokens {
 }
 
 impl RepeatTokens {
-    pub fn clear_comments(&mut self) {
-        self.repeat.clear_comments();
-        self.until.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.repeat.clear_whitespaces();
-        self.until.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.repeat.replace_referenced_tokens(code);
-        self.until.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.repeat.shift_token_line(amount);
-        self.until.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [repeat, until]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -84,27 +66,5 @@ impl RepeatStatement {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/statements/while_statement.rs
+++ b/src/nodes/statements/while_statement.rs
@@ -8,29 +8,7 @@ pub struct WhileTokens {
 }
 
 impl WhileTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#while.clear_comments();
-        self.r#do.clear_comments();
-        self.end.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#while.clear_whitespaces();
-        self.r#do.clear_whitespaces();
-        self.end.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#while.replace_referenced_tokens(code);
-        self.r#do.replace_referenced_tokens(code);
-        self.end.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#while.shift_token_line(amount);
-        self.r#do.shift_token_line(amount);
-        self.end.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [r#while, r#do, end]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -89,27 +67,5 @@ impl WhileStatement {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }

--- a/src/nodes/token.rs
+++ b/src/nodes/token.rs
@@ -217,6 +217,13 @@ impl Token {
             .retain(|trivia| trivia.kind() != TriviaKind::Whitespace);
     }
 
+    pub(crate) fn filter_comments(&mut self, filter: impl Fn(&Trivia) -> bool) {
+        self.leading_trivia
+            .retain(|trivia| trivia.kind() != TriviaKind::Comment || filter(trivia));
+        self.trailing_trivia
+            .retain(|trivia| trivia.kind() != TriviaKind::Comment || filter(trivia));
+    }
+
     pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
         if let Position::LineNumberReference {
             start,

--- a/src/nodes/typed_identifier.rs
+++ b/src/nodes/typed_identifier.rs
@@ -61,33 +61,10 @@ impl TypedIdentifier {
         self.r#type.take()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.name.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.name.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.name.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.name.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [name]
+        iter = [token]
+    );
 }
 
 impl<IntoIdentifier: Into<Identifier>> From<IntoIdentifier> for TypedIdentifier {

--- a/src/nodes/types/array.rs
+++ b/src/nodes/types/array.rs
@@ -39,29 +39,7 @@ impl ArrayType {
         &mut self.inner_type
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,23 +49,5 @@ pub struct ArrayTypeTokens {
 }
 
 impl ArrayTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_brace.clear_comments();
-        self.closing_brace.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_brace.clear_whitespaces();
-        self.closing_brace.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_brace.replace_referenced_tokens(code);
-        self.closing_brace.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_brace.shift_token_line(amount);
-        self.closing_brace.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [opening_brace, closing_brace]);
 }

--- a/src/nodes/types/expression_type.rs
+++ b/src/nodes/types/expression_type.rs
@@ -39,29 +39,7 @@ impl ExpressionType {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -72,27 +50,5 @@ pub struct ExpressionTypeTokens {
 }
 
 impl ExpressionTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.r#typeof.clear_comments();
-        self.opening_parenthese.clear_comments();
-        self.closing_parenthese.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.r#typeof.clear_whitespaces();
-        self.opening_parenthese.clear_whitespaces();
-        self.closing_parenthese.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.r#typeof.replace_referenced_tokens(code);
-        self.opening_parenthese.replace_referenced_tokens(code);
-        self.closing_parenthese.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.r#typeof.shift_token_line(amount);
-        self.opening_parenthese.shift_token_line(amount);
-        self.closing_parenthese.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [r#typeof, opening_parenthese, closing_parenthese]);
 }

--- a/src/nodes/types/function.rs
+++ b/src/nodes/types/function.rs
@@ -68,41 +68,7 @@ impl FunctionArgumentType {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(name) = &mut self.name {
-            name.clear_comments();
-        }
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(name) = &mut self.name {
-            name.clear_whitespaces();
-        }
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(name) = &mut self.name {
-            name.replace_referenced_tokens(code);
-        }
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(name) = &mut self.name {
-            name.shift_token_line(amount);
-        }
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [name, token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -273,53 +239,7 @@ impl FunctionType {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_comments();
-        }
-        for argument in &mut self.arguments {
-            argument.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.clear_whitespaces();
-        }
-        for argument in &mut self.arguments {
-            argument.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.replace_referenced_tokens(code);
-        }
-        for argument in &mut self.arguments {
-            argument.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-        if let Some(generics) = &mut self.generic_parameters {
-            generics.shift_token_line(amount);
-        }
-        for argument in &mut self.arguments {
-            argument.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens, generic_parameters, arguments]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -331,39 +251,8 @@ pub struct FunctionTypeTokens {
 }
 
 impl FunctionTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_parenthese.clear_comments();
-        self.closing_parenthese.clear_comments();
-        self.arrow.clear_comments();
-        for comma in self.commas.iter_mut() {
-            comma.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_parenthese.clear_whitespaces();
-        self.closing_parenthese.clear_whitespaces();
-        self.arrow.clear_whitespaces();
-        for comma in self.commas.iter_mut() {
-            comma.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_parenthese.replace_referenced_tokens(code);
-        self.closing_parenthese.replace_referenced_tokens(code);
-        self.arrow.replace_referenced_tokens(code);
-        for comma in self.commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_parenthese.shift_token_line(amount);
-        self.closing_parenthese.shift_token_line(amount);
-        self.arrow.shift_token_line(amount);
-        for comma in self.commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [opening_parenthese, closing_parenthese, arrow]
+        iter = [commas]
+    );
 }

--- a/src/nodes/types/generics.rs
+++ b/src/nodes/types/generics.rs
@@ -44,33 +44,10 @@ impl GenericTypePack {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.name.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.name.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.name.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.name.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [name]
+        iter = [token]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -161,53 +138,9 @@ impl GenericParameters {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        for identifier in &mut self.type_variables {
-            identifier.clear_comments();
-        }
-        for generic_pack in &mut self.generic_type_packs {
-            generic_pack.clear_comments();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        for identifier in &mut self.type_variables {
-            identifier.clear_whitespaces();
-        }
-        for generic_pack in &mut self.generic_type_packs {
-            generic_pack.clear_whitespaces();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for identifier in &mut self.type_variables {
-            identifier.replace_referenced_tokens(code);
-        }
-        for generic_pack in &mut self.generic_type_packs {
-            generic_pack.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for identifier in &mut self.type_variables {
-            identifier.shift_token_line(amount);
-        }
-        for generic_pack in &mut self.generic_type_packs {
-            generic_pack.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        iter = [type_variables, generic_type_packs, tokens]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -218,37 +151,10 @@ pub struct GenericParametersTokens {
 }
 
 impl GenericParametersTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_list.clear_comments();
-        self.closing_list.clear_comments();
-        for comma in self.commas.iter_mut() {
-            comma.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_list.clear_whitespaces();
-        self.closing_list.clear_whitespaces();
-        for comma in self.commas.iter_mut() {
-            comma.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_list.replace_referenced_tokens(code);
-        self.closing_list.replace_referenced_tokens(code);
-        for comma in self.commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_list.shift_token_line(amount);
-        self.closing_list.shift_token_line(amount);
-        for comma in self.commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [opening_list, closing_list]
+        iter = [commas]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -331,29 +237,7 @@ impl GenericTypePackWithDefault {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -408,33 +292,10 @@ impl TypeVariableWithDefault {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.variable.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.variable.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.variable.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.variable.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [variable]
+        iter = [token]
+    );
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -600,29 +461,7 @@ impl GenericParametersWithDefaults {
             && self.generic_type_packs_with_default.is_empty()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 pub enum GenericParameter {

--- a/src/nodes/types/generics.rs
+++ b/src/nodes/types/generics.rs
@@ -138,9 +138,7 @@ impl GenericParameters {
         self.tokens.as_ref()
     }
 
-    super::impl_token_fns!(
-        iter = [type_variables, generic_type_packs, tokens]
-    );
+    super::impl_token_fns!(iter = [type_variables, generic_type_packs, tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/nodes/types/intersection.rs
+++ b/src/nodes/types/intersection.rs
@@ -53,30 +53,6 @@ impl IntersectionType {
         &self.right_type
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
-
     pub fn left_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -87,4 +63,6 @@ impl IntersectionType {
     pub fn right_needs_parentheses(r#type: &Type) -> bool {
         matches!(r#type, Type::Optional(_) | Type::Union(_))
     }
+
+    super::impl_token_fns!(iter = [token]);
 }

--- a/src/nodes/types/mod.rs
+++ b/src/nodes/types/mod.rs
@@ -32,6 +32,8 @@ pub use variadic_type_pack::*;
 
 use crate::nodes::Token;
 
+use super::impl_token_fns;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Type {
     Name(TypeName),

--- a/src/nodes/types/optional.rs
+++ b/src/nodes/types/optional.rs
@@ -41,30 +41,6 @@ impl OptionalType {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
-
     pub fn needs_parentheses(r#type: &Type) -> bool {
         // todo: parentheses are not needed for nested optional types but
         // a bug in full-moon forces darklua to put parentheses around
@@ -75,4 +51,6 @@ impl OptionalType {
             Type::Intersection(_) | Type::Union(_) | Type::Optional(_) | Type::Function(_)
         )
     }
+
+    super::impl_token_fns!(iter = [token]);
 }

--- a/src/nodes/types/parenthese.rs
+++ b/src/nodes/types/parenthese.rs
@@ -46,29 +46,7 @@ impl ParentheseType {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -78,23 +56,5 @@ pub struct ParentheseTypeTokens {
 }
 
 impl ParentheseTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.left_parenthese.clear_comments();
-        self.right_parenthese.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.left_parenthese.clear_whitespaces();
-        self.right_parenthese.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.left_parenthese.replace_referenced_tokens(code);
-        self.right_parenthese.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.left_parenthese.shift_token_line(amount);
-        self.right_parenthese.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [left_parenthese, right_parenthese]);
 }

--- a/src/nodes/types/string_type.rs
+++ b/src/nodes/types/string_type.rs
@@ -62,23 +62,5 @@ impl StringType {
         self.value.has_double_quote()
     }
 
-    #[inline]
-    pub fn clear_comments(&mut self) {
-        self.value.clear_comments();
-    }
-
-    #[inline]
-    pub fn clear_whitespaces(&mut self) {
-        self.value.clear_whitespaces();
-    }
-
-    #[inline]
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.value.replace_referenced_tokens(code);
-    }
-
-    #[inline]
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.value.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [value]);
 }

--- a/src/nodes/types/table.rs
+++ b/src/nodes/types/table.rs
@@ -1,4 +1,4 @@
-use crate::nodes::{Identifier, Token};
+use crate::nodes::{Identifier, Token, Trivia};
 
 use super::{StringType, Type};
 
@@ -53,29 +53,7 @@ impl TableIndexerType {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -86,29 +64,7 @@ pub struct TableIndexTypeTokens {
 }
 
 impl TableIndexTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_bracket.clear_comments();
-        self.closing_bracket.clear_comments();
-        self.colon.clear_comments();
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_bracket.clear_whitespaces();
-        self.closing_bracket.clear_whitespaces();
-        self.colon.clear_whitespaces();
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_bracket.replace_referenced_tokens(code);
-        self.closing_bracket.replace_referenced_tokens(code);
-        self.colon.replace_referenced_tokens(code);
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_bracket.shift_token_line(amount);
-        self.closing_bracket.shift_token_line(amount);
-        self.colon.shift_token_line(amount);
-    }
+    super::impl_token_fns!(target = [opening_bracket, closing_bracket, colon]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -162,33 +118,7 @@ impl TablePropertyType {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.property.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.property.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.property.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.property.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(target = [property] iter = [token]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -242,33 +172,7 @@ impl TableLiteralPropertyType {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.string.clear_comments();
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.string.clear_whitespaces();
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.string.replace_referenced_tokens(code);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.string.shift_token_line(amount);
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(target = [string] iter = [tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -308,6 +212,14 @@ impl TableEntryType {
             TableEntryType::Property(property) => property.shift_token_line(amount),
             TableEntryType::Literal(literal) => literal.shift_token_line(amount),
             TableEntryType::Indexer(indexer) => indexer.shift_token_line(amount),
+        }
+    }
+
+    pub(crate) fn filter_comments(&mut self, filter: impl Fn(&Trivia) -> bool) {
+        match self {
+            TableEntryType::Property(property) => property.filter_comments(filter),
+            TableEntryType::Literal(literal) => literal.filter_comments(filter),
+            TableEntryType::Indexer(indexer) => indexer.filter_comments(filter),
         }
     }
 }
@@ -444,41 +356,7 @@ impl TableType {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        for property in self.entries.iter_mut() {
-            property.clear_comments();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        for property in self.entries.iter_mut() {
-            property.clear_whitespaces();
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        for property in self.entries.iter_mut() {
-            property.replace_referenced_tokens(code);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        for property in self.entries.iter_mut() {
-            property.shift_token_line(amount);
-        }
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [entries, tokens]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -489,35 +367,8 @@ pub struct TableTypeTokens {
 }
 
 impl TableTypeTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_brace.clear_comments();
-        self.closing_brace.clear_comments();
-        for token in self.separators.iter_mut() {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_brace.clear_whitespaces();
-        self.closing_brace.clear_whitespaces();
-        for token in self.separators.iter_mut() {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_brace.replace_referenced_tokens(code);
-        self.closing_brace.replace_referenced_tokens(code);
-        for token in self.separators.iter_mut() {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_brace.shift_token_line(amount);
-        self.closing_brace.shift_token_line(amount);
-        for token in self.separators.iter_mut() {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [opening_brace, closing_brace]
+        iter = [separators]
+    );
 }

--- a/src/nodes/types/type_field.rs
+++ b/src/nodes/types/type_field.rs
@@ -49,31 +49,5 @@ impl TypeField {
         self.token.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.namespace.clear_comments();
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.namespace.clear_whitespaces();
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.namespace.replace_referenced_tokens(code);
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.namespace.shift_token_line(amount);
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(target = [namespace] iter = [token]);
 }

--- a/src/nodes/types/type_name.rs
+++ b/src/nodes/types/type_name.rs
@@ -64,33 +64,7 @@ impl TypeName {
         self.type_parameters.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        self.type_name.clear_comments();
-        if let Some(parameters) = &mut self.type_parameters {
-            parameters.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.type_name.clear_comments();
-        if let Some(parameters) = &mut self.type_parameters {
-            parameters.clear_comments();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.type_name.replace_referenced_tokens(code);
-        if let Some(parameters) = &mut self.type_parameters {
-            parameters.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.type_name.shift_token_line(amount);
-        if let Some(parameters) = &mut self.type_parameters {
-            parameters.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(target = [type_name] iter = [type_parameters]);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -151,29 +125,7 @@ impl TypeParameters {
         self.tokens.as_ref()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 impl FromIterator<TypeParameter> for TypeParameters {
@@ -252,35 +204,8 @@ pub struct TypeParametersTokens {
 }
 
 impl TypeParametersTokens {
-    pub fn clear_comments(&mut self) {
-        self.opening_list.clear_comments();
-        self.closing_list.clear_comments();
-        for comma in &mut self.commas {
-            comma.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.opening_list.clear_whitespaces();
-        self.closing_list.clear_whitespaces();
-        for comma in &mut self.commas {
-            comma.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.opening_list.replace_referenced_tokens(code);
-        self.closing_list.replace_referenced_tokens(code);
-        for comma in &mut self.commas {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.opening_list.shift_token_line(amount);
-        self.closing_list.shift_token_line(amount);
-        for comma in &mut self.commas {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [opening_list, closing_list]
+        iter = [commas]
+    );
 }

--- a/src/nodes/types/type_pack.rs
+++ b/src/nodes/types/type_pack.rs
@@ -85,29 +85,7 @@ impl TypePack {
         self.tokens.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(tokens) = &mut self.tokens {
-            tokens.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [tokens]);
 }
 
 impl FromIterator<Type> for TypePack {
@@ -155,35 +133,8 @@ pub struct TypePackTokens {
 }
 
 impl TypePackTokens {
-    pub fn clear_comments(&mut self) {
-        self.left_parenthese.clear_comments();
-        self.right_parenthese.clear_comments();
-        for comma in self.commas.iter_mut() {
-            comma.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        self.left_parenthese.clear_whitespaces();
-        self.right_parenthese.clear_whitespaces();
-        for comma in self.commas.iter_mut() {
-            comma.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        self.left_parenthese.replace_referenced_tokens(code);
-        self.right_parenthese.replace_referenced_tokens(code);
-        for comma in self.commas.iter_mut() {
-            comma.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        self.left_parenthese.shift_token_line(amount);
-        self.right_parenthese.shift_token_line(amount);
-        for comma in self.commas.iter_mut() {
-            comma.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(
+        target = [left_parenthese, right_parenthese]
+        iter = [commas]
+    );
 }

--- a/src/nodes/types/union.rs
+++ b/src/nodes/types/union.rs
@@ -53,30 +53,6 @@ impl UnionType {
         &self.right_type
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
-
     pub fn left_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -87,4 +63,6 @@ impl UnionType {
     pub fn right_needs_parentheses(r#type: &Type) -> bool {
         matches!(r#type, Type::Intersection(_))
     }
+
+    super::impl_token_fns!(iter = [token]);
 }

--- a/src/nodes/types/variadic_type_pack.rs
+++ b/src/nodes/types/variadic_type_pack.rs
@@ -47,27 +47,5 @@ impl VariadicTypePack {
         self.token.as_mut()
     }
 
-    pub fn clear_comments(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_comments();
-        }
-    }
-
-    pub fn clear_whitespaces(&mut self) {
-        if let Some(token) = &mut self.token {
-            token.clear_whitespaces();
-        }
-    }
-
-    pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
-        if let Some(token) = &mut self.token {
-            token.replace_referenced_tokens(code);
-        }
-    }
-
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
-        if let Some(token) = &mut self.token {
-            token.shift_token_line(amount);
-        }
-    }
+    super::impl_token_fns!(iter = [token]);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -550,8 +550,7 @@ mod test {
             };
         }
 
-        macro_rules!
-        test_parse_last_statement_with_tokens {
+        macro_rules! test_parse_last_statement_with_tokens {
             ($($name:ident($input:literal) => $value:expr),* $(,)?) => {
                 test_parse_block_with_tokens!(
                     $(

--- a/src/rules/remove_comments.rs
+++ b/src/rules/remove_comments.rs
@@ -499,17 +499,7 @@ impl RuleConfiguration for RemoveComments {
         for (key, value) in properties {
             match key.as_str() {
                 "except" => {
-                    self.except = value
-                        .expect_string_list(&key)?
-                        .into_iter()
-                        .filter_map(|regex_str| match Regex::new(&regex_str) {
-                            Ok(pattern) => Some(pattern),
-                            Err(err) => {
-                                log::warn!("unable to compile regex from `{}`: {}", regex_str, err);
-                                None
-                            }
-                        })
-                        .collect();
+                    self.except = value.expect_regex_list(&key)?;
                 }
                 _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
             }
@@ -568,7 +558,11 @@ mod test {
             except: ["^[0-9"],
         }"#,
         );
-        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+
+        insta::assert_snapshot!(
+            "remove_comments_configure_with_invalid_regex_error",
+            result.unwrap_err().to_string()
+        );
     }
 
     #[test]

--- a/src/rules/remove_comments.rs
+++ b/src/rules/remove_comments.rs
@@ -1,10 +1,10 @@
+use regex::Regex;
+
 use crate::nodes::*;
 use crate::process::{DefaultVisitor, NodeProcessor, NodeVisitor};
 use crate::rules::{
     Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
 };
-
-use super::verify_no_rule_properties;
 
 #[derive(Debug, Default)]
 pub(crate) struct RemoveCommentProcessor {}
@@ -230,22 +230,292 @@ impl NodeProcessor for RemoveCommentProcessor {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct FilterCommentProcessor<'a> {
+    original_code: &'a str,
+    except: &'a Vec<Regex>,
+}
+
+impl<'a> FilterCommentProcessor<'a> {
+    pub(crate) fn new(original_code: &'a str, except: &'a Vec<Regex>) -> Self {
+        Self {
+            original_code,
+            except,
+        }
+    }
+
+    fn ignore_trivia(&self, trivia: &Trivia) -> bool {
+        let content = trivia.read(&self.original_code);
+        println!("test comment `{}`", content);
+        self.except.iter().any(|pattern| pattern.is_match(content))
+    }
+}
+
+impl<'a> NodeProcessor for FilterCommentProcessor<'a> {
+    fn process_block(&mut self, block: &mut Block) {
+        block.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_function_call(&mut self, call: &mut FunctionCall) {
+        call.filter_comments(|trivia| self.ignore_trivia(trivia));
+        call.mutate_arguments()
+            .filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_assign_statement(&mut self, assign: &mut AssignStatement) {
+        assign.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_compound_assign_statement(&mut self, assign: &mut CompoundAssignStatement) {
+        assign.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_do_statement(&mut self, statement: &mut DoStatement) {
+        statement.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_function_statement(&mut self, function: &mut FunctionStatement) {
+        function.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_generic_for_statement(&mut self, generic_for: &mut GenericForStatement) {
+        generic_for.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_if_statement(&mut self, if_statement: &mut IfStatement) {
+        if_statement.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_last_statement(&mut self, statement: &mut LastStatement) {
+        match statement {
+            LastStatement::Break(token) | LastStatement::Continue(token) => {
+                if let Some(token) = token {
+                    token.filter_comments(|trivia| self.ignore_trivia(trivia));
+                }
+            }
+            LastStatement::Return(statement) => {
+                statement.filter_comments(|trivia| self.ignore_trivia(trivia))
+            }
+        }
+    }
+
+    fn process_local_assign_statement(&mut self, assign: &mut LocalAssignStatement) {
+        assign.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_local_function_statement(&mut self, function: &mut LocalFunctionStatement) {
+        function.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_numeric_for_statement(&mut self, numeric_for: &mut NumericForStatement) {
+        numeric_for.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_repeat_statement(&mut self, repeat: &mut RepeatStatement) {
+        repeat.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_while_statement(&mut self, statement: &mut WhileStatement) {
+        statement.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_type_declaration(&mut self, type_declaration: &mut TypeDeclarationStatement) {
+        type_declaration.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_expression(&mut self, expression: &mut Expression) {
+        match expression {
+            Expression::False(token)
+            | Expression::Nil(token)
+            | Expression::True(token)
+            | Expression::VariableArguments(token) => {
+                if let Some(token) = token {
+                    token.filter_comments(|trivia| self.ignore_trivia(trivia))
+                }
+            }
+            Expression::Binary(_)
+            | Expression::Call(_)
+            | Expression::Field(_)
+            | Expression::Function(_)
+            | Expression::Identifier(_)
+            | Expression::If(_)
+            | Expression::Index(_)
+            | Expression::Number(_)
+            | Expression::Parenthese(_)
+            | Expression::String(_)
+            | Expression::InterpolatedString(_)
+            | Expression::Table(_)
+            | Expression::Unary(_)
+            | Expression::TypeCast(_) => {}
+        }
+    }
+
+    fn process_binary_expression(&mut self, binary: &mut BinaryExpression) {
+        binary.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_field_expression(&mut self, field: &mut FieldExpression) {
+        field.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_function_expression(&mut self, function: &mut FunctionExpression) {
+        function.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_if_expression(&mut self, if_expression: &mut IfExpression) {
+        if_expression.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_variable_expression(&mut self, identifier: &mut Identifier) {
+        identifier.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_index_expression(&mut self, index: &mut IndexExpression) {
+        index.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_number_expression(&mut self, number: &mut NumberExpression) {
+        number.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_parenthese_expression(&mut self, expression: &mut ParentheseExpression) {
+        expression.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_string_expression(&mut self, string: &mut StringExpression) {
+        string.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_table_expression(&mut self, table: &mut TableExpression) {
+        table.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_unary_expression(&mut self, unary: &mut UnaryExpression) {
+        unary.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_interpolated_string_expression(
+        &mut self,
+        string: &mut InterpolatedStringExpression,
+    ) {
+        string.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
+        type_cast.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_prefix_expression(&mut self, _: &mut Prefix) {}
+
+    fn process_type(&mut self, r#type: &mut Type) {
+        match r#type {
+            Type::True(token) | Type::False(token) | Type::Nil(token) => {
+                if let Some(token) = token {
+                    token.filter_comments(|trivia| self.ignore_trivia(trivia));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn process_type_name(&mut self, type_name: &mut TypeName) {
+        type_name.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_type_field(&mut self, type_field: &mut TypeField) {
+        type_field.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_string_type(&mut self, string_type: &mut StringType) {
+        string_type.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_array_type(&mut self, array: &mut ArrayType) {
+        array.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_table_type(&mut self, table: &mut TableType) {
+        table.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_expression_type(&mut self, expression_type: &mut ExpressionType) {
+        expression_type.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_parenthese_type(&mut self, parenthese_type: &mut ParentheseType) {
+        parenthese_type.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_function_type(&mut self, function_type: &mut FunctionType) {
+        function_type.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_optional_type(&mut self, optional: &mut OptionalType) {
+        optional.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_intersection_type(&mut self, intersection: &mut IntersectionType) {
+        intersection.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_union_type(&mut self, union: &mut UnionType) {
+        union.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_type_pack(&mut self, type_pack: &mut TypePack) {
+        type_pack.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_generic_type_pack(&mut self, generic_type_pack: &mut GenericTypePack) {
+        generic_type_pack.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_variadic_type_pack(&mut self, variadic_type_pack: &mut VariadicTypePack) {
+        variadic_type_pack.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+}
+
 pub const REMOVE_COMMENTS_RULE_NAME: &str = "remove_comments";
 
 /// A rule that removes comments associated with AST nodes.
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct RemoveComments {}
+#[derive(Debug, Default)]
+pub struct RemoveComments {
+    except: Vec<Regex>,
+}
 
 impl FlawlessRule for RemoveComments {
-    fn flawless_process(&self, block: &mut Block, _: &Context) {
-        let mut processor = RemoveCommentProcessor::default();
-        DefaultVisitor::visit_block(block, &mut processor);
+    fn flawless_process(&self, block: &mut Block, context: &Context) {
+        if self.except.is_empty() {
+            let mut processor = RemoveCommentProcessor::default();
+            DefaultVisitor::visit_block(block, &mut processor);
+        } else {
+            let mut processor = FilterCommentProcessor::new(context.original_code(), &self.except);
+            DefaultVisitor::visit_block(block, &mut processor);
+        }
     }
 }
 
 impl RuleConfiguration for RemoveComments {
     fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
-        verify_no_rule_properties(&properties)?;
+        for (key, value) in properties {
+            match key.as_str() {
+                "except" => {
+                    self.except = value
+                        .expect_string_list(&key)?
+                        .into_iter()
+                        .filter_map(|regex_str| match Regex::new(&regex_str) {
+                            Ok(pattern) => Some(pattern),
+                            Err(err) => {
+                                log::warn!("unable to compile regex from `{}`: {}", regex_str, err);
+                                None
+                            }
+                        })
+                        .collect();
+                }
+                _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
+            }
+        }
+
         Ok(())
     }
 
@@ -286,6 +556,17 @@ mod test {
             r#"{
             rule: 'remove_comments',
             prop: "something",
+        }"#,
+        );
+        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+    }
+
+    #[test]
+    fn configure_with_invalid_regex_error() {
+        let result = json5::from_str::<Box<dyn Rule>>(
+            r#"{
+            rule: 'remove_comments',
+            except: ["^[0-9"],
         }"#,
         );
         pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");

--- a/src/rules/remove_comments.rs
+++ b/src/rules/remove_comments.rs
@@ -245,8 +245,7 @@ impl<'a> FilterCommentProcessor<'a> {
     }
 
     fn ignore_trivia(&self, trivia: &Trivia) -> bool {
-        let content = trivia.read(&self.original_code);
-        println!("test comment `{}`", content);
+        let content = trivia.read(self.original_code);
         self.except.iter().any(|pattern| pattern.is_match(content))
     }
 }

--- a/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_configure_with_invalid_regex_error.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_configure_with_invalid_regex_error.snap
@@ -1,0 +1,9 @@
+---
+source: src/rules/remove_comments.rs
+expression: result.unwrap_err().to_string()
+---
+unexpected value for field 'except': invalid regex provided `^[0-9`
+  regex parse error:
+    ^[0-9
+     ^
+error: unclosed character class

--- a/tests/rule_tests/remove_comments.rs
+++ b/tests/rule_tests/remove_comments.rs
@@ -42,7 +42,18 @@ macro_rules! test_remove_comments_rule {
 test_remove_comments_rule!(
     RemoveComments::default(),
     empty_do("do end -- comment") => "do end ",
+    before_empty_do("-- comment\ndo end") => "\ndo end",
     comment_after_semicolon("print('hello');-- bye") => "print('hello');",
+);
+
+test_remove_comments_rule!(
+    json5::from_str::<Box<dyn Rule>>(r#"{
+        rule: 'remove_comments',
+        except: ['^--!'],
+    }"#,
+    )
+    .unwrap(),
+    keep_one_comment_before_empty_do("--!native\n-- comment\ndo end") => "--!native\n\ndo end",
 );
 
 #[test]


### PR DESCRIPTION
Closes #173 

These changes add a `except` parameter to the `remove_comments` rule. This makes it possible to avoid removing `--!native` comments.

- [x] add entry to the changelog
