### PR TITLE
Adds an option to force relative paths.

### DIFF
--- a/src/rules/convert_require/roblox_require_mode.rs
+++ b/src/rules/convert_require/roblox_require_mode.rs
@@ -22,6 +22,8 @@ pub struct RobloxRequireMode {
     indexing_style: RobloxIndexStyle,
     #[serde(skip)]
     cached_sourcemap: Option<RojoSourcemap>,
+    #[serde(default)]
+    force_relative_path: bool,
 }
 
 impl RobloxRequireMode {
@@ -91,7 +93,7 @@ impl RobloxRequireMode {
                 );
 
                 if let Some(instance_path) =
-                    sourcemap.get_instance_path(&source_path, &require_relative_to_sourcemap)
+                    sourcemap.get_instance_path(&source_path, &require_relative_to_sourcemap, self.force_relative_path)
                 {
                     Ok(Some(Arguments::default().with_argument(
                         instance_path.convert(&self.indexing_style),

--- a/src/rules/convert_require/rojo_sourcemap.rs
+++ b/src/rules/convert_require/rojo_sourcemap.rs
@@ -120,6 +120,7 @@ impl RojoSourcemap {
         &self,
         from_file: impl AsRef<Path>,
         target_file: impl AsRef<Path>,
+        force_relative_path: bool,
     ) -> Option<InstancePath> {
         let from_file = from_file.as_ref();
         let target_file = target_file.as_ref();
@@ -156,7 +157,7 @@ impl RojoSourcemap {
 
         let relative_path_length = parents.len().saturating_add(descendants.len());
 
-        if !self.is_datamodel || relative_path_length <= target_ancestors.len() {
+        if !self.is_datamodel || force_relative_path || relative_path_length <= target_ancestors.len() {
             log::trace!("  ⨽ use Roblox path from script instance");
 
             let mut instance_path = InstancePath::from_script();
@@ -267,7 +268,7 @@ mod test {
             );
             pretty_assertions::assert_eq!(
                 sourcemap
-                    .get_instance_path("src/init.lua", "src/value.lua")
+                    .get_instance_path("src/init.lua", "src/value.lua", false)
                     .unwrap(),
                 script_path(&["value"])
             );
@@ -296,7 +297,7 @@ mod test {
             );
             pretty_assertions::assert_eq!(
                 sourcemap
-                    .get_instance_path("src/main.lua", "src/value.lua")
+                    .get_instance_path("src/main.lua", "src/value.lua", false)
                     .unwrap(),
                 script_path(&["parent", "value"])
             );
@@ -331,7 +332,7 @@ mod test {
             );
             pretty_assertions::assert_eq!(
                 sourcemap
-                    .get_instance_path("src/main.lua", "src/Lib/format.lua")
+                    .get_instance_path("src/main.lua", "src/Lib/format.lua", false)
                     .unwrap(),
                 script_path(&["parent", "Lib", "format"])
             );
@@ -355,7 +356,7 @@ mod test {
             );
             pretty_assertions::assert_eq!(
                 sourcemap
-                    .get_instance_path("src/main.lua", "src/init.lua")
+                    .get_instance_path("src/main.lua", "src/init.lua", false)
                     .unwrap(),
                 script_path(&["parent"])
             );
@@ -386,7 +387,7 @@ mod test {
             );
             pretty_assertions::assert_eq!(
                 sourcemap
-                    .get_instance_path("src/Sub/test.lua", "src/Sub/init.lua")
+                    .get_instance_path("src/Sub/test.lua", "src/Sub/init.lua", false)
                     .unwrap(),
                 script_path(&["parent"])
             );


### PR DESCRIPTION
Closes Issue [#214 ](https://github.com/seaofvoices/darklua/issues/214)

**Allows for Darklua to be used for Projects in cross-environment scenarios, as well as plugin development**
The only change is this implements a new boolean to the transform require rule: "force_relative_path", which simply forces a path to be relative to the script the transformation is occurring on. See the examples below.

**Example**

```lua
-- Let's assume your project structure has a hierarchy in which results in your relative path length is larger then your ancestor length. 

-- See https://github.com/seaofvoices/darklua/blob/60c886e92051601f3e4b71a1cf641db29110d162/src/rules/convert_require/rojo_sourcemap.rs#L159

-- In this case, your require path would be forced to an ancestor approach, which is problematic in situations where the ancestries may change; such as multiple environments, or for plugin development.

-- This case is especially problematic for plugin design, where the plugin must use relative pathing at all times, otherwise it will attempt to get your work environment rather then the local plugin install.

--------------------------------------

-- "force_relative_path": true
local variable = require(script.Parent.Parent.Parent.Parent:WaitForChild('childA'):WaitForChild('childB'):WaitForChild('childC'))

--------------------------------------

-- "force_relative_path": false
local variable = require(game:GetService('ServerStorage'):WaitForChild('parentA'):WaitForChild('chilA'):WaitForChild('childB'):WaitForChild('childC'))

--------------------------------------

```

<!-- Tests -->
*Wasn't entirely sure the best approach for implementing a test for this, however all previous tests work - which at bare minimum allows for compatibility and ease for updating. If you have any advice let me know.*

- [ ] Add tests which otherwise would force getting a path from the DataModel.

<!-- Changelogs -->

- [ ] Updating the changelog, there is no mention of whether or not this is done by the maintainer of if we should include it in our pull requests. I can include if this is passed.