### PR TITLE
Add `remove_generalized_iteration` rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,19 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -171,9 +190,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -299,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +443,7 @@ version = "0.13.1"
 dependencies = [
  "anstyle",
  "assert_cmd",
+ "blake3",
  "clap",
  "criterion",
  "ctrlc",
@@ -422,6 +451,7 @@ dependencies = [
  "elsa",
  "env_logger",
  "full_moon",
+ "hex",
  "include_dir",
  "insta",
  "json5",
@@ -439,6 +469,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_yaml",
+ "strfmt",
  "tempfile",
  "toml",
  "tracing",
@@ -685,6 +716,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -1491,6 +1528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "similar"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1572,12 @@ dependencies = [
  "psm",
  "winapi",
 ]
+
+[[package]]
+name = "strfmt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ stacker = ["full_moon/stacker"]
 
 [dependencies]
 anstyle = "1.0.6"
+blake3 = "1.5.4"
 clap = { version = "4.5.3", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.10.0"
 env_logger = "0.11.3"
 full_moon = { version = "0.19.0", features = ["roblox"] }
+hex = "0.4.3"
 json5 = "0.4.1"
 log = "0.4.21"
 pathdiff = "0.2.1"
@@ -41,6 +43,7 @@ regex = "1.10.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.114"
 serde_yaml = "0.9.32"
+strfmt = "0.2.4"
 toml = "0.8.11"
 tracing = { version = "0.1", optional = true }
 wax = "0.5.0"

--- a/src/nodes/statements/generic_for.rs
+++ b/src/nodes/statements/generic_for.rs
@@ -95,6 +95,11 @@ impl GenericForStatement {
     }
 
     #[inline]
+    pub fn mutate_expressions(&mut self) -> &mut Vec<Expression> {
+        &mut self.expressions
+    }
+
+    #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -30,6 +30,7 @@ mod rule_property;
 mod shift_token_line;
 mod unused_if_branch;
 mod unused_while;
+mod remove_generalized_iteration;
 
 pub use append_text_comment::*;
 pub use call_parens::*;
@@ -58,6 +59,7 @@ pub use rule_property::*;
 pub(crate) use shift_token_line::*;
 pub use unused_if_branch::*;
 pub use unused_while::*;
+pub use remove_generalized_iteration::*;
 
 use crate::nodes::Block;
 use crate::Resources;
@@ -214,6 +216,7 @@ pub fn get_default_rules() -> Vec<Box<dyn Rule>> {
         Box::<RemoveNilDeclaration>::default(),
         Box::<RenameVariables>::default(),
         Box::<RemoveFunctionCallParens>::default(),
+		Box::<RemoveGeneralizedIteration>::default(),
     ]
 }
 
@@ -242,6 +245,7 @@ pub fn get_all_rule_names() -> Vec<&'static str> {
         REMOVE_UNUSED_VARIABLE_RULE_NAME,
         REMOVE_UNUSED_WHILE_RULE_NAME,
         RENAME_VARIABLES_RULE_NAME,
+		REMOVE_GENERALIZED_ITERATION_RULE_NAME,
     ]
 }
 
@@ -275,6 +279,7 @@ impl FromStr for Box<dyn Rule> {
             REMOVE_UNUSED_VARIABLE_RULE_NAME => Box::<RemoveUnusedVariable>::default(),
             REMOVE_UNUSED_WHILE_RULE_NAME => Box::<RemoveUnusedWhile>::default(),
             RENAME_VARIABLES_RULE_NAME => Box::<RenameVariables>::default(),
+			REMOVE_GENERALIZED_ITERATION => Box::<RemoveGeneralizedIteration>::default(),
             _ => return Err(format!("invalid rule name: {}", string)),
         };
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -18,6 +18,7 @@ mod remove_call_match;
 mod remove_comments;
 mod remove_compound_assign;
 mod remove_debug_profiling;
+mod remove_generalized_iteration;
 mod remove_interpolated_string;
 mod remove_nil_declarations;
 mod remove_spaces;
@@ -27,10 +28,10 @@ mod rename_variables;
 mod replace_referenced_tokens;
 pub(crate) mod require;
 mod rule_property;
+pub(crate) mod runtime_variable;
 mod shift_token_line;
 mod unused_if_branch;
 mod unused_while;
-mod remove_generalized_iteration;
 
 pub use append_text_comment::*;
 pub use call_parens::*;
@@ -48,6 +49,7 @@ pub use remove_assertions::*;
 pub use remove_comments::*;
 pub use remove_compound_assign::*;
 pub use remove_debug_profiling::*;
+pub use remove_generalized_iteration::*;
 pub use remove_interpolated_string::*;
 pub use remove_nil_declarations::*;
 pub use remove_spaces::*;
@@ -59,7 +61,6 @@ pub use rule_property::*;
 pub(crate) use shift_token_line::*;
 pub use unused_if_branch::*;
 pub use unused_while::*;
-pub use remove_generalized_iteration::*;
 
 use crate::nodes::Block;
 use crate::Resources;
@@ -216,7 +217,7 @@ pub fn get_default_rules() -> Vec<Box<dyn Rule>> {
         Box::<RemoveNilDeclaration>::default(),
         Box::<RenameVariables>::default(),
         Box::<RemoveFunctionCallParens>::default(),
-		Box::<RemoveGeneralizedIteration>::default(),
+        Box::<RemoveGeneralizedIteration>::default(),
     ]
 }
 
@@ -245,7 +246,7 @@ pub fn get_all_rule_names() -> Vec<&'static str> {
         REMOVE_UNUSED_VARIABLE_RULE_NAME,
         REMOVE_UNUSED_WHILE_RULE_NAME,
         RENAME_VARIABLES_RULE_NAME,
-		REMOVE_GENERALIZED_ITERATION_RULE_NAME,
+        REMOVE_GENERALIZED_ITERATION_RULE_NAME,
     ]
 }
 
@@ -279,7 +280,7 @@ impl FromStr for Box<dyn Rule> {
             REMOVE_UNUSED_VARIABLE_RULE_NAME => Box::<RemoveUnusedVariable>::default(),
             REMOVE_UNUSED_WHILE_RULE_NAME => Box::<RemoveUnusedWhile>::default(),
             RENAME_VARIABLES_RULE_NAME => Box::<RenameVariables>::default(),
-			REMOVE_GENERALIZED_ITERATION => Box::<RemoveGeneralizedIteration>::default(),
+            REMOVE_GENERALIZED_ITERATION_RULE_NAME => Box::<RemoveGeneralizedIteration>::default(),
             _ => return Err(format!("invalid rule name: {}", string)),
         };
 

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -21,23 +21,6 @@ struct Processor {
     skip_block_once: bool,
 }
 
-// impl Processor {
-//     fn process_generic_for<'a>(&self, block: &'a mut Block, iterator_identifier: &TypedIdentifier) -> Vec<(usize, Expression)> {
-//         let mut stmts: Vec<&mut Statement> = block.iter_mut_statements().collect();
-//         let mut generic_for_indexes: Vec<(usize, Expression)> = Vec::new();
-//         for (i, stmt) in (0..stmts.len()).zip(stmts.iter_mut()) {
-//             if let Statement::GenericFor(generic_for) = stmt {
-//                 let mut exps: Vec<&mut Expression> = generic_for.iter_mut_expressions().collect();
-//                 if exps.len() == 1 {
-//                     *exps[0] = Expression::Identifier(iterator_identifier.get_identifier().clone());
-//                     generic_for_indexes.push((i, exps[0].to_owned()));
-//                 }
-//             }
-//         }
-//         generic_for_indexes
-//     }
-// }
-
 fn get_type_condition(arg: Expression, type_name: &str) -> Box<BinaryExpression> {
     let type_call = Box::new(FunctionCall::new(
         Prefix::from_name("type"),
@@ -167,15 +150,6 @@ impl Processor {
 
 impl NodeProcessor for Processor {
     fn process_block(&mut self, block: &mut Block) {
-        // let iterator_identifier = TypedIdentifier::new(&self.iterator_variable_name);
-        // let generic_for_indexes = self.process_generic_for(block, &iterator_identifier);
-        // for (i, input_exp) in generic_for_indexes.iter() {
-        //     let iterator_local_assign = LocalAssignStatement::new(
-        //         vec![iterator_identifier.clone()],
-        //         vec![input_exp.to_owned()]
-        //     );
-        //     block.insert_statement(*i, Statement::LocalAssign(iterator_local_assign.into()));
-        // }
         if self.skip_block_once {
             self.skip_block_once = false;
             return;
@@ -191,7 +165,7 @@ impl NodeProcessor for Processor {
 
 pub const REMOVE_GENERALIZED_ITERATION_RULE_NAME: &str = "remove_generalized_iteration";
 
-/// A rule that removes trailing `nil` in local assignments.
+/// A rule that removes generalized iteration.
 #[derive(Debug, PartialEq, Eq)]
 pub struct RemoveGeneralizedIteration {
     runtime_variable_format: String,

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -11,7 +11,6 @@ use super::runtime_variable::{
 };
 use super::{Rule, RuleProcessResult};
 
-const VARIABLE_PREFIX: &str = "_DARKLUA_REMOVE_GENERALIZED_ITERATION";
 const METATABLE_VARIABLE_NAME: &str = "_m";
 
 struct Processor {
@@ -174,7 +173,7 @@ pub struct RemoveGeneralizedIteration {
 impl Default for RemoveGeneralizedIteration {
     fn default() -> Self {
         Self {
-            runtime_variable_format: DEFAULT_RUNTIME_VARIABLE_FORMAT.to_string(),
+            runtime_variable_format: "_DARKLUA_REMOVE_GENERALIZED_ITERATION_{name}{hash}".to_string(),
         }
     }
 }
@@ -182,7 +181,6 @@ impl Default for RemoveGeneralizedIteration {
 impl Rule for RemoveGeneralizedIteration {
     fn process(&self, block: &mut Block, _: &Context) -> RuleProcessResult {
         let var_builder = RuntimeVariableBuilder::new(
-            VARIABLE_PREFIX,
             self.runtime_variable_format.as_str(),
             format!("{block:?}").as_bytes(),
             Some(vec![METATABLE_VARIABLE_NAME.to_string()]),

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -1,42 +1,239 @@
-use crate::nodes::{Block, Expression, GenericForStatement, LocalAssignStatement};
-use crate::process::{DefaultVisitor, Evaluator, NodeProcessor, NodeVisitor};
-use crate::rules::{
-    Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
+use crate::nodes::{
+    AssignStatement, BinaryExpression, BinaryOperator, Block, DoStatement, Expression,
+    FieldExpression, FunctionCall, Identifier, IfBranch, IfStatement, LocalAssignStatement, Prefix,
+    Statement, StringExpression, TupleArguments, TypedIdentifier, Variable,
 };
+use crate::process::{DefaultVisitor, NodeProcessor, NodeVisitor};
+use crate::rules::{Context, RuleConfiguration, RuleConfigurationError, RuleProperties};
 
-use super::verify_no_rule_properties;
+use super::runtime_variable::{
+    RuntimeVariable, RuntimeVariableBuilder, DEFAULT_RUNTIME_VARIABLE_FORMAT,
+};
+use super::{Rule, RuleProcessResult};
 
-#[derive(Default)]
-struct Processor {}
+const VARIABLE_PREFIX: &str = "_DARKLUA_REMOVE_GENERALIZED_ITERATION";
+const METATABLE_VARIABLE_NAME: &str = "_m";
+
+struct Processor {
+    iterator_variable: RuntimeVariable,
+    invariant_variable: RuntimeVariable,
+    control_variable: RuntimeVariable,
+    skip_block_once: bool,
+}
+
+// impl Processor {
+//     fn process_generic_for<'a>(&self, block: &'a mut Block, iterator_identifier: &TypedIdentifier) -> Vec<(usize, Expression)> {
+//         let mut stmts: Vec<&mut Statement> = block.iter_mut_statements().collect();
+//         let mut generic_for_indexes: Vec<(usize, Expression)> = Vec::new();
+//         for (i, stmt) in (0..stmts.len()).zip(stmts.iter_mut()) {
+//             if let Statement::GenericFor(generic_for) = stmt {
+//                 let mut exps: Vec<&mut Expression> = generic_for.iter_mut_expressions().collect();
+//                 if exps.len() == 1 {
+//                     *exps[0] = Expression::Identifier(iterator_identifier.get_identifier().clone());
+//                     generic_for_indexes.push((i, exps[0].to_owned()));
+//                 }
+//             }
+//         }
+//         generic_for_indexes
+//     }
+// }
+
+fn get_type_condition(arg: Expression, type_name: &str) -> Box<BinaryExpression> {
+    let type_call = Box::new(FunctionCall::new(
+        Prefix::from_name("type"),
+        TupleArguments::new(vec![arg]).into(),
+        None,
+    ));
+    Box::new(BinaryExpression::new(
+        BinaryOperator::Equal,
+        Expression::Call(type_call),
+        Expression::String(StringExpression::from_value(type_name)),
+    ))
+}
+
+impl Processor {
+    fn process_into_do(&self, block: &mut Block) -> Option<Statement> {
+        for stmt in block.iter_mut_statements() {
+            if let Statement::GenericFor(generic_for) = stmt {
+                let exps = generic_for.mutate_expressions();
+                if exps.len() == 1 {
+                    let mut stmts: Vec<Statement> = Vec::new();
+                    let iterator_typed_identifier =
+                        self.iterator_variable.generate_typed_identifier();
+                    let iterator_identifier = iterator_typed_identifier.get_identifier().clone();
+
+                    let invariant_typed_identifier =
+                        self.invariant_variable.generate_typed_identifier();
+                    let invariant_identifier = invariant_typed_identifier.get_identifier().clone();
+
+                    let control_typed_identifier =
+                        self.control_variable.generate_typed_identifier();
+                    let control_identifier = control_typed_identifier.get_identifier().clone();
+
+                    let iterator_local_assign = LocalAssignStatement::new(
+                        vec![
+                            iterator_typed_identifier,
+                            invariant_typed_identifier,
+                            control_typed_identifier,
+                        ],
+                        vec![exps[0].to_owned()],
+                    );
+
+                    let iterator_exp = Expression::Identifier(iterator_identifier.clone());
+                    exps[0] = iterator_exp.clone();
+                    let invariant_exp = Expression::Identifier(invariant_identifier.clone());
+                    exps.push(invariant_exp);
+                    let control_exp = Expression::Identifier(control_identifier.clone());
+                    exps.push(control_exp);
+
+                    let if_table_condition = get_type_condition(iterator_exp.clone(), "table");
+
+                    let mt_typed_identifier = TypedIdentifier::new(METATABLE_VARIABLE_NAME);
+                    let mt_identifier = mt_typed_identifier.get_identifier().clone();
+
+                    let get_mt_call = FunctionCall::new(
+                        Prefix::from_name("getmetatable"),
+                        TupleArguments::new(vec![iterator_exp.clone()]).into(),
+                        None,
+                    );
+                    let mt_local_assign = LocalAssignStatement::new(
+                        vec![mt_typed_identifier],
+                        vec![get_mt_call.into()],
+                    );
+
+                    let if_mt_table_condition =
+                        get_type_condition(mt_identifier.clone().into(), "table");
+                    let mt_iter = FieldExpression::new(
+                        Prefix::Identifier(mt_identifier),
+                        Identifier::new("__iter"),
+                    );
+                    let if_mt_iter_function_condition =
+                        get_type_condition(mt_iter.clone().into(), "function");
+
+                    let mt_iter_call = FunctionCall::from_prefix(Prefix::Field(Box::new(mt_iter)));
+                    let assign_from_iter = AssignStatement::new(
+                        vec![
+                            Variable::Identifier(iterator_identifier.clone()),
+                            Variable::Identifier(invariant_identifier.clone()),
+                            Variable::Identifier(control_identifier.clone()),
+                        ],
+                        vec![mt_iter_call.into()],
+                    );
+
+                    let pairs_call = FunctionCall::new(
+                        Prefix::from_name("pairs"),
+                        TupleArguments::new(vec![iterator_identifier.clone().into()]).into(),
+                        None,
+                    );
+                    let assign_from_pairs = AssignStatement::new(
+                        vec![
+                            Variable::Identifier(iterator_identifier),
+                            Variable::Identifier(invariant_identifier),
+                            Variable::Identifier(control_identifier),
+                        ],
+                        vec![pairs_call.into()],
+                    );
+
+                    let if_mt_table_block = Block::new(vec![assign_from_iter.into()], None);
+                    let if_not_mt_table_block = Block::new(vec![assign_from_pairs.into()], None);
+                    let if_mt_table_branch = IfBranch::new(
+                        Expression::Binary(Box::new(BinaryExpression::new(
+                            BinaryOperator::And,
+                            Expression::Binary(if_mt_table_condition),
+                            Expression::Binary(if_mt_iter_function_condition),
+                        ))),
+                        if_mt_table_block,
+                    );
+                    let if_mt_table_stmt =
+                        IfStatement::new(vec![if_mt_table_branch], Some(if_not_mt_table_block));
+
+                    let if_table_block =
+                        Block::new(vec![mt_local_assign.into(), if_mt_table_stmt.into()], None);
+                    let if_table_branch =
+                        IfBranch::new(Expression::Binary(if_table_condition), if_table_block);
+                    let if_table_stmt = IfStatement::new(vec![if_table_branch], None);
+
+                    stmts.push(iterator_local_assign.into());
+                    stmts.push(if_table_stmt.into());
+                    stmts.push(generic_for.clone().into());
+
+                    return Some(DoStatement::new(Block::new(stmts, None)).into());
+                }
+            }
+        }
+        None
+    }
+}
 
 impl NodeProcessor for Processor {
-	fn process_generic_for_statement(&mut self, generic_for: &mut crate::nodes::GenericForStatement) {
-		let iter_mut = generic_for.iter_mut_expressions();
-		if iter_mut.count() > 1 {
-			return;
-		}
-		for exp in iter_mut {
-
-		}
-	}
+    fn process_block(&mut self, block: &mut Block) {
+        // let iterator_identifier = TypedIdentifier::new(&self.iterator_variable_name);
+        // let generic_for_indexes = self.process_generic_for(block, &iterator_identifier);
+        // for (i, input_exp) in generic_for_indexes.iter() {
+        //     let iterator_local_assign = LocalAssignStatement::new(
+        //         vec![iterator_identifier.clone()],
+        //         vec![input_exp.to_owned()]
+        //     );
+        //     block.insert_statement(*i, Statement::LocalAssign(iterator_local_assign.into()));
+        // }
+        if self.skip_block_once {
+            self.skip_block_once = false;
+            return;
+        }
+        let do_stmt = self.process_into_do(block);
+        if let Some(stmt) = do_stmt {
+            self.skip_block_once = true;
+            block.clear();
+            block.insert_statement(0, stmt);
+        }
+    }
 }
 
 pub const REMOVE_GENERALIZED_ITERATION_RULE_NAME: &str = "remove_generalized_iteration";
 
 /// A rule that removes trailing `nil` in local assignments.
-#[derive(Debug, Default, PartialEq, Eq)]
-pub struct RemoveGeneralizedIteration {}
+#[derive(Debug, PartialEq, Eq)]
+pub struct RemoveGeneralizedIteration {
+    runtime_variable_format: String,
+}
 
-impl FlawlessRule for RemoveGeneralizedIteration {
-    fn flawless_process(&self, block: &mut Block, _: &Context) {
-        let mut processor = Processor::default();
+impl Default for RemoveGeneralizedIteration {
+    fn default() -> Self {
+        Self {
+            runtime_variable_format: DEFAULT_RUNTIME_VARIABLE_FORMAT.to_string(),
+        }
+    }
+}
+
+impl Rule for RemoveGeneralizedIteration {
+    fn process(&self, block: &mut Block, _: &Context) -> RuleProcessResult {
+        let var_builder = RuntimeVariableBuilder::new(
+            VARIABLE_PREFIX,
+            self.runtime_variable_format.as_str(),
+            format!("{block:?}").as_bytes(),
+            Some(vec![METATABLE_VARIABLE_NAME.to_string()]),
+        );
+        let mut processor = Processor {
+            iterator_variable: var_builder.build("iter")?,
+            invariant_variable: var_builder.build("invar")?,
+            control_variable: var_builder.build("control")?,
+            skip_block_once: false,
+        };
         DefaultVisitor::visit_block(block, &mut processor);
+        Ok(())
     }
 }
 
 impl RuleConfiguration for RemoveGeneralizedIteration {
     fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
-        verify_no_rule_properties(&properties)?;
+        for (key, value) in properties {
+            match key.as_str() {
+                "runtime_variable_format" => {
+                    self.runtime_variable_format = value.expect_string(&key)?;
+                }
+                _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
+            }
+        }
 
         Ok(())
     }

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -7,7 +7,7 @@ use crate::process::{DefaultVisitor, NodeProcessor, NodeVisitor};
 use crate::rules::{Context, RuleConfiguration, RuleConfigurationError, RuleProperties};
 
 use super::runtime_variable::{
-    RuntimeVariable, RuntimeVariableBuilder, DEFAULT_RUNTIME_VARIABLE_FORMAT,
+    RuntimeVariableBuilder, DEFAULT_RUNTIME_VARIABLE_FORMAT,
 };
 use super::{Rule, RuleProcessResult};
 
@@ -15,9 +15,9 @@ const VARIABLE_PREFIX: &str = "_DARKLUA_REMOVE_GENERALIZED_ITERATION";
 const METATABLE_VARIABLE_NAME: &str = "_m";
 
 struct Processor {
-    iterator_variable: RuntimeVariable,
-    invariant_variable: RuntimeVariable,
-    control_variable: RuntimeVariable,
+    iterator_variable_name: String,
+    invariant_variable_name: String,
+    control_variable_name: String,
     skip_block_once: bool,
 }
 
@@ -42,15 +42,15 @@ impl Processor {
                 if exps.len() == 1 {
                     let mut stmts: Vec<Statement> = Vec::new();
                     let iterator_typed_identifier =
-                        self.iterator_variable.generate_typed_identifier();
+                        TypedIdentifier::new(self.iterator_variable_name.as_str());
                     let iterator_identifier = iterator_typed_identifier.get_identifier().clone();
 
                     let invariant_typed_identifier =
-                        self.invariant_variable.generate_typed_identifier();
+                        TypedIdentifier::new(self.invariant_variable_name.as_str());
                     let invariant_identifier = invariant_typed_identifier.get_identifier().clone();
 
                     let control_typed_identifier =
-                        self.control_variable.generate_typed_identifier();
+                        TypedIdentifier::new(self.control_variable_name.as_str());
                     let control_identifier = control_typed_identifier.get_identifier().clone();
 
                     let iterator_local_assign = LocalAssignStatement::new(
@@ -188,9 +188,9 @@ impl Rule for RemoveGeneralizedIteration {
             Some(vec![METATABLE_VARIABLE_NAME.to_string()]),
         );
         let mut processor = Processor {
-            iterator_variable: var_builder.build("iter")?,
-            invariant_variable: var_builder.build("invar")?,
-            control_variable: var_builder.build("control")?,
+            iterator_variable_name: var_builder.build("iter")?,
+            invariant_variable_name: var_builder.build("invar")?,
+            control_variable_name: var_builder.build("control")?,
             skip_block_once: false,
         };
         DefaultVisitor::visit_block(block, &mut processor);

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -6,9 +6,7 @@ use crate::nodes::{
 use crate::process::{DefaultVisitor, NodeProcessor, NodeVisitor};
 use crate::rules::{Context, RuleConfiguration, RuleConfigurationError, RuleProperties};
 
-use super::runtime_variable::{
-    RuntimeVariableBuilder, DEFAULT_RUNTIME_VARIABLE_FORMAT,
-};
+use super::runtime_variable::RuntimeVariableBuilder;
 use super::{Rule, RuleProcessResult};
 
 const METATABLE_VARIABLE_NAME: &str = "_m";
@@ -173,7 +171,8 @@ pub struct RemoveGeneralizedIteration {
 impl Default for RemoveGeneralizedIteration {
     fn default() -> Self {
         Self {
-            runtime_variable_format: "_DARKLUA_REMOVE_GENERALIZED_ITERATION_{name}{hash}".to_string(),
+            runtime_variable_format: "_DARKLUA_REMOVE_GENERALIZED_ITERATION_{name}{hash}"
+                .to_string(),
         }
     }
 }

--- a/src/rules/remove_generalized_iteration.rs
+++ b/src/rules/remove_generalized_iteration.rs
@@ -1,0 +1,81 @@
+use crate::nodes::{Block, Expression, GenericForStatement, LocalAssignStatement};
+use crate::process::{DefaultVisitor, Evaluator, NodeProcessor, NodeVisitor};
+use crate::rules::{
+    Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
+};
+
+use super::verify_no_rule_properties;
+
+#[derive(Default)]
+struct Processor {}
+
+impl NodeProcessor for Processor {
+	fn process_generic_for_statement(&mut self, generic_for: &mut crate::nodes::GenericForStatement) {
+		let iter_mut = generic_for.iter_mut_expressions();
+		if iter_mut.count() > 1 {
+			return;
+		}
+		for exp in iter_mut {
+
+		}
+	}
+}
+
+pub const REMOVE_GENERALIZED_ITERATION_RULE_NAME: &str = "remove_generalized_iteration";
+
+/// A rule that removes trailing `nil` in local assignments.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RemoveGeneralizedIteration {}
+
+impl FlawlessRule for RemoveGeneralizedIteration {
+    fn flawless_process(&self, block: &mut Block, _: &Context) {
+        let mut processor = Processor::default();
+        DefaultVisitor::visit_block(block, &mut processor);
+    }
+}
+
+impl RuleConfiguration for RemoveGeneralizedIteration {
+    fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
+        verify_no_rule_properties(&properties)?;
+
+        Ok(())
+    }
+
+    fn get_name(&self) -> &'static str {
+        REMOVE_GENERALIZED_ITERATION_RULE_NAME
+    }
+
+    fn serialize_to_properties(&self) -> RuleProperties {
+        RuleProperties::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::rules::Rule;
+
+    use insta::assert_json_snapshot;
+
+    fn new_rule() -> RemoveGeneralizedIteration {
+        RemoveGeneralizedIteration::default()
+    }
+
+    #[test]
+    fn serialize_default_rule() {
+        let rule: Box<dyn Rule> = Box::new(new_rule());
+
+        assert_json_snapshot!("default_remove_generalized_iteration", rule);
+    }
+
+    #[test]
+    fn configure_with_extra_field_error() {
+        let result = json5::from_str::<Box<dyn Rule>>(
+            r#"{
+            rule: 'remove_generalized_iteration',
+            prop: "something",
+        }"#,
+        );
+        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+    }
+}

--- a/src/rules/runtime_variable.rs
+++ b/src/rules/runtime_variable.rs
@@ -1,0 +1,78 @@
+use blake3;
+use hex;
+use std::collections::HashMap;
+use strfmt::strfmt;
+
+// use crate::nodes::{
+//     AssignStatement, Expression, Identifier, LocalAssignStatement, TypedIdentifier,
+// };
+use crate::nodes::TypedIdentifier;
+
+pub const DEFAULT_RUNTIME_VARIABLE_FORMAT: &str = "{prefix}_{name}{hash}";
+
+pub struct RuntimeVariable {
+    name: String,
+}
+
+impl RuntimeVariable {
+    pub fn generate_typed_identifier(&self) -> TypedIdentifier {
+        TypedIdentifier::new(&self.name)
+    }
+
+    // pub fn generate_identifier(&self) -> Identifier {
+    //     Identifier::new(&self.name)
+    // }
+
+    // pub fn generate_local_assignment(&self, value: Option<Expression>) -> LocalAssignStatement {
+    //     if let Some(value) = value {
+    //         LocalAssignStatement::new(vec![self.generate_typed_identifier()], vec![value])
+    //     } else {
+    //         LocalAssignStatement::from_variable(self.generate_identifier())
+    //     }
+    // }
+
+    // pub fn generate_assignment(&self, value: Expression) -> AssignStatement {
+    //     AssignStatement::new(vec![self.generate_identifier().into()], vec![value])
+    // }
+}
+
+pub struct RuntimeVariableBuilder {
+    prefix: String,
+    format: String,
+    hash: String,
+    keywords: Option<Vec<String>>,
+}
+
+impl RuntimeVariableBuilder {
+    pub fn new(
+        prefix: impl Into<String>,
+        format: impl Into<String>,
+        identifier: &[u8],
+        keywords: Option<Vec<String>>,
+    ) -> Self {
+        let hash = blake3::hash(identifier);
+        Self {
+            prefix: prefix.into(),
+            format: format.into(),
+            hash: hex::encode(&hash.as_bytes()[..8]),
+            keywords,
+        }
+    }
+
+    pub fn build(&self, name: &str) -> Result<RuntimeVariable, String> {
+        let mut vars = HashMap::new();
+        vars.insert("prefix".to_string(), self.prefix.as_str());
+        vars.insert("name".to_string(), name);
+        vars.insert("hash".to_string(), self.hash.as_str());
+
+        let name = strfmt(&self.format, &vars).map_err(|err| err.to_string())?;
+
+        if let Some(keywords) = &self.keywords {
+            if keywords.contains(&name) {
+                Err(format!("Runtime variable `{name}` cannot be set because it contains a reserved keyword."))?;
+            }
+        }
+
+        Ok(RuntimeVariable { name })
+    }
+}

--- a/src/rules/runtime_variable.rs
+++ b/src/rules/runtime_variable.rs
@@ -3,10 +3,9 @@ use hex;
 use std::collections::HashMap;
 use strfmt::strfmt;
 
-pub const DEFAULT_RUNTIME_VARIABLE_FORMAT: &str = "{prefix}_{name}{hash}";
+pub const DEFAULT_RUNTIME_VARIABLE_FORMAT: &str = "{name}{hash}";
 
 pub struct RuntimeVariableBuilder {
-    prefix: String,
     format: String,
     hash: String,
     keywords: Option<Vec<String>>,
@@ -14,14 +13,12 @@ pub struct RuntimeVariableBuilder {
 
 impl RuntimeVariableBuilder {
     pub fn new(
-        prefix: impl Into<String>,
         format: impl Into<String>,
         identifier: &[u8],
         keywords: Option<Vec<String>>,
     ) -> Self {
         let hash = blake3::hash(identifier);
         Self {
-            prefix: prefix.into(),
             format: format.into(),
             hash: hex::encode(&hash.as_bytes()[..8]),
             keywords,
@@ -30,7 +27,6 @@ impl RuntimeVariableBuilder {
 
     pub fn build(&self, name: &str) -> Result<String, String> {
         let mut vars = HashMap::new();
-        vars.insert("prefix".to_string(), self.prefix.as_str());
         vars.insert("name".to_string(), name);
         vars.insert("hash".to_string(), self.hash.as_str());
 

--- a/src/rules/runtime_variable.rs
+++ b/src/rules/runtime_variable.rs
@@ -3,8 +3,6 @@ use hex;
 use std::collections::HashMap;
 use strfmt::strfmt;
 
-pub const DEFAULT_RUNTIME_VARIABLE_FORMAT: &str = "{name}{hash}";
-
 pub struct RuntimeVariableBuilder {
     format: String,
     hash: String,

--- a/src/rules/runtime_variable.rs
+++ b/src/rules/runtime_variable.rs
@@ -3,38 +3,7 @@ use hex;
 use std::collections::HashMap;
 use strfmt::strfmt;
 
-// use crate::nodes::{
-//     AssignStatement, Expression, Identifier, LocalAssignStatement, TypedIdentifier,
-// };
-use crate::nodes::TypedIdentifier;
-
 pub const DEFAULT_RUNTIME_VARIABLE_FORMAT: &str = "{prefix}_{name}{hash}";
-
-pub struct RuntimeVariable {
-    name: String,
-}
-
-impl RuntimeVariable {
-    pub fn generate_typed_identifier(&self) -> TypedIdentifier {
-        TypedIdentifier::new(&self.name)
-    }
-
-    // pub fn generate_identifier(&self) -> Identifier {
-    //     Identifier::new(&self.name)
-    // }
-
-    // pub fn generate_local_assignment(&self, value: Option<Expression>) -> LocalAssignStatement {
-    //     if let Some(value) = value {
-    //         LocalAssignStatement::new(vec![self.generate_typed_identifier()], vec![value])
-    //     } else {
-    //         LocalAssignStatement::from_variable(self.generate_identifier())
-    //     }
-    // }
-
-    // pub fn generate_assignment(&self, value: Expression) -> AssignStatement {
-    //     AssignStatement::new(vec![self.generate_identifier().into()], vec![value])
-    // }
-}
 
 pub struct RuntimeVariableBuilder {
     prefix: String,
@@ -59,7 +28,7 @@ impl RuntimeVariableBuilder {
         }
     }
 
-    pub fn build(&self, name: &str) -> Result<RuntimeVariable, String> {
+    pub fn build(&self, name: &str) -> Result<String, String> {
         let mut vars = HashMap::new();
         vars.insert("prefix".to_string(), self.prefix.as_str());
         vars.insert("name".to_string(), name);
@@ -73,6 +42,6 @@ impl RuntimeVariableBuilder {
             }
         }
 
-        Ok(RuntimeVariable { name })
+        Ok(name)
     }
 }


### PR DESCRIPTION
Closes #203

# Examples
## Input
```luau
for i,v in {1,2,3} do
	print(i,v)
end

```
## Output
```lua
do local _DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_invardf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_controldf0c36eb99574eba={1,2,3} if type(_DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba)=='table'then local _m=getmetatable(_DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba)if type(_m)=='table'and type(_m.__iter)=='function'then _DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_invardf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_controldf0c36eb99574eba=_m.__iter()else _DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_invardf0c36eb99574eba, _DARKLUA_REMOVE_GENERALIZED_ITERATION_controldf0c36eb99574eba=pairs(_DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba)end end for i,v in _DARKLUA_REMOVE_GENERALIZED_ITERATION_iterdf0c36eb99574eba,_DARKLUA_REMOVE_GENERALIZED_ITERATION_invardf0c36eb99574eba,_DARKLUA_REMOVE_GENERALIZED_ITERATION_controldf0c36eb99574eba do
	print(i,v)
end
end
```

# Limitations (Notes from #203)
1. Using `pairs(input)` does not necessarily conform to the order of Luau generic iteration (for example, consecutive array indices starting from 1 go first)
2. Doesn't handle iterating over userdata (with `__iter` defined), which is supported by Luau
3. There may also be issues with accessing `__iter` if `__metatable` is set

# Credits
- Thanks for @sircfenner (original issue post: #203) for the convention idea.

# TO-DOs
- [ ] Add tests (btw, the output was tested in `lua5.3`)
