### PR TITLE
Fix `rename_variables` rule to rename type namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix `rename_variables` rule to rename module names in types ([#233](https://github.com/seaofvoices/darklua/pull/233))
 * fix string encoding containing unicode characters taking more than 1 byte ([#232](https://github.com/seaofvoices/darklua/pull/232))
 * fix `append_text_comment` to not add an extra space to comments ([#231](https://github.com/seaofvoices/darklua/pull/231))
 * add rule to remove floor divisions (`remove_floor_division`) ([#230](https://github.com/seaofvoices/darklua/pull/230))

--- a/src/rules/rename_variables/rename_processor.rs
+++ b/src/rules/rename_variables/rename_processor.rs
@@ -1,4 +1,4 @@
-use crate::nodes::{Expression, Identifier, LocalFunctionStatement};
+use crate::nodes::{Expression, Identifier, LocalFunctionStatement, TypeField};
 use crate::process::utils::{identifier_permutator, CharPermutator};
 use crate::process::{utils::KEYWORDS, NodeProcessor, Scope};
 
@@ -162,6 +162,14 @@ impl NodeProcessor for RenameProcessor {
     fn process_variable_expression(&mut self, variable: &mut Identifier) {
         if let Some(obfuscated_name) = self.get_obfuscated_name(variable.get_name()) {
             variable.set_name(obfuscated_name);
+        }
+    }
+
+    fn process_type_field(&mut self, type_field: &mut TypeField) {
+        if let Some(obfuscated_name) =
+            self.get_obfuscated_name(type_field.get_namespace().get_name())
+        {
+            type_field.mutate_namespace().set_name(obfuscated_name);
         }
     }
 }

--- a/tests/rule_tests/rename_variables.rs
+++ b/tests/rule_tests/rename_variables.rs
@@ -45,6 +45,8 @@ test_rule!(
         => "return function(a, b) return a + b end",
     recycle_previous_identifiers("do local foo end local foo") => "do local a end local a",
     reexported_type_field("local types = require('./types') export type Oof = types.Oof") => "local a = require('./types') export type Oof = a.Oof",
+    type_variable_type_field("local React = require('@pkg/@jsdotlua/react') type Props = { children: React.ReactNode }")
+        => "local a = require('@pkg/@jsdotlua/react') type Props = { children: a.ReactNode }",
 );
 
 test_rule!(
@@ -90,6 +92,8 @@ test_rule!(
         => "return function(a, b) return a + b end",
     recycle_previous_identifiers("do local foo end local foo") => "do local a end local a",
     reexported_type_field("local types = require('./types') export type Oof = types.Oof") => "local a = require('./types') export type Oof = a.Oof",
+    type_variable_type_field("local React = require('@pkg/@jsdotlua/react') type Props = { children: React.ReactNode }")
+        => "local a = require('@pkg/@jsdotlua/react') type Props = { children: a.ReactNode }",
 );
 
 test_rule_without_effects!(

--- a/tests/rule_tests/rename_variables.rs
+++ b/tests/rule_tests/rename_variables.rs
@@ -44,6 +44,7 @@ test_rule!(
     function_expression_parameters_reference("return function(foo, bar) return foo + bar end")
         => "return function(a, b) return a + b end",
     recycle_previous_identifiers("do local foo end local foo") => "do local a end local a",
+    reexported_type_field("local types = require('./types') export type Oof = types.Oof") => "local a = require('./types') export type Oof = a.Oof",
 );
 
 test_rule!(
@@ -88,6 +89,7 @@ test_rule!(
     function_expression_parameters_reference("return function(foo, bar) return foo + bar end")
         => "return function(a, b) return a + b end",
     recycle_previous_identifiers("do local foo end local foo") => "do local a end local a",
+    reexported_type_field("local types = require('./types') export type Oof = types.Oof") => "local a = require('./types') export type Oof = a.Oof",
 );
 
 test_rule_without_effects!(


### PR DESCRIPTION
Closes #206 


- [x] add entry to the changelog
