### PR TITLE
Add `mutate_expressions` method to `GenericForStatement`

### DIFF
--- a/src/nodes/statements/generic_for.rs
+++ b/src/nodes/statements/generic_for.rs
@@ -95,6 +95,11 @@ impl GenericForStatement {
     }
 
     #[inline]
+    pub fn mutate_expressions(&mut self) -> &mut Vec<Expression> {
+        &mut self.expressions
+    }
+
+    #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }


### PR DESCRIPTION
Closes #235 

There is a more detailed reason and explanation why this method is needed for that closing issue, but it is useful for removing, adding, or popping expressions from `GenericForStatement`.