### PR TITLE
roblox-ts `TS.import` support

### DIFF
--- a/src/rules/bundle/hybrid_require_mode/mod.rs
+++ b/src/rules/bundle/hybrid_require_mode/mod.rs
@@ -1,0 +1,17 @@
+use crate::{
+    nodes::Block,
+    rules::{
+        bundle::BundleOptions, require::HybridRequireMode, Context,
+    },
+};
+
+use super::process_block_generic;
+
+pub(crate) fn process_block(
+    block: &mut Block,
+    context: &Context,
+    options: &BundleOptions,
+    hybrid_require_mode: &HybridRequireMode,
+) -> Result<(), String> {
+    process_block_generic(block, context, options, hybrid_require_mode) 
+}

--- a/src/rules/bundle/hybrid_require_mode/mod.rs
+++ b/src/rules/bundle/hybrid_require_mode/mod.rs
@@ -1,8 +1,6 @@
 use crate::{
     nodes::Block,
-    rules::{
-        bundle::BundleOptions, require::HybridRequireMode, Context,
-    },
+    rules::{bundle::BundleOptions, require::HybridRequireMode, Context},
 };
 
 use super::process_block_generic;
@@ -13,5 +11,5 @@ pub(crate) fn process_block(
     options: &BundleOptions,
     hybrid_require_mode: &HybridRequireMode,
 ) -> Result<(), String> {
-    process_block_generic(block, context, options, hybrid_require_mode) 
+    process_block_generic(block, context, options, hybrid_require_mode)
 }

--- a/src/rules/bundle/mod.rs
+++ b/src/rules/bundle/mod.rs
@@ -7,7 +7,8 @@ use std::path::Path;
 use crate::nodes::Block;
 use crate::process::{NodeVisitor, ScopeVisitor};
 use crate::rules::{
-    Context, FlawlessRule, ReplaceReferencedTokens, Rule, RuleConfiguration, RuleConfigurationError, RuleProcessResult, RuleProperties
+    Context, FlawlessRule, ReplaceReferencedTokens, Rule, RuleConfiguration,
+    RuleConfigurationError, RuleProcessResult, RuleProperties,
 };
 use crate::utils::Timer;
 use crate::Parser;

--- a/src/rules/bundle/path_require_mode/mod.rs
+++ b/src/rules/bundle/path_require_mode/mod.rs
@@ -88,6 +88,10 @@ impl<'a, 'b, 'code, 'resources, T: RequirePathLocatorMode>
     }
 
     fn require_call(&self, call: &FunctionCall) -> Option<PathBuf> {
+        if let Some(x) = self.path_locator.require_call(call, &self.source) {
+            return Some(x);
+        }
+
         if is_require_call(call, self) {
             self.path_locator
                 .match_path_require_call(call, &self.source)

--- a/src/rules/bundle/require_mode.rs
+++ b/src/rules/bundle/require_mode.rs
@@ -2,15 +2,25 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::rules::{require::PathRequireMode, RuleProcessResult};
+use crate::rules::{
+    require::{HybridRequireMode, PathRequireMode},
+    RuleProcessResult,
+};
 use crate::{nodes::Block, rules::Context};
 
-use super::{path_require_mode, BundleOptions};
+use super::{hybrid_require_mode, path_require_mode, BundleOptions};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "name")]
 pub enum BundleRequireMode {
+    Hybrid(HybridRequireMode),
     Path(PathRequireMode),
+}
+
+impl From<HybridRequireMode> for BundleRequireMode {
+    fn from(value: HybridRequireMode) -> Self {
+        Self::Hybrid(value)
+    }
 }
 
 impl From<PathRequireMode> for BundleRequireMode {
@@ -25,6 +35,7 @@ impl FromStr for BundleRequireMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
             "path" => Self::Path(Default::default()),
+            "hybrid" => Self::Hybrid(Default::default()),
             _ => return Err(format!("invalid require mode `{}`", s)),
         })
     }
@@ -46,6 +57,9 @@ impl BundleRequireMode {
         match self {
             Self::Path(path_require_mode) => {
                 path_require_mode::process_block(block, context, options, path_require_mode)
+            }
+            Self::Hybrid(hybrid_require_mode) => {
+                hybrid_require_mode::process_block(block, context, options, hybrid_require_mode)
             }
         }
     }

--- a/src/rules/convert_require/mod.rs
+++ b/src/rules/convert_require/mod.rs
@@ -13,7 +13,7 @@ use crate::rules::{Context, RuleConfiguration, RuleConfigurationError, RulePrope
 
 use instance_path::InstancePath;
 pub use roblox_index_style::RobloxIndexStyle;
-pub use roblox_require_mode::RobloxRequireMode;
+pub use roblox_require_mode::{parse_roblox, RobloxRequireMode};
 
 use super::{verify_required_properties, Rule, RuleProcessResult};
 

--- a/src/rules/require/hybrid_require_mode.rs
+++ b/src/rules/require/hybrid_require_mode.rs
@@ -1,8 +1,16 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::VecDeque,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{nodes::FunctionCall, rules::parse_roblox};
+use crate::{
+    frontend::DarkluaResult,
+    nodes::{Arguments, Expression, FieldExpression, FunctionCall, Prefix},
+    rules::parse_roblox,
+    DarkluaError,
+};
 
 use super::{match_path_require_call, PathRequireMode, RequirePathLocatorMode};
 
@@ -10,6 +18,9 @@ use super::{match_path_require_call, PathRequireMode, RequirePathLocatorMode};
 pub struct HybridRequireMode {
     #[serde(flatten)]
     path_require_mode: PathRequireMode,
+
+    #[serde(default)]
+    convert_ts_imports: bool,
 }
 
 impl RequirePathLocatorMode for HybridRequireMode {
@@ -30,4 +41,144 @@ impl RequirePathLocatorMode for HybridRequireMode {
             })
             .or(match_path_require_call(call))
     }
+    fn require_call(&self, call: &FunctionCall, source: &Path) -> Option<PathBuf> {
+        if !self.convert_ts_imports {
+            return None;
+        }
+
+        let Prefix::Field(field) = call.get_prefix() else {
+            return None;
+        };
+        match field.get_prefix() {
+            Prefix::Identifier(x) if x.get_name() == "TS" && x.get_token().is_none() => Some(()),
+            _ => None,
+        }?;
+        if !(field.get_field().get_name() == "import" && field.get_field().get_token().is_none()) {
+            return None;
+        }
+
+        let Arguments::Tuple(values) = call.get_arguments() else {
+            return None;
+        };
+        let mut current_path = source.to_path_buf();
+
+        if current_path.ends_with("init.lua") || current_path.ends_with("init.luau") {
+            current_path.pop();
+        }
+
+        let mut path_builder = VecDeque::new();
+        values.iter_values().for_each(|v| {
+            parse_roblox_expression(v, &mut path_builder, &mut current_path).ok();
+        });
+        while let Some(x) = path_builder.pop_back() {
+            current_path.push(x);
+        }
+
+        pathdiff::diff_paths(current_path, PathBuf::from("./"))
+    }
+}
+
+fn parse_roblox_call(call: &FunctionCall, current_path: &mut PathBuf) -> DarkluaResult<()> {
+    match call.get_prefix() {
+        Prefix::Field(field) => {
+            match field.get_prefix() {
+                Prefix::Identifier(x) if x.get_name() == "TS" && x.get_token().is_none() => {}
+                _ => {
+                    return Err(
+                        DarkluaError::custom("expected call to be apart of the TS module")
+                            .context("while parsing roblox-ts require"),
+                    )?
+                }
+            };
+            if !(field.get_field().get_name() == "getModule"
+                && field.get_field().get_token().is_none())
+            {
+                return Err(DarkluaError::custom("expected call to be TS.getModule")
+                    .context("while parsing roblox-ts require"));
+            }
+        }
+        _ => return Err(DarkluaError::custom("a"))?,
+    };
+
+    let mut temp_path = PathBuf::from("node_modules");
+    let Arguments::Tuple(args) = call.get_arguments() else {
+        return Err(DarkluaError::custom(
+            "expected call arguments for TS.getModule to be a tuple",
+        )
+        .context("while parsing roblox-ts require"))?;
+    };
+    args.iter_values().for_each(|arg| {
+        if let Expression::String(x) = arg {
+            temp_path.push(x.get_value())
+        }
+    });
+
+    let _ = temp_path.join(&current_path);
+    *current_path = temp_path;
+    Ok(())
+}
+
+fn parse_roblox_prefix(
+    prefix: &Prefix,
+    path_builder: &mut VecDeque<String>,
+    current_path: &mut PathBuf,
+) -> DarkluaResult<()> {
+    match prefix {
+        Prefix::Field(x) => parse_roblox_field(x, path_builder, current_path)?,
+        Prefix::Identifier(x) => {
+            handle_roblox_script_parent(x.get_name(), path_builder, current_path)?
+        }
+        Prefix::Call(x) => parse_roblox_call(x, current_path)?,
+        _ => Err(
+            DarkluaError::custom("unexpected prefix, only constants accepted")
+                .context("while parsing roblox require"),
+        )?,
+    };
+    Ok(())
+}
+
+fn parse_roblox_expression(
+    expression: &Expression,
+    path_builder: &mut VecDeque<String>,
+    current_path: &mut PathBuf,
+) -> DarkluaResult<()> {
+    match expression {
+        Expression::Field(x) => parse_roblox_field(x, path_builder, current_path)?,
+        Expression::Identifier(x) => {
+            handle_roblox_script_parent(x.get_name(), path_builder, current_path)?
+        }
+        Expression::String(x) => {
+            handle_roblox_script_parent(x.get_value(), path_builder, current_path)?
+        }
+        Expression::Call(x) => parse_roblox_call(x, current_path)?,
+        _ => Err(
+            DarkluaError::custom("unexpected expression, only constants accepted")
+                .context("while parsing roblox require"),
+        )?,
+    };
+    Ok(())
+}
+
+fn parse_roblox_field(
+    field: &FieldExpression,
+    path_builder: &mut VecDeque<String>,
+    current_path: &mut PathBuf,
+) -> DarkluaResult<()> {
+    parse_roblox_prefix(field.get_prefix(), path_builder, current_path)?;
+    handle_roblox_script_parent(field.get_field().get_name(), path_builder, current_path)
+}
+
+fn handle_roblox_script_parent(
+    str: &str,
+    path_builder: &mut VecDeque<String>,
+    current_path: &mut PathBuf,
+) -> DarkluaResult<()> {
+    match str {
+        "script" => {}
+        "Parent" => {
+            current_path.pop();
+        }
+        x => path_builder.push_front(x.to_string()),
+    };
+    Ok(())
 }

--- a/src/rules/require/hybrid_require_mode.rs
+++ b/src/rules/require/hybrid_require_mode.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{nodes::FunctionCall, rules::parse_roblox};
+
+use super::{match_path_require_call, PathRequireMode, RequirePathLocatorMode};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct HybridRequireMode {
+    #[serde(flatten)]
+    path_require_mode: PathRequireMode,
+}
+
+impl RequirePathLocatorMode for HybridRequireMode {
+    fn get_source(&self, name: &str) -> Option<&Path> {
+        self.path_require_mode.get_source(name)
+    }
+    fn module_folder_name(&self) -> &str {
+        self.path_require_mode.module_folder_name()
+    }
+    fn match_path_require_call(&self, call: &FunctionCall, source: &Path) -> Option<PathBuf> {
+        parse_roblox(call, source)
+            .ok()
+            .flatten()
+            .and_then(|x| {
+                let mut source_parent = source.to_path_buf();
+                source_parent.pop();
+                pathdiff::diff_paths(x, source_parent).map(|x| PathBuf::from("./").join(x))
+            })
+            // .map(|x| {
+            //     println!("{x:?}");
+            //     let y = source.join(x);
+            //     println!("{y:?}");
+            //     y
+            // })
+            .or(match_path_require_call(call))
+    }
+}

--- a/src/rules/require/hybrid_require_mode.rs
+++ b/src/rules/require/hybrid_require_mode.rs
@@ -28,12 +28,6 @@ impl RequirePathLocatorMode for HybridRequireMode {
                 source_parent.pop();
                 pathdiff::diff_paths(x, source_parent).map(|x| PathBuf::from("./").join(x))
             })
-            // .map(|x| {
-            //     println!("{x:?}");
-            //     let y = source.join(x);
-            //     println!("{y:?}");
-            //     y
-            // })
             .or(match_path_require_call(call))
     }
 }

--- a/src/rules/require/mod.rs
+++ b/src/rules/require/mod.rs
@@ -1,8 +1,12 @@
+mod hybrid_require_mode;
 mod match_require;
 mod path_iterator;
 mod path_locator;
 mod path_require_mode;
+mod require_path_locator_mode;
 
+pub(crate) use hybrid_require_mode::HybridRequireMode;
 pub(crate) use match_require::{is_require_call, match_path_require_call};
 pub(crate) use path_locator::RequirePathLocator;
 pub(crate) use path_require_mode::PathRequireMode;
+pub(crate) use require_path_locator_mode::RequirePathLocatorMode;

--- a/src/rules/require/path_locator.rs
+++ b/src/rules/require/path_locator.rs
@@ -1,18 +1,18 @@
 use std::path::{Path, PathBuf};
 
-use super::{path_iterator, PathRequireMode};
-use crate::{utils, DarkluaError, Resources};
+use super::{path_iterator, RequirePathLocatorMode};
+use crate::{nodes::FunctionCall, utils, DarkluaError, Resources};
 
 #[derive(Debug)]
-pub(crate) struct RequirePathLocator<'a, 'b, 'resources> {
-    path_require_mode: &'a PathRequireMode,
+pub(crate) struct RequirePathLocator<'a, 'b, 'resources, T: RequirePathLocatorMode> {
+    path_require_mode: &'a T,
     extra_module_relative_location: &'b Path,
     resources: &'resources Resources,
 }
 
-impl<'a, 'b, 'c> RequirePathLocator<'a, 'b, 'c> {
+impl<'a, 'b, 'c, T: RequirePathLocatorMode> RequirePathLocator<'a, 'b, 'c, T> {
     pub(crate) fn new(
-        path_require_mode: &'a PathRequireMode,
+        path_require_mode: &'a T,
         extra_module_relative_location: &'b Path,
         resources: &'c Resources,
     ) -> Self {
@@ -21,6 +21,14 @@ impl<'a, 'b, 'c> RequirePathLocator<'a, 'b, 'c> {
             extra_module_relative_location,
             resources,
         }
+    }
+
+    pub(crate) fn match_path_require_call(
+        &self,
+        call: &FunctionCall,
+        source: &Path,
+    ) -> Option<PathBuf> {
+        self.path_require_mode.match_path_require_call(call, source)
     }
 
     pub(crate) fn find_require_path(

--- a/src/rules/require/path_locator.rs
+++ b/src/rules/require/path_locator.rs
@@ -31,6 +31,10 @@ impl<'a, 'b, 'c, T: RequirePathLocatorMode> RequirePathLocator<'a, 'b, 'c, T> {
         self.path_require_mode.match_path_require_call(call, source)
     }
 
+    pub(crate) fn require_call(&self, call: &FunctionCall, source: &Path) -> Option<PathBuf> {
+        self.path_require_mode.require_call(call, source)
+    }
+
     pub(crate) fn find_require_path(
         &self,
         path: impl Into<PathBuf>,

--- a/src/rules/require/require_path_locator_mode.rs
+++ b/src/rules/require/require_path_locator_mode.rs
@@ -1,0 +1,9 @@
+use std::path::{Path, PathBuf};
+
+use crate::nodes::FunctionCall;
+
+pub trait RequirePathLocatorMode {
+    fn get_source(&self, name: &str) -> Option<&Path>;
+    fn module_folder_name(&self) -> &str;
+    fn match_path_require_call(&self, call: &FunctionCall, source: &Path) -> Option<PathBuf>;
+}

--- a/src/rules/require/require_path_locator_mode.rs
+++ b/src/rules/require/require_path_locator_mode.rs
@@ -6,4 +6,7 @@ pub trait RequirePathLocatorMode {
     fn get_source(&self, name: &str) -> Option<&Path>;
     fn module_folder_name(&self) -> &str;
     fn match_path_require_call(&self, call: &FunctionCall, source: &Path) -> Option<PathBuf>;
+    fn require_call(&self, _call: &FunctionCall, _source: &Path) -> Option<PathBuf> {
+        None
+    }
 }


### PR DESCRIPTION
Closes #241 - This PR relies upon #245 being merged, please merge that first, if you want this to be merged.

This PR adds support for roblox-ts's way of handling imports via their RuntimeLibrary's `TS.import` and `TS.getModule`. It builds upon #245 to convert those functions into paths for darklua to process.

- [ ] add entry to the changelog
