### PR TITLE
Support bundling with Luau types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* support Luau types when bundling ([#249](https://github.com/seaofvoices/darklua/pull/249))
+
 ## 0.15.0
 
 * improve file watching: re-process specific files, sourcemap changes re-process the project, bundling re-starts whenever a dependent file changes ([#239](https://github.com/seaofvoices/darklua/pull/239))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ dependencies = [
  "env_logger",
  "full_moon",
  "include_dir",
+ "indexmap 2.7.0",
  "insta",
  "json5",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ durationfmt = "0.1.1"
 elsa = "1.10.0"
 env_logger = "0.11.5"
 full_moon = { version = "1.0.0", features = ["roblox"] }
+indexmap = "2.7.0"
 json5 = "0.4.1"
 log = "0.4.22"
 pathdiff = "0.2.3"

--- a/src/nodes/arguments.rs
+++ b/src/nodes/arguments.rs
@@ -138,7 +138,7 @@ impl Arguments {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             Arguments::Tuple(tuple) => tuple.shift_token_line(amount),
             Arguments::String(_) | Arguments::Table(_) => {}

--- a/src/nodes/expressions/interpolated_string.rs
+++ b/src/nodes/expressions/interpolated_string.rs
@@ -133,7 +133,7 @@ impl InterpolationSegment {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             InterpolationSegment::String(segment) => segment.shift_token_line(amount),
             InterpolationSegment::Value(segment) => segment.shift_token_line(amount),

--- a/src/nodes/expressions/number.rs
+++ b/src/nodes/expressions/number.rs
@@ -273,7 +273,7 @@ impl NumberExpression {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             NumberExpression::Decimal(number) => number.shift_token_line(amount),
             NumberExpression::Hex(number) => number.shift_token_line(amount),

--- a/src/nodes/expressions/table.rs
+++ b/src/nodes/expressions/table.rs
@@ -180,7 +180,7 @@ impl TableEntry {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             TableEntry::Field(entry) => entry.shift_token_line(amount),
             TableEntry::Index(entry) => entry.shift_token_line(amount),

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -78,7 +78,7 @@ macro_rules! impl_token_fns {
             )*)?
         }
 
-        pub(crate) fn shift_token_line(&mut self, amount: usize) {
+        pub(crate) fn shift_token_line(&mut self, amount: isize) {
             $(
                 self.$field.shift_token_line(amount);
             )*

--- a/src/nodes/statements/type_declaration.rs
+++ b/src/nodes/statements/type_declaration.rs
@@ -70,6 +70,14 @@ impl TypeDeclarationStatement {
     }
 
     #[inline]
+    pub fn remove_exported(&mut self) {
+        self.exported = false;
+        if let Some(tokens) = self.tokens.as_mut() {
+            tokens.export.take();
+        }
+    }
+
+    #[inline]
     pub fn is_exported(&self) -> bool {
         self.exported
     }
@@ -195,7 +203,7 @@ impl TypeDeclarationStatement {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         self.name.shift_token_line(amount);
         if let Some(tokens) = &mut self.tokens {
             tokens.shift_token_line(amount);

--- a/src/nodes/token.rs
+++ b/src/nodes/token.rs
@@ -263,10 +263,12 @@ impl Token {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match &mut self.position {
             Position::LineNumberReference { line_number, .. }
-            | Position::LineNumber { line_number, .. } => *line_number += amount,
+            | Position::LineNumber { line_number, .. } => {
+                *line_number = line_number.saturating_add_signed(amount);
+            }
             Position::Any { .. } => {}
         }
     }

--- a/src/nodes/types/table.rs
+++ b/src/nodes/types/table.rs
@@ -207,7 +207,7 @@ impl TableEntryType {
         }
     }
 
-    pub(crate) fn shift_token_line(&mut self, amount: usize) {
+    pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             TableEntryType::Property(property) => property.shift_token_line(amount),
             TableEntryType::Literal(literal) => literal.shift_token_line(amount),

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -18,5 +18,5 @@ pub use node_counter::NodeCounter;
 pub use node_processor::{NodePostProcessor, NodeProcessor};
 pub use post_visitor::{DefaultPostVisitor, NodePostVisitor};
 pub(crate) use scope_visitor::IdentifierTracker;
-pub use scope_visitor::{Scope, ScopeVisitor};
+pub use scope_visitor::{Scope, ScopePostVisitor, ScopeVisitor};
 pub use visitors::{DefaultVisitor, NodeVisitor};

--- a/src/process/scope_visitor.rs
+++ b/src/process/scope_visitor.rs
@@ -6,6 +6,7 @@ use crate::process::utils::is_valid_identifier;
 use crate::process::{NodeProcessor, NodeVisitor};
 
 use super::utils::{identifier_permutator, Permutator};
+use super::{NodePostProcessor, NodePostVisitor};
 
 /// Defines methods to interact with the concept of lexical scoping. The struct implementing this
 /// trait should be able to keep track of identifiers when used along the ScopeVisitor.
@@ -225,6 +226,226 @@ impl<T: NodeProcessor + Scope> NodeVisitor<T> for ScopeVisitor {
         Self::visit_expression(statement.mutate_condition(), scope);
 
         scope.pop();
+    }
+}
+
+/// A visitor that can be used only with a NodeProcessor that also implements the Scope trait.
+pub struct ScopePostVisitor;
+
+impl ScopePostVisitor {
+    fn visit_block_without_push<T: NodeProcessor + NodePostProcessor + Scope>(
+        block: &mut Block,
+        scope: &mut T,
+    ) {
+        scope.process_block(block);
+
+        block
+            .iter_mut_statements()
+            .for_each(|statement| Self::visit_statement(statement, scope));
+
+        if let Some(last_statement) = block.mutate_last_statement() {
+            Self::visit_last_statement(last_statement, scope);
+        };
+        scope.process_after_block(block);
+    }
+}
+
+impl<T: NodeProcessor + NodePostProcessor + Scope> NodePostVisitor<T> for ScopePostVisitor {
+    fn visit_block(block: &mut Block, scope: &mut T) {
+        scope.push();
+        Self::visit_block_without_push(block, scope);
+        scope.pop();
+    }
+
+    fn visit_local_assign(statement: &mut LocalAssignStatement, scope: &mut T) {
+        scope.process_local_assign_statement(statement);
+
+        statement
+            .iter_mut_values()
+            .for_each(|value| Self::visit_expression(value, scope));
+
+        for r#type in statement
+            .iter_mut_variables()
+            .filter_map(TypedIdentifier::mutate_type)
+        {
+            Self::visit_type(r#type, scope);
+        }
+
+        statement.for_each_assignment(|variable, expression| {
+            scope.insert_local(variable.mutate_name(), expression)
+        });
+
+        scope.process_after_local_assign_statement(statement);
+    }
+
+    fn visit_function_expression(function: &mut FunctionExpression, scope: &mut T) {
+        scope.process_function_expression(function);
+
+        for r#type in function
+            .iter_mut_parameters()
+            .filter_map(TypedIdentifier::mutate_type)
+        {
+            Self::visit_type(r#type, scope);
+        }
+
+        if let Some(variadic_type) = function.mutate_variadic_type() {
+            Self::visit_function_variadic_type(variadic_type, scope);
+        }
+
+        if let Some(return_type) = function.mutate_return_type() {
+            Self::visit_function_return_type(return_type, scope);
+        }
+
+        scope.push();
+        function
+            .mutate_parameters()
+            .iter_mut()
+            .for_each(|parameter| scope.insert(parameter.mutate_name()));
+
+        scope.process_scope(function.mutate_block(), None);
+
+        Self::visit_block(function.mutate_block(), scope);
+        scope.pop();
+
+        scope.process_after_function_expression(function);
+    }
+
+    fn visit_function_statement(statement: &mut FunctionStatement, scope: &mut T) {
+        scope.process_function_statement(statement);
+        scope.process_variable_expression(statement.mutate_function_name().mutate_identifier());
+
+        for r#type in statement
+            .iter_mut_parameters()
+            .filter_map(TypedIdentifier::mutate_type)
+        {
+            Self::visit_type(r#type, scope);
+        }
+
+        if let Some(variadic_type) = statement.mutate_variadic_type() {
+            Self::visit_function_variadic_type(variadic_type, scope);
+        }
+
+        if let Some(return_type) = statement.mutate_return_type() {
+            Self::visit_function_return_type(return_type, scope);
+        }
+
+        scope.push();
+        if statement.get_name().has_method() {
+            scope.insert_self();
+        }
+        statement
+            .mutate_parameters()
+            .iter_mut()
+            .for_each(|parameter| scope.insert(parameter.mutate_name()));
+
+        scope.process_scope(statement.mutate_block(), None);
+
+        Self::visit_block(statement.mutate_block(), scope);
+        scope.pop();
+
+        scope.process_after_function_statement(statement);
+    }
+
+    fn visit_local_function(statement: &mut LocalFunctionStatement, scope: &mut T) {
+        scope.process_local_function_statement(statement);
+
+        scope.insert_local_function(statement);
+
+        for r#type in statement
+            .iter_mut_parameters()
+            .filter_map(TypedIdentifier::mutate_type)
+        {
+            Self::visit_type(r#type, scope);
+        }
+
+        if let Some(variadic_type) = statement.mutate_variadic_type() {
+            Self::visit_function_variadic_type(variadic_type, scope);
+        }
+
+        if let Some(return_type) = statement.mutate_return_type() {
+            Self::visit_function_return_type(return_type, scope);
+        }
+
+        scope.push();
+        statement
+            .mutate_parameters()
+            .iter_mut()
+            .for_each(|parameter| scope.insert(parameter.mutate_name()));
+
+        scope.process_scope(statement.mutate_block(), None);
+
+        Self::visit_block(statement.mutate_block(), scope);
+        scope.pop();
+
+        scope.process_after_local_function_statement(statement);
+    }
+
+    fn visit_generic_for(statement: &mut GenericForStatement, scope: &mut T) {
+        scope.process_generic_for_statement(statement);
+
+        statement
+            .iter_mut_expressions()
+            .for_each(|expression| Self::visit_expression(expression, scope));
+
+        scope.push();
+        statement
+            .iter_mut_identifiers()
+            .for_each(|identifier| scope.insert(identifier.mutate_name()));
+
+        for r#type in statement
+            .iter_mut_identifiers()
+            .filter_map(TypedIdentifier::mutate_type)
+        {
+            Self::visit_type(r#type, scope);
+        }
+
+        scope.process_scope(statement.mutate_block(), None);
+
+        Self::visit_block(statement.mutate_block(), scope);
+        scope.pop();
+
+        scope.process_after_generic_for_statement(statement);
+    }
+
+    fn visit_numeric_for(statement: &mut NumericForStatement, scope: &mut T) {
+        scope.process_numeric_for_statement(statement);
+
+        Self::visit_expression(statement.mutate_start(), scope);
+        Self::visit_expression(statement.mutate_end(), scope);
+
+        if let Some(step) = statement.mutate_step() {
+            Self::visit_expression(step, scope);
+        };
+
+        if let Some(r#type) = statement.mutate_identifier().mutate_type() {
+            Self::visit_type(r#type, scope);
+        }
+
+        scope.push();
+        scope.insert(statement.mutate_identifier().mutate_name());
+
+        scope.process_scope(statement.mutate_block(), None);
+
+        Self::visit_block(statement.mutate_block(), scope);
+        scope.pop();
+
+        scope.process_after_numeric_for_statement(statement);
+    }
+
+    fn visit_repeat_statement(statement: &mut RepeatStatement, scope: &mut T) {
+        scope.process_repeat_statement(statement);
+
+        scope.push();
+
+        let (block, condition) = statement.mutate_block_and_condition();
+        scope.process_scope(block, Some(condition));
+
+        Self::visit_block_without_push(statement.mutate_block(), scope);
+        Self::visit_expression(statement.mutate_condition(), scope);
+
+        scope.pop();
+
+        scope.process_after_repeat_statement(statement);
     }
 }
 

--- a/src/rules/append_text_comment.rs
+++ b/src/rules/append_text_comment.rs
@@ -97,7 +97,7 @@ impl Rule for AppendTextComment {
         }
 
         let shift_lines = text.lines().count();
-        ShiftTokenLine::new(shift_lines).flawless_process(block, context);
+        ShiftTokenLine::new(shift_lines as isize).flawless_process(block, context);
 
         match self.location {
             AppendLocation::Start => {

--- a/src/rules/bundle/mod.rs
+++ b/src/rules/bundle/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod path_require_mode;
+mod rename_type_declaration;
 mod require_mode;
 
 use std::path::Path;
@@ -9,6 +10,7 @@ use crate::rules::{
 };
 use crate::Parser;
 
+pub(crate) use rename_type_declaration::RenameTypeDeclarationProcessor;
 pub use require_mode::BundleRequireMode;
 use wax::Pattern;
 

--- a/src/rules/bundle/path_require_mode/module_definitions.rs
+++ b/src/rules/bundle/path_require_mode/module_definitions.rs
@@ -1,15 +1,19 @@
 use std::path::{Path, PathBuf};
 
+use indexmap::IndexMap;
+
 use crate::frontend::DarkluaResult;
 use crate::nodes::{
     Arguments, AssignStatement, Block, DoStatement, Expression, FieldExpression, FunctionCall,
-    FunctionExpression, FunctionName, FunctionReturnType, FunctionStatement, Identifier,
-    IfStatement, IndexExpression, LastStatement, LocalAssignStatement, Prefix, ReturnStatement,
-    Statement, StringExpression, TableEntry, TableExpression, Token, TupleArguments,
-    TupleArgumentsTokens, Type, UnaryExpression, UnaryOperator,
+    FunctionExpression, FunctionName, FunctionStatement, Identifier, IfStatement, IndexExpression,
+    LastStatement, LocalAssignStatement, Prefix, ReturnStatement, Statement, StringExpression,
+    TableEntry, TableExpression, Token, TupleArguments, TupleArgumentsTokens, UnaryExpression,
+    UnaryOperator,
 };
 use crate::process::utils::{generate_identifier, identifier_permutator, CharPermutator};
+use crate::rules::bundle::RenameTypeDeclarationProcessor;
 use crate::rules::{Context, FlawlessRule, ShiftTokenLine};
+use crate::utils::lines;
 use crate::DarkluaError;
 
 use super::RequiredResource;
@@ -17,20 +21,37 @@ use super::RequiredResource;
 #[derive(Debug)]
 pub(crate) struct BuildModuleDefinitions {
     modules_identifier: String,
-    module_cache_field: &'static str,
-    module_load_field: &'static str,
-    module_definitions: Vec<(String, Block, PathBuf)>,
+    module_definitions: IndexMap<String, ModuleDefinition>,
     module_name_permutator: CharPermutator,
+    rename_type_declaration: RenameTypeDeclarationProcessor,
 }
+
+#[derive(Debug)]
+struct ModuleDefinition {
+    block: Block,
+    path: PathBuf,
+}
+
+impl ModuleDefinition {
+    fn new(block: Block, path: PathBuf) -> Self {
+        Self { block, path }
+    }
+}
+
+const BUNDLE_MODULES_VARIABLE_LOAD_FIELD: &str = "load";
+const BUNDLE_MODULES_VARIABLE_CACHE_FIELD: &str = "cache";
 
 impl BuildModuleDefinitions {
     pub(crate) fn new(modules_identifier: impl Into<String>) -> Self {
+        let modules_identifier = modules_identifier.into();
         Self {
-            modules_identifier: modules_identifier.into(),
-            module_cache_field: "cache",
-            module_load_field: "load",
-            module_definitions: Vec::new(),
+            modules_identifier: modules_identifier.clone(),
+            module_definitions: Default::default(),
             module_name_permutator: identifier_permutator(),
+            rename_type_declaration: RenameTypeDeclarationProcessor::new(
+                modules_identifier,
+                BUNDLE_MODULES_VARIABLE_LOAD_FIELD,
+            ),
         }
     }
 
@@ -40,7 +61,7 @@ impl BuildModuleDefinitions {
         require_path: &Path,
         call: &FunctionCall,
     ) -> DarkluaResult<Expression> {
-        let block = match required_resource {
+        let mut block = match required_resource {
             RequiredResource::Block(block) => {
                 if let Some(LastStatement::Return(return_statement)) = block.get_last_statement() {
                     if return_statement.len() != 1 {
@@ -62,10 +83,18 @@ impl BuildModuleDefinitions {
             }
         };
 
+        let exported_types = self
+            .rename_type_declaration
+            .extract_exported_types(&mut block);
+
         let module_name = self.generate_module_name();
 
-        self.module_definitions
-            .push((module_name.clone(), block, require_path.to_path_buf()));
+        self.module_definitions.insert(
+            module_name.clone(),
+            ModuleDefinition::new(block, require_path.to_path_buf()),
+        );
+        self.rename_type_declaration
+            .insert_module_types(module_name.clone(), exported_types);
 
         let token_trivia_identifier = match call.get_prefix() {
             Prefix::Identifier(require_identifier) => require_identifier.get_token(),
@@ -73,13 +102,13 @@ impl BuildModuleDefinitions {
         };
 
         let load_field = if let Some(token_trivia_identifier) = token_trivia_identifier {
-            let mut field_token = Token::from_content(self.module_load_field);
+            let mut field_token = Token::from_content(BUNDLE_MODULES_VARIABLE_LOAD_FIELD);
             for trivia in token_trivia_identifier.iter_trailing_trivia() {
                 field_token.push_trailing_trivia(trivia.clone());
             }
-            Identifier::new(self.module_load_field).with_token(field_token)
+            Identifier::new(BUNDLE_MODULES_VARIABLE_LOAD_FIELD).with_token(field_token)
         } else {
-            Identifier::new(self.module_load_field)
+            Identifier::new(BUNDLE_MODULES_VARIABLE_LOAD_FIELD)
         };
 
         let arguments = match call.get_arguments() {
@@ -128,7 +157,9 @@ impl BuildModuleDefinitions {
         loop {
             let name = generate_identifier(&mut self.module_name_permutator);
 
-            if name != self.module_cache_field && name != self.module_load_field {
+            if name != BUNDLE_MODULES_VARIABLE_CACHE_FIELD
+                && name != BUNDLE_MODULES_VARIABLE_LOAD_FIELD
+            {
                 break name;
             }
         }
@@ -139,19 +170,21 @@ impl BuildModuleDefinitions {
             return;
         }
 
-        for (_, _, path) in self.module_definitions.iter() {
-            context.add_file_dependency(path.clone());
+        for module in self.module_definitions.values() {
+            context.add_file_dependency(module.path.clone());
         }
+
+        self.rename_type_declaration.rename_types(block);
 
         let modules_identifier = Identifier::from(&self.modules_identifier);
 
-        let mut shift_lines = 0;
-        for (_module_name, module_block, _module_path) in self.module_definitions.iter_mut() {
-            let inserted_lines = total_lines(module_block);
+        let mut shift_lines = self.rename_type_declaration.get_type_lines();
+        for module in self.module_definitions.values_mut() {
+            let inserted_lines = lines::block_total(&module.block);
 
-            ShiftTokenLine::new(shift_lines).flawless_process(module_block, context);
+            ShiftTokenLine::new(shift_lines).flawless_process(&mut module.block, context);
 
-            shift_lines += inserted_lines;
+            shift_lines += inserted_lines as isize;
         }
 
         ShiftTokenLine::new(shift_lines).flawless_process(block, context);
@@ -159,10 +192,10 @@ impl BuildModuleDefinitions {
         let statements = self
             .module_definitions
             .drain(..)
-            .map(|(module_name, module_block, _)| {
+            .map(|(module_name, module)| {
                 let function_name =
-                    FunctionName::from_name(modules_identifier.clone()).with_field(module_name);
-                FunctionStatement::new(function_name, module_block, Vec::new(), false)
+                    FunctionName::from_name(modules_identifier.clone()).with_field(&module_name);
+                FunctionStatement::new(function_name, module.block, Vec::new(), false)
             })
             .map(Statement::from)
             .collect();
@@ -177,6 +210,15 @@ impl BuildModuleDefinitions {
             0,
             LocalAssignStatement::from_variable(self.modules_identifier),
         );
+
+        for statement in self
+            .rename_type_declaration
+            .extract_type_declarations()
+            .into_iter()
+            .rev()
+        {
+            block.insert_statement(0, statement);
+        }
     }
 
     fn build_modules_table(&self) -> TableExpression {
@@ -185,7 +227,7 @@ impl BuildModuleDefinitions {
         let index_cache = IndexExpression::new(
             FieldExpression::new(
                 Identifier::from(&self.modules_identifier),
-                self.module_cache_field,
+                BUNDLE_MODULES_VARIABLE_CACHE_FIELD,
             ),
             Identifier::from(parameter_name),
         );
@@ -215,10 +257,10 @@ impl BuildModuleDefinitions {
 
         TableExpression::default()
             .append_entry(TableEntry::from_string_key_and_value(
-                self.module_cache_field,
+                BUNDLE_MODULES_VARIABLE_CACHE_FIELD,
                 TableExpression::default(),
             ))
-            .append_field(self.module_load_field, load_function)
+            .append_field(BUNDLE_MODULES_VARIABLE_LOAD_FIELD, load_function)
     }
 }
 
@@ -232,241 +274,4 @@ fn transfer_trivia(mut receiving_token: Token, take_token: &Token) -> Token {
         receiving_token.push_trailing_trivia(kind.with_content(content));
     }
     receiving_token
-}
-
-fn total_lines(block: &Block) -> usize {
-    last_block_token(block)
-        .and_then(|token| {
-            token
-                .iter_trailing_trivia()
-                .last()
-                .and_then(|trivia| {
-                    trivia.get_line_number().map(|line| {
-                        line + trivia
-                            .try_read()
-                            .unwrap_or_default()
-                            .chars()
-                            .filter(|c| *c == '\n')
-                            .count()
-                    })
-                })
-                .or_else(|| token.get_line_number())
-        })
-        .unwrap_or(0)
-}
-
-fn last_block_token(block: &Block) -> Option<&Token> {
-    block
-        .get_tokens()
-        .and_then(|tokens| tokens.final_token.as_ref())
-        .or_else(|| {
-            block
-                .get_last_statement()
-                .and_then(last_last_statement_token)
-                .or_else(|| {
-                    block
-                        .iter_statements()
-                        .last()
-                        .and_then(last_statement_token)
-                })
-        })
-}
-
-fn last_statement_token(statement: &Statement) -> Option<&Token> {
-    match statement {
-        Statement::Assign(assign) => assign.last_value().and_then(last_expression_token),
-        Statement::Do(do_statement) => do_statement.get_tokens().map(|tokens| &tokens.end),
-        Statement::Call(call) => last_call_token(call),
-        Statement::CompoundAssign(assign) => last_expression_token(assign.get_value()),
-        Statement::Function(function) => function.get_tokens().map(|tokens| &tokens.end),
-        Statement::GenericFor(generic_for) => generic_for.get_tokens().map(|tokens| &tokens.end),
-        Statement::If(if_statement) => if_statement.get_tokens().map(|tokens| &tokens.end),
-        Statement::LocalAssign(local_assign) => local_assign
-            .iter_values()
-            .last()
-            .and_then(last_expression_token)
-            .or_else(|| {
-                local_assign
-                    .iter_variables()
-                    .last()
-                    .and_then(|identifier| identifier.get_token())
-            }),
-        Statement::LocalFunction(local_function) => {
-            local_function.get_tokens().map(|tokens| &tokens.end)
-        }
-        Statement::NumericFor(numeric_for) => numeric_for.get_tokens().map(|tokens| &tokens.end),
-        Statement::Repeat(repeat) => last_expression_token(repeat.get_condition()),
-        Statement::While(while_statement) => while_statement.get_tokens().map(|tokens| &tokens.end),
-        Statement::TypeDeclaration(type_declaration) => {
-            last_type_token(type_declaration.get_type())
-        }
-    }
-}
-
-fn last_last_statement_token(last: &LastStatement) -> Option<&Token> {
-    match last {
-        LastStatement::Break(token) | LastStatement::Continue(token) => token.as_ref(),
-        LastStatement::Return(return_statement) => return_statement
-            .iter_expressions()
-            .last()
-            .and_then(last_expression_token)
-            .or_else(|| return_statement.get_tokens().map(|tokens| &tokens.r#return)),
-    }
-}
-
-fn last_expression_token(expression: &Expression) -> Option<&Token> {
-    match expression {
-        Expression::Binary(binary) => last_expression_token(binary.right()),
-        Expression::Call(call) => last_call_token(call),
-        Expression::Field(field) => field.get_field().get_token(),
-        Expression::Function(function) => function.get_tokens().map(|tokens| &tokens.end),
-        Expression::Identifier(identifier) => identifier.get_token(),
-        Expression::If(if_expression) => last_expression_token(if_expression.get_else_result()),
-        Expression::Index(index) => index.get_tokens().map(|tokens| &tokens.closing_bracket),
-        Expression::Number(number) => number.get_token(),
-        Expression::Parenthese(parentheses) => parentheses
-            .get_tokens()
-            .map(|tokens| &tokens.right_parenthese),
-        Expression::String(string) => string.get_token(),
-        Expression::InterpolatedString(string) => {
-            string.get_tokens().map(|tokens| &tokens.closing_tick)
-        }
-        Expression::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
-        Expression::Nil(token)
-        | Expression::False(token)
-        | Expression::True(token)
-        | Expression::VariableArguments(token) => token.as_ref(),
-        Expression::Unary(unary) => last_expression_token(unary.get_expression()),
-        Expression::TypeCast(type_cast) => last_type_token(type_cast.get_type()),
-    }
-}
-
-fn last_type_token(r#type: &Type) -> Option<&Token> {
-    match r#type {
-        Type::Name(name) => {
-            if let Some(type_params) = name.get_type_parameters() {
-                type_params.get_tokens().map(|tokens| &tokens.closing_list)
-            } else {
-                name.get_type_name().get_token()
-            }
-        }
-        Type::Field(field) => {
-            if let Some(type_params) = field.get_type_name().get_type_parameters() {
-                type_params.get_tokens().map(|tokens| &tokens.closing_list)
-            } else {
-                field.get_type_name().get_type_name().get_token()
-            }
-        }
-        Type::True(token) | Type::False(token) | Type::Nil(token) => token.as_ref(),
-        Type::String(string) => string.get_token(),
-        Type::Array(array) => array.get_tokens().map(|tokens| &tokens.closing_brace),
-        Type::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
-        Type::TypeOf(expression_type) => expression_type
-            .get_tokens()
-            .map(|tokens| &tokens.closing_parenthese),
-        Type::Parenthese(parenthese) => parenthese
-            .get_tokens()
-            .map(|tokens| &tokens.right_parenthese),
-        Type::Function(function) => match function.get_return_type() {
-            FunctionReturnType::Type(return_type) => last_type_token(return_type),
-            FunctionReturnType::TypePack(type_pack) => type_pack
-                .get_tokens()
-                .map(|tokens| &tokens.right_parenthese),
-            FunctionReturnType::GenericTypePack(generic_pack) => generic_pack.get_token(),
-            FunctionReturnType::VariadicTypePack(variadic_pack) => {
-                last_type_token(variadic_pack.get_type())
-            }
-        },
-        Type::Optional(optional) => optional.get_token(),
-        Type::Intersection(intersection) => last_type_token(intersection.last_type()),
-        Type::Union(union_type) => last_type_token(union_type.last_type()),
-    }
-}
-
-fn last_call_token(call: &FunctionCall) -> Option<&Token> {
-    match call.get_arguments() {
-        Arguments::Tuple(tuple) => tuple.get_tokens().map(|tokens| &tokens.closing_parenthese),
-        Arguments::String(string) => string.get_token(),
-        Arguments::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    mod test_total_lines {
-        use super::*;
-
-        macro_rules! test_total_lines {
-            (
-                $($name:ident ($code:literal) => $value:expr),+,
-            ) => {
-                $(
-                    #[test]
-                    fn $name() {
-                        let code = $code;
-
-                        let mut block = $crate::Parser::default().preserve_tokens().parse(&code).unwrap();
-
-                        let resources = $crate::Resources::from_memory();
-                        let context = $crate::rules::ContextBuilder::new(
-                                "placeholder",
-                                &resources,
-                                &code
-                            )
-                            .build();
-
-                        $crate::rules::ReplaceReferencedTokens::default()
-                        .flawless_process(&mut block, &context);
-
-                        let received_lines = total_lines(&block);
-                        assert_eq!(
-                            received_lines,
-                            $value,
-                            "expected {} line{} but received {}.\n{:#?}",
-                            $value,
-                            if $value > 1 { "s" } else { "" },
-                            received_lines,
-                            block,
-                        );
-                    }
-                )*
-            };
-        }
-
-        test_total_lines!(
-            return_statement("return\n") => 2,
-            return_one("return 1") => 1,
-            return_true("return true") => 1,
-            return_false("return true,\n\tfalse\n") => 3,
-            return_nil("return nil\n") => 2,
-            return_string("return 'hello' --end\n") => 2,
-            return_not_variable("return not variable") => 1,
-            return_function_call("return call()") => 1,
-            return_variadic_args("return ... -- comment") => 1,
-            return_parenthese("return (\ncall()\n)") => 3,
-            return_table("return {\n\t}\n") => 3,
-            return_function_expression("return function(arg1, ...)\nend -- ") => 2,
-            return_function_call_with_table_arguments("return call {\nelement\n}") => 3,
-            function_call_with_table_arguments("call {\nelement\n}") => 3,
-            require_with_string_argument("require 'module.lua'\n") => 2,
-            return_require_with_string_argument("return require 'module.lua'\n") => 2,
-            return_if_expression("return if condition then\n\tok\nelse\n\terr") => 4,
-            if_statement("if condition then\n\treturn ok\nelse\n\treturn err\nend -- end if") => 5,
-            do_statement("do\n--comment\n\n\nend") => 5,
-            compound_assign("\nvar += 10.5") => 2,
-            assign_with_binary_expression("var = var + 2") => 1,
-            local_assign_with_field_expression("local var =\n\tobject.prop\n-- end") => 3,
-            local_assign_with_index_expression("local var =\n\tobject['prop']\n-- end") => 3,
-            local_function_definition("local function fn()\nend\n") => 3,
-            function_definition("function fn()\nend\n --comment\n") => 4,
-            generic_for("for k, v in pairs({}) do\nend\n --comment") => 3,
-            numeric_for("for i = 1, 10 do\n-- comment\nend\n") => 4,
-            repeat_statement("\nrepeat\n-- do\nuntil condition\n") => 5,
-            while_statement("\nwhile condition do\n-- do\nend\n") => 5,
-            break_statement("break\n") => 2,
-            continue_statement("continue\n") => 2,
-        );
-    }
 }

--- a/src/rules/bundle/rename_type_declaration.rs
+++ b/src/rules/bundle/rename_type_declaration.rs
@@ -66,8 +66,8 @@ impl RenameTypeDeclarationProcessor {
         self.all_types.insert(module_name, types);
     }
 
-    fn generate_unique_type(&mut self, original_name: &String) -> String {
-        let mut new_name = original_name.clone();
+    fn generate_unique_type(&mut self, original_name: &str) -> String {
+        let mut new_name = original_name.to_owned();
         new_name.push_str(&self.suffix);
         new_name.push_str(&self.permutator.next().unwrap());
         new_name
@@ -178,7 +178,7 @@ impl NodeProcessor for RenameTypeDeclarationProcessor {
                 .and_then(|module_types| {
                     module_types.get(type_field.get_type_name().get_type_name().get_name())
                 })
-                .map(|renamed| TypeName::new(renamed))
+                .map(TypeName::new)
                 .map(Type::from),
             _ => None,
         };
@@ -203,9 +203,8 @@ impl NodePostProcessor for RenameTypeDeclarationProcessor {
                 let last_line = lines::statement_total(&current);
                 let total = 1 + last_line.saturating_sub(first_line) as isize;
 
-                let mut shift_processor = ShiftTokenLineProcessor::new(
-                    1 + self.type_lines as isize - first_line as isize,
-                );
+                let mut shift_processor =
+                    ShiftTokenLineProcessor::new(1 + self.type_lines - first_line as isize);
                 DefaultVisitor::visit_statement(&mut current, &mut shift_processor);
 
                 self.type_lines += total;

--- a/src/rules/bundle/rename_type_declaration.rs
+++ b/src/rules/bundle/rename_type_declaration.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+use std::mem;
+
+use crate::nodes::*;
+use crate::process::utils::{identifier_permutator, CharPermutator};
+use crate::process::{
+    DefaultVisitor, NodePostProcessor, NodePostVisitor, NodeProcessor, NodeVisitor, Scope,
+    ScopePostVisitor,
+};
+use crate::rules::ShiftTokenLineProcessor;
+use crate::utils::{lines, ScopedHashMap};
+
+#[derive(Debug)]
+pub(crate) struct RenameTypeDeclarationProcessor {
+    suffix: String,
+    /// a map from the original type name to its newly generated name
+    renamed_types: ScopedHashMap<String, String>,
+    /// a map from identifiers to module names
+    type_namespace: ScopedHashMap<String, String>,
+    /// the exported types found
+    exported_types: HashMap<String, String>,
+    /// a map from module names to their exported types
+    all_types: HashMap<String, HashMap<String, String>>,
+    /// permutator to generate unique type identifier suffixes
+    permutator: CharPermutator,
+    modules_identifier: String,
+    module_load_field: &'static str,
+    hoist_types: bool,
+    type_lines: isize,
+    type_declarations: Vec<Statement>,
+}
+
+impl RenameTypeDeclarationProcessor {
+    pub(crate) fn new(modules_identifier: String, module_load_field: &'static str) -> Self {
+        Self {
+            suffix: "__DARKLUA_TYPE_".into(),
+            renamed_types: Default::default(),
+            type_namespace: Default::default(),
+            exported_types: Default::default(),
+            all_types: Default::default(),
+            permutator: identifier_permutator(),
+            modules_identifier,
+            module_load_field,
+            hoist_types: true,
+            type_lines: 0,
+            type_declarations: Default::default(),
+        }
+    }
+
+    pub(crate) fn rename_types(&mut self, block: &mut Block) {
+        self.hoist_types = false;
+        ScopePostVisitor::visit_block(block, self);
+    }
+
+    pub(crate) fn extract_exported_types(&mut self, block: &mut Block) -> HashMap<String, String> {
+        self.hoist_types = true;
+        ScopePostVisitor::visit_block(block, self);
+        mem::take(&mut self.exported_types)
+    }
+
+    pub(crate) fn insert_module_types(
+        &mut self,
+        module_name: String,
+        types: HashMap<String, String>,
+    ) {
+        self.all_types.insert(module_name, types);
+    }
+
+    fn generate_unique_type(&mut self, original_name: &String) -> String {
+        let mut new_name = original_name.clone();
+        new_name.push_str(&self.suffix);
+        new_name.push_str(&self.permutator.next().unwrap());
+        new_name
+    }
+
+    fn get_module_name(&self, value: &Expression) -> Option<String> {
+        if let Expression::Call(value) = value {
+            if let Prefix::Field(field) = value.get_prefix() {
+                if field.get_field().get_name() == self.module_load_field {
+                    if let Prefix::Identifier(variable) = field.get_prefix() {
+                        if variable.get_name() == &self.modules_identifier {
+                            return value
+                                .get_arguments()
+                                .clone()
+                                .to_expressions()
+                                .into_iter()
+                                .next()
+                                .and_then(|argument| {
+                                    if let Expression::String(string_value) = argument {
+                                        Some(string_value.into_value())
+                                    } else {
+                                        None
+                                    }
+                                });
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn rename_type_declaration(&mut self, declaration: &mut TypeDeclarationStatement) {
+        let original_name = declaration.get_name().get_name().to_owned();
+
+        let new_name = self.generate_unique_type(&original_name);
+
+        if declaration.is_exported() {
+            declaration.remove_exported();
+            self.exported_types
+                .insert(original_name.clone(), new_name.clone());
+        }
+
+        self.renamed_types.insert(original_name, new_name.clone());
+
+        declaration.mutate_name().set_name(new_name);
+    }
+
+    pub(crate) fn get_type_lines(&self) -> isize {
+        self.type_lines
+    }
+
+    pub(crate) fn extract_type_declarations(&mut self) -> Vec<Statement> {
+        mem::take(&mut self.type_declarations)
+    }
+}
+
+impl Scope for RenameTypeDeclarationProcessor {
+    fn push(&mut self) {
+        self.renamed_types.push();
+        self.type_namespace.push();
+    }
+
+    fn pop(&mut self) {
+        self.renamed_types.pop();
+        self.type_namespace.pop();
+    }
+
+    fn insert(&mut self, _: &mut String) {}
+
+    fn insert_self(&mut self) {}
+
+    fn insert_local(&mut self, identifier: &mut String, value: Option<&mut Expression>) {
+        if let Some(module_name) = value.and_then(|value| self.get_module_name(value)) {
+            self.type_namespace.insert(identifier.clone(), module_name);
+        }
+    }
+
+    fn insert_local_function(&mut self, _: &mut LocalFunctionStatement) {}
+}
+
+impl NodeProcessor for RenameTypeDeclarationProcessor {
+    fn process_block(&mut self, block: &mut Block) {
+        if !self.hoist_types {
+            return;
+        }
+
+        for statement in block.iter_mut_statements() {
+            if let Statement::TypeDeclaration(declaration) = statement {
+                self.rename_type_declaration(declaration);
+            }
+        }
+    }
+
+    fn process_type(&mut self, r#type: &mut Type) {
+        let replace_with = match r#type {
+            Type::Name(type_name) => {
+                if let Some(new_name) = self.renamed_types.get(type_name.get_type_name().get_name())
+                {
+                    type_name.mutate_type_name().set_name(new_name);
+                }
+                None
+            }
+            Type::Field(type_field) => self
+                .type_namespace
+                .get(type_field.get_namespace().get_name())
+                .and_then(|module_name| self.all_types.get(module_name))
+                .and_then(|module_types| {
+                    module_types.get(type_field.get_type_name().get_type_name().get_name())
+                })
+                .map(|renamed| TypeName::new(renamed))
+                .map(Type::from),
+            _ => None,
+        };
+
+        if let Some(new_type) = replace_with {
+            *r#type = new_type;
+        }
+    }
+}
+
+impl NodePostProcessor for RenameTypeDeclarationProcessor {
+    fn process_after_block(&mut self, block: &mut Block) {
+        if !self.hoist_types {
+            return;
+        }
+
+        block.filter_mut_statements(|statement| {
+            if let Statement::TypeDeclaration(_declaration) = statement {
+                let mut current = mem::replace(statement, DoStatement::default().into());
+
+                let first_line = lines::statement_first(&current);
+                let last_line = lines::statement_total(&current);
+                let total = 1 + last_line.saturating_sub(first_line) as isize;
+
+                let mut shift_processor = ShiftTokenLineProcessor::new(
+                    1 + self.type_lines as isize - first_line as isize,
+                );
+                DefaultVisitor::visit_statement(&mut current, &mut shift_processor);
+
+                self.type_lines += total;
+                self.type_declarations.push(current);
+
+                false
+            } else {
+                true
+            }
+        });
+    }
+}

--- a/src/rules/bundle/rename_type_declaration.rs
+++ b/src/rules/bundle/rename_type_declaration.rs
@@ -179,7 +179,15 @@ impl NodeProcessor for RenameTypeDeclarationProcessor {
                     module_types.get(type_field.get_type_name().get_type_name().get_name())
                 })
                 .map(TypeName::new)
-                .map(Type::from),
+                .map(|type_name| {
+                    Type::from(
+                        if let Some(parameters) = type_field.get_type_name().get_type_parameters() {
+                            type_name.with_type_parameters(parameters.clone())
+                        } else {
+                            type_name
+                        },
+                    )
+                }),
             _ => None,
         };
 

--- a/src/rules/shift_token_line.rs
+++ b/src/rules/shift_token_line.rs
@@ -7,17 +7,17 @@ use crate::rules::{
 use super::verify_no_rule_properties;
 
 #[derive(Debug)]
-struct Processor {
-    shift_amount: usize,
+pub(crate) struct ShiftTokenLineProcessor {
+    shift_amount: isize,
 }
 
-impl Processor {
-    fn new(shift_amount: usize) -> Self {
+impl ShiftTokenLineProcessor {
+    pub(crate) fn new(shift_amount: isize) -> Self {
         Self { shift_amount }
     }
 }
 
-impl NodeProcessor for Processor {
+impl NodeProcessor for ShiftTokenLineProcessor {
     fn process_block(&mut self, block: &mut Block) {
         block.shift_token_line(self.shift_amount);
     }
@@ -242,11 +242,11 @@ pub const SHIFT_TOKEN_LINE: &str = "shift_token_line";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ShiftTokenLine {
-    shift_amount: usize,
+    shift_amount: isize,
 }
 
 impl ShiftTokenLine {
-    pub(crate) fn new(shift_amount: usize) -> Self {
+    pub(crate) fn new(shift_amount: isize) -> Self {
         Self { shift_amount }
     }
 }
@@ -254,7 +254,7 @@ impl ShiftTokenLine {
 impl FlawlessRule for ShiftTokenLine {
     fn flawless_process(&self, block: &mut Block, _context: &Context) {
         if self.shift_amount != 0 {
-            let mut processor = Processor::new(self.shift_amount);
+            let mut processor = ShiftTokenLineProcessor::new(self.shift_amount);
             DefaultVisitor::visit_block(block, &mut processor);
         }
     }

--- a/src/rules/snapshots/darklua_core__rules__rename_type_declaration__test__default_rename_type_declaration.snap
+++ b/src/rules/snapshots/darklua_core__rules__rename_type_declaration__test__default_rename_type_declaration.snap
@@ -1,0 +1,5 @@
+---
+source: src/rules/rename_type_declaration.rs
+expression: rule
+---
+"rename_type_declaration"

--- a/src/utils/lines.rs
+++ b/src/utils/lines.rs
@@ -1,0 +1,306 @@
+use crate::nodes::{
+    Arguments, Block, Expression, FunctionCall, FunctionReturnType, LastStatement, Prefix,
+    Statement, Token, Type, Variable,
+};
+
+pub(crate) fn block_total(block: &Block) -> usize {
+    last_block_token(block)
+        .and_then(get_token_line)
+        .unwrap_or(0)
+}
+
+pub(crate) fn statement_total(statement: &Statement) -> usize {
+    last_statement_token(statement)
+        .and_then(get_token_line)
+        .unwrap_or(0)
+}
+
+pub(crate) fn statement_first(statement: &Statement) -> usize {
+    first_statement_token(statement)
+        .and_then(get_token_line)
+        .unwrap_or(0)
+}
+
+fn get_token_line(token: &Token) -> Option<usize> {
+    token
+        .iter_trailing_trivia()
+        .last()
+        .and_then(|trivia| {
+            trivia.get_line_number().map(|line| {
+                line + trivia
+                    .try_read()
+                    .unwrap_or_default()
+                    .chars()
+                    .filter(|c| *c == '\n')
+                    .count()
+            })
+        })
+        .or_else(|| token.get_line_number())
+}
+
+fn last_block_token(block: &Block) -> Option<&Token> {
+    block
+        .get_tokens()
+        .and_then(|tokens| tokens.final_token.as_ref())
+        .or_else(|| {
+            block
+                .get_last_statement()
+                .and_then(last_last_statement_token)
+                .or_else(|| {
+                    block
+                        .iter_statements()
+                        .last()
+                        .and_then(last_statement_token)
+                })
+        })
+}
+
+fn last_statement_token(statement: &Statement) -> Option<&Token> {
+    match statement {
+        Statement::Assign(assign) => assign.last_value().and_then(last_expression_token),
+        Statement::Do(do_statement) => do_statement.get_tokens().map(|tokens| &tokens.end),
+        Statement::Call(call) => last_call_token(call),
+        Statement::CompoundAssign(assign) => last_expression_token(assign.get_value()),
+        Statement::Function(function) => function.get_tokens().map(|tokens| &tokens.end),
+        Statement::GenericFor(generic_for) => generic_for.get_tokens().map(|tokens| &tokens.end),
+        Statement::If(if_statement) => if_statement.get_tokens().map(|tokens| &tokens.end),
+        Statement::LocalAssign(local_assign) => local_assign
+            .iter_values()
+            .last()
+            .and_then(last_expression_token)
+            .or_else(|| {
+                local_assign
+                    .iter_variables()
+                    .last()
+                    .and_then(|identifier| identifier.get_token())
+            }),
+        Statement::LocalFunction(local_function) => {
+            local_function.get_tokens().map(|tokens| &tokens.end)
+        }
+        Statement::NumericFor(numeric_for) => numeric_for.get_tokens().map(|tokens| &tokens.end),
+        Statement::Repeat(repeat) => last_expression_token(repeat.get_condition()),
+        Statement::While(while_statement) => while_statement.get_tokens().map(|tokens| &tokens.end),
+        Statement::TypeDeclaration(type_declaration) => {
+            last_type_token(type_declaration.get_type())
+        }
+    }
+}
+
+fn last_last_statement_token(last: &LastStatement) -> Option<&Token> {
+    match last {
+        LastStatement::Break(token) | LastStatement::Continue(token) => token.as_ref(),
+        LastStatement::Return(return_statement) => return_statement
+            .iter_expressions()
+            .last()
+            .and_then(last_expression_token)
+            .or_else(|| return_statement.get_tokens().map(|tokens| &tokens.r#return)),
+    }
+}
+
+fn last_expression_token(expression: &Expression) -> Option<&Token> {
+    match expression {
+        Expression::Binary(binary) => last_expression_token(binary.right()),
+        Expression::Call(call) => last_call_token(call),
+        Expression::Field(field) => field.get_field().get_token(),
+        Expression::Function(function) => function.get_tokens().map(|tokens| &tokens.end),
+        Expression::Identifier(identifier) => identifier.get_token(),
+        Expression::If(if_expression) => last_expression_token(if_expression.get_else_result()),
+        Expression::Index(index) => index.get_tokens().map(|tokens| &tokens.closing_bracket),
+        Expression::Number(number) => number.get_token(),
+        Expression::Parenthese(parentheses) => parentheses
+            .get_tokens()
+            .map(|tokens| &tokens.right_parenthese),
+        Expression::String(string) => string.get_token(),
+        Expression::InterpolatedString(string) => {
+            string.get_tokens().map(|tokens| &tokens.closing_tick)
+        }
+        Expression::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
+        Expression::Nil(token)
+        | Expression::False(token)
+        | Expression::True(token)
+        | Expression::VariableArguments(token) => token.as_ref(),
+        Expression::Unary(unary) => last_expression_token(unary.get_expression()),
+        Expression::TypeCast(type_cast) => last_type_token(type_cast.get_type()),
+    }
+}
+
+fn last_type_token(r#type: &Type) -> Option<&Token> {
+    match r#type {
+        Type::Name(name) => {
+            if let Some(type_params) = name.get_type_parameters() {
+                type_params.get_tokens().map(|tokens| &tokens.closing_list)
+            } else {
+                name.get_type_name().get_token()
+            }
+        }
+        Type::Field(field) => {
+            if let Some(type_params) = field.get_type_name().get_type_parameters() {
+                type_params.get_tokens().map(|tokens| &tokens.closing_list)
+            } else {
+                field.get_type_name().get_type_name().get_token()
+            }
+        }
+        Type::True(token) | Type::False(token) | Type::Nil(token) => token.as_ref(),
+        Type::String(string) => string.get_token(),
+        Type::Array(array) => array.get_tokens().map(|tokens| &tokens.closing_brace),
+        Type::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
+        Type::TypeOf(expression_type) => expression_type
+            .get_tokens()
+            .map(|tokens| &tokens.closing_parenthese),
+        Type::Parenthese(parenthese) => parenthese
+            .get_tokens()
+            .map(|tokens| &tokens.right_parenthese),
+        Type::Function(function) => match function.get_return_type() {
+            FunctionReturnType::Type(return_type) => last_type_token(return_type),
+            FunctionReturnType::TypePack(type_pack) => type_pack
+                .get_tokens()
+                .map(|tokens| &tokens.right_parenthese),
+            FunctionReturnType::GenericTypePack(generic_pack) => generic_pack.get_token(),
+            FunctionReturnType::VariadicTypePack(variadic_pack) => {
+                last_type_token(variadic_pack.get_type())
+            }
+        },
+        Type::Optional(optional) => optional.get_token(),
+        Type::Intersection(intersection) => last_type_token(intersection.last_type()),
+        Type::Union(union_type) => last_type_token(union_type.last_type()),
+    }
+}
+
+fn last_call_token(call: &FunctionCall) -> Option<&Token> {
+    match call.get_arguments() {
+        Arguments::Tuple(tuple) => tuple.get_tokens().map(|tokens| &tokens.closing_parenthese),
+        Arguments::String(string) => string.get_token(),
+        Arguments::Table(table) => table.get_tokens().map(|tokens| &tokens.closing_brace),
+    }
+}
+
+fn first_statement_token(statement: &Statement) -> Option<&Token> {
+    match statement {
+        Statement::Assign(assign) => assign
+            .iter_variables()
+            .next()
+            .and_then(first_variable_token),
+        Statement::Do(do_statement) => do_statement.get_tokens().map(|tokens| &tokens.r#do),
+        Statement::Call(call) => first_prefix_token(call.get_prefix()),
+        Statement::CompoundAssign(assign) => first_variable_token(assign.get_variable()),
+        Statement::Function(function) => function.get_tokens().map(|tokens| &tokens.function),
+        Statement::GenericFor(generic_for) => generic_for.get_tokens().map(|tokens| &tokens.r#for),
+        Statement::If(if_statement) => if_statement.get_tokens().map(|tokens| &tokens.r#if),
+        Statement::LocalAssign(local_assign) => {
+            local_assign.get_tokens().map(|tokens| &tokens.local)
+        }
+        Statement::LocalFunction(local_function) => {
+            local_function.get_tokens().map(|tokens| &tokens.local)
+        }
+        Statement::NumericFor(numeric_for) => numeric_for.get_tokens().map(|tokens| &tokens.r#for),
+        Statement::Repeat(repeat) => repeat.get_tokens().map(|tokens| &tokens.repeat),
+        Statement::While(while_statement) => {
+            while_statement.get_tokens().map(|tokens| &tokens.r#while)
+        }
+        Statement::TypeDeclaration(type_declaration) => {
+            type_declaration.get_tokens().and_then(|tokens| {
+                if type_declaration.is_exported() {
+                    tokens.export.as_ref()
+                } else {
+                    Some(&tokens.r#type)
+                }
+            })
+        }
+    }
+}
+
+fn first_variable_token(variable: &Variable) -> Option<&Token> {
+    match variable {
+        Variable::Identifier(identifier) => identifier.get_token(),
+        Variable::Field(field_expression) => first_prefix_token(field_expression.get_prefix()),
+        Variable::Index(index_expression) => first_prefix_token(index_expression.get_prefix()),
+    }
+}
+
+fn first_prefix_token(prefix: &Prefix) -> Option<&Token> {
+    match prefix {
+        Prefix::Call(function_call) => first_prefix_token(function_call.get_prefix()),
+        Prefix::Field(field_expression) => first_prefix_token(field_expression.get_prefix()),
+        Prefix::Identifier(identifier) => identifier.get_token(),
+        Prefix::Index(index_expression) => first_prefix_token(index_expression.get_prefix()),
+        Prefix::Parenthese(parenthese_expression) => parenthese_expression
+            .get_tokens()
+            .map(|tokens| &tokens.left_parenthese),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    macro_rules! test_total_lines {
+        (
+            $($name:ident ($code:literal) => $value:expr),+,
+        ) => {
+            $(
+                #[test]
+                fn $name() {
+                    use $crate::rules::FlawlessRule;
+
+                    let code = $code;
+
+                    let mut block = $crate::Parser::default().preserve_tokens().parse(&code).unwrap();
+
+                    let resources = $crate::Resources::from_memory();
+                    let context = $crate::rules::ContextBuilder::new(
+                            "placeholder",
+                            &resources,
+                            &code
+                        )
+                        .build();
+
+                    $crate::rules::ReplaceReferencedTokens::default()
+                    .flawless_process(&mut block, &context);
+
+                    let received_lines = super::block_total(&block);
+                    assert_eq!(
+                        received_lines,
+                        $value,
+                        "expected {} line{} but received {}.\n{:#?}",
+                        $value,
+                        if $value > 1 { "s" } else { "" },
+                        received_lines,
+                        block,
+                    );
+                }
+            )*
+        };
+    }
+
+    test_total_lines!(
+        return_statement("return\n") => 2,
+        return_one("return 1") => 1,
+        return_true("return true") => 1,
+        return_false("return true,\n\tfalse\n") => 3,
+        return_nil("return nil\n") => 2,
+        return_string("return 'hello' --end\n") => 2,
+        return_not_variable("return not variable") => 1,
+        return_function_call("return call()") => 1,
+        return_variadic_args("return ... -- comment") => 1,
+        return_parenthese("return (\ncall()\n)") => 3,
+        return_table("return {\n\t}\n") => 3,
+        return_function_expression("return function(arg1, ...)\nend -- ") => 2,
+        return_function_call_with_table_arguments("return call {\nelement\n}") => 3,
+        function_call_with_table_arguments("call {\nelement\n}") => 3,
+        require_with_string_argument("require 'module.lua'\n") => 2,
+        return_require_with_string_argument("return require 'module.lua'\n") => 2,
+        return_if_expression("return if condition then\n\tok\nelse\n\terr") => 4,
+        if_statement("if condition then\n\treturn ok\nelse\n\treturn err\nend -- end if") => 5,
+        do_statement("do\n--comment\n\n\nend") => 5,
+        compound_assign("\nvar += 10.5") => 2,
+        assign_with_binary_expression("var = var + 2") => 1,
+        local_assign_with_field_expression("local var =\n\tobject.prop\n-- end") => 3,
+        local_assign_with_index_expression("local var =\n\tobject['prop']\n-- end") => 3,
+        local_function_definition("local function fn()\nend\n") => 3,
+        function_definition("function fn()\nend\n --comment\n") => 4,
+        generic_for("for k, v in pairs({}) do\nend\n --comment") => 3,
+        numeric_for("for i = 1, 10 do\n-- comment\nend\n") => 4,
+        repeat_statement("\nrepeat\n-- do\nuntil condition\n") => 5,
+        while_statement("\nwhile condition do\n-- do\nend\n") => 5,
+        break_statement("break\n") => 2,
+        continue_statement("continue\n") => 2,
+    );
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,8 +1,11 @@
 mod expressions_as_statement;
+pub(crate) mod lines;
+mod scoped_hash_map;
 mod serde_string_or_struct;
 mod timer;
 
 pub(crate) use expressions_as_statement::{expressions_as_expression, expressions_as_statement};
+pub(crate) use scoped_hash_map::ScopedHashMap;
 pub(crate) use serde_string_or_struct::string_or_struct;
 pub use timer::Timer;
 

--- a/src/utils/scoped_hash_map.rs
+++ b/src/utils/scoped_hash_map.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ScopedHashMap<Key, Value> {
+    stack: Vec<HashMap<Key, Value>>,
+}
+
+impl<Key: Eq + Hash, Value> ScopedHashMap<Key, Value> {
+    pub(crate) fn get(&self, key: &Key) -> Option<&Value> {
+        self.stack.iter().rev().find_map(|map| map.get(key))
+    }
+
+    pub(crate) fn insert(&mut self, key: Key, value: Value) {
+        if let Some(hash_map) = self.stack.last_mut() {
+            hash_map.insert(key, value);
+        } else {
+            let mut hash_map = HashMap::new();
+            hash_map.insert(key, value);
+            self.stack.push(hash_map);
+        }
+    }
+
+    pub(crate) fn push(&mut self) {
+        self.stack.push(Default::default())
+    }
+
+    pub(crate) fn pop(&mut self) {
+        self.stack.pop();
+    }
+}

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -242,6 +242,18 @@ mod without_rules {
     }
 
     #[test]
+    fn require_lua_file_forward_exported_types_with_generics() {
+        process_main(
+            &memory_resources!(
+                "src/value.lua" => "export type Value<T> = string | T return true",
+                "src/main.lua" => "local value = require('./value.lua') export type Value<T> = value.Value<T>",
+                ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG,
+            ),
+            "require_lua_file_forward_exported_types_with_generics",
+        );
+    }
+
+    #[test]
     fn require_lua_file_after_declaration() {
         let resources = memory_resources!(
             "src/value.lua" => "return true",

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -230,6 +230,18 @@ mod without_rules {
     }
 
     #[test]
+    fn require_lua_file_forward_exported_types() {
+        process_main(
+            &memory_resources!(
+                "src/value.lua" => "export type Value = string return true",
+                "src/main.lua" => "local value = require('./value.lua') export type Value = value.Value",
+                ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG,
+            ),
+            "require_lua_file_forward_exported_types",
+        );
+    }
+
+    #[test]
     fn require_lua_file_after_declaration() {
         let resources = memory_resources!(
             "src/value.lua" => "return true",

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types.snap
@@ -1,0 +1,30 @@
+---
+source: tests/bundle.rs
+expression: main
+---
+type Value__DARKLUA_TYPE_a = string
+
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
+
+do
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return true
+    end
+end
+
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
+
+export type Value = Value__DARKLUA_TYPE_a

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types_with_generics.snap
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types_with_generics.snap
@@ -1,8 +1,6 @@
 ---
 source: tests/bundle.rs
-assertion_line: 85
 expression: main
-snapshot_kind: text
 ---
 type Value__DARKLUA_TYPE_a<T> = string | T
 

--- a/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types_with_generics.snap.new
+++ b/tests/snapshots/bundle__without_rules__bundle_without_rules_require_lua_file_forward_exported_types_with_generics.snap.new
@@ -1,0 +1,32 @@
+---
+source: tests/bundle.rs
+assertion_line: 85
+expression: main
+snapshot_kind: text
+---
+type Value__DARKLUA_TYPE_a<T> = string | T
+
+local __DARKLUA_BUNDLE_MODULES
+
+__DARKLUA_BUNDLE_MODULES = {
+    cache = {},
+    load = function(m)
+        if not __DARKLUA_BUNDLE_MODULES.cache[m] then
+            __DARKLUA_BUNDLE_MODULES.cache[m] = {
+                c = __DARKLUA_BUNDLE_MODULES[m](),
+            }
+        end
+
+        return __DARKLUA_BUNDLE_MODULES.cache[m].c
+    end,
+}
+
+do
+    function __DARKLUA_BUNDLE_MODULES.a()
+        return true
+    end
+end
+
+local value = __DARKLUA_BUNDLE_MODULES.load('a')
+
+export type Value<T> = Value__DARKLUA_TYPE_a<T>


### PR DESCRIPTION
Closes #144 

Thank you to @CompeyDev for sponsoring this feature on my [ko-fi](https://ko-fi.com/seaofvoices) 🎉 

Darklua will now be able to correctly preserve types when bundling Luau.

Note that because of how Luau currently works, types that uses `typeof` (like `type Example = typeof(variable)`) can't be hoisted correctly if they include a local variable.

- [x] add entry to the changelog
