### PR TITLE
Fix floating point number representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* fix floating point number representation ([#251](https://github.com/seaofvoices/darklua/pull/251))
 * read Luau configuration files (`.luaurc`) to get path aliases ([#246](https://github.com/seaofvoices/darklua/pull/246))
 * support Luau types when bundling ([#249](https://github.com/seaofvoices/darklua/pull/249))
 

--- a/src/generator/dense.rs
+++ b/src/generator/dense.rs
@@ -811,8 +811,8 @@ impl LuaGenerator for DenseLuaGenerator {
         use nodes::NumberExpression::*;
 
         match number {
-            Decimal(number) => {
-                let float = number.get_raw_float();
+            Decimal(decimal) => {
+                let float = decimal.get_raw_float();
                 if float.is_nan() {
                     self.push_char('(');
                     self.push_char('0');
@@ -829,17 +829,7 @@ impl LuaGenerator for DenseLuaGenerator {
                     self.push_char('0');
                     self.push_char(')');
                 } else {
-                    let mut result = format!("{}", float);
-
-                    if let Some(exponent) = number.get_exponent() {
-                        let exponent_char = number
-                            .is_uppercase()
-                            .map(|is_uppercase| if is_uppercase { 'E' } else { 'e' })
-                            .unwrap_or('e');
-
-                        result.push(exponent_char);
-                        result.push_str(&format!("{}", exponent));
-                    };
+                    let result = utils::write_number(number);
 
                     self.push_str(&result);
                 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1053,6 +1053,7 @@ mod $mod_name {
             number_100_25 => 100.25,
             number_2000_05 => 2000.05,
             binary_0b10101 => BinaryNumber::new(0b10101, false),
+            number_4_6982573308436185e159 => "4.6982573308436185e159".parse::<NumberExpression>().ok(),
         ));
 
         snapshot_node!($mod_name, $generator, table, write_expression => (

--- a/src/generator/snapshots/darklua_core__generator__test__dense__snapshots__number__dense_number_number_4_6982573308436185e159.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__dense__snapshots__number__dense_number_number_4_6982573308436185e159.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generator.into_string()
+---
+4.6982573308436185e159

--- a/src/generator/snapshots/darklua_core__generator__test__readable__snapshots__number__readable_number_number_4_6982573308436185e159.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__readable__snapshots__number__readable_number_number_4_6982573308436185e159.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generator.into_string()
+---
+4.6982573308436185e159

--- a/src/generator/snapshots/darklua_core__generator__test__token_based__snapshots__number__token_based_number_number_4_6982573308436185e159.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__token_based__snapshots__number__token_based_number_number_4_6982573308436185e159.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generator.into_string()
+---
+4.6982573308436185e159

--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -234,7 +234,7 @@ pub fn write_number(number: &NumberExpression) -> String {
             } else if float.fract() == 0.0 {
                 format!("{}", float)
             } else {
-                format!("{:?}", float)
+                format!("{:.}", float)
             }
         }
         NumberExpression::Hex(number) => {

--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -201,6 +201,7 @@ pub fn write_number(number: &NumberExpression) -> String {
     match number {
         NumberExpression::Decimal(number) => {
             let float = number.get_raw_float();
+            #[allow(clippy::if_same_then_else)]
             if float.is_nan() {
                 "(0/0)".to_owned()
             } else if float.is_infinite() {
@@ -215,11 +216,11 @@ pub fn write_number(number: &NumberExpression) -> String {
                 let formatted = format!(
                     "{}{}{}",
                     mantissa,
-                    number
-                        .is_uppercase()
-                        .unwrap_or_default()
-                        .then_some("E")
-                        .unwrap_or("e"),
+                    if number.is_uppercase().unwrap_or_default() {
+                        "E"
+                    } else {
+                        "e"
+                    },
                     exponent
                 );
 

--- a/src/nodes/expressions/mod.rs
+++ b/src/nodes/expressions/mod.rs
@@ -109,9 +109,8 @@ impl From<f64> for Expression {
                     UnaryExpression::new(UnaryOperator::Minus, Expression::from(value.abs())).into()
                 } else if value < 0.1 {
                     let exponent = value.log10().floor();
-                    let new_value = value / 10_f64.powf(exponent);
 
-                    DecimalNumber::new(new_value)
+                    DecimalNumber::new(value)
                         .with_exponent(exponent as i64, true)
                         .into()
                 } else if value > 999.0 && (value / 100.0).fract() == 0.0 {
@@ -123,7 +122,7 @@ impl From<f64> for Expression {
                         power /= 10.0;
                     }
 
-                    DecimalNumber::new(value / power)
+                    DecimalNumber::new(value)
                         .with_exponent(exponent as i64, true)
                         .into()
                 } else {
@@ -346,6 +345,7 @@ mod test {
         snapshot_from_expression!(
             f64_0 => 0_f64,
             f64_1e42 => 1e42_f64,
+            f64_1_2345e50 => 1.2345e50_f64,
             f64_infinity => f64::INFINITY,
             i64_minus_one => -1_i64,
             f64_minus_zero => -0.0,

--- a/src/nodes/expressions/snapshots/darklua_core__nodes__expressions__test__expression_from_floats__f64_1_2345e50.snap
+++ b/src/nodes/expressions/snapshots/darklua_core__nodes__expressions__test__expression_from_floats__f64_1_2345e50.snap
@@ -5,10 +5,10 @@ expression: result
 Number(
     Decimal(
         DecimalNumber {
-            float: 1e42,
+            float: 1.2345e50,
             exponent: Some(
                 (
-                    42,
+                    46,
                     true,
                 ),
             ),

--- a/src/nodes/expressions/string.rs
+++ b/src/nodes/expressions/string.rs
@@ -42,8 +42,7 @@ impl StringExpression {
 
         match (chars.next(), chars.next_back()) {
             (Some((_, first_char)), Some((_, last_char))) if first_char == last_char => {
-                string_utils::read_escaped_string(chars, Some(string.as_bytes().len()))
-                    .map(Self::from_value)
+                string_utils::read_escaped_string(chars, Some(string.len())).map(Self::from_value)
             }
             (None, None) | (None, Some(_)) | (Some(_), None) => {
                 Err(StringError::invalid("missing quotes"))


### PR DESCRIPTION
Closes #248 

This PR change the inner representation of the decimal numbers to avoid miss-formatting the numbers when printing them back.

I decided to remove the `DecimalNumber::get_raw_float` method from the public API.

- [x] add entry to the changelog
