### PR TITLE
Add `remove_statement` method to `Block`

### DIFF
--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -59,6 +59,13 @@ impl Block {
         self.statements.push(statement.into());
     }
 
+    pub fn remove_statement(&mut self, index: usize) {
+        self.statements.remove(index);
+        if let Some(tokens) = &mut self.tokens {
+            tokens.semicolons.remove(index);
+        }
+    }
+
     pub fn with_statement<T: Into<Statement>>(mut self, statement: T) -> Self {
         self.statements.push(statement.into());
         self
@@ -405,6 +412,15 @@ mod test {
                 final_token: None,
             })
         );
+    }
+
+    #[test]
+    fn remove_statement() {
+        let mut block = parse_block_with_tokens("while true do end");
+
+        block.remove_statement(0);
+
+        assert!(block.is_empty());
     }
 
     #[test]

--- a/src/nodes/block.rs
+++ b/src/nodes/block.rs
@@ -60,8 +60,14 @@ impl Block {
     }
 
     pub fn remove_statement(&mut self, index: usize) {
+        if self.statements.get(index).is_none() {
+            return;
+        }
         self.statements.remove(index);
         if let Some(tokens) = &mut self.tokens {
+            if tokens.semicolons.get(index).is_none() {
+                return;
+            }
             tokens.semicolons.remove(index);
         }
     }
@@ -421,6 +427,15 @@ mod test {
         block.remove_statement(0);
 
         assert!(block.is_empty());
+    }
+
+    #[test]
+    fn remove_statement_out_of_bounds() {
+        let mut block = parse_block_with_tokens("while true do end");
+
+        block.remove_statement(1);
+
+        assert!(block.statements_len() == 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #252 

This new public method lets users remove statements at a specific index.

## Changes
- Add `remove_statement(index: usize)` public method for struct `Block`.
- Add a simple test.

cargo fmt'ed and all tests were successful.