### PR TITLE
Library node docs

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
@@ -36,7 +36,7 @@ jobs:
         with:
           version: "latest"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -62,7 +62,7 @@ jobs:
           mv darklua-wasm/pkg darklua-wasm/node-pkg
           wasm-pack build darklua-wasm -t bundler --release
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: github.ref != 'refs/heads/main'
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
         run: npx gatsby build
 
       - name: Archive site
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: site/public
 
@@ -98,4 +98,4 @@ jobs:
     steps:
       - name: Deploy site to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo build --release
 
       - name: Setup Lua
-        uses: leafo/gh-actions-lua@11
+        uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.1.5"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo build --release
 
       - name: Setup Lua
-        uses: leafo/gh-actions-lua@v9
+        uses: leafo/gh-actions-lua@11
         with:
           luaVersion: "5.1.5"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* export the `PathRequireMode` struct when using the darklua library ([#273](https://github.com/seaofvoices/darklua/pull/273))
+
 ## 0.16.0
 
 * add `remove_statement(index)` method to `Block` ([#254](https://github.com/seaofvoices/darklua/pull/254))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-* export the `PathRequireMode` struct when using the darklua library ([#273](https://github.com/seaofvoices/darklua/pull/273))
+* export the `PathRequireMode` struct when using the darklua library and refactor AST node types to reduce size difference between variants ([#273](https://github.com/seaofvoices/darklua/pull/273))
 
 ## 0.16.0
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<div align="center">
+
 [![checks](https://github.com/seaofvoices/darklua/actions/workflows/test.yml/badge.svg)](https://github.com/seaofvoices/darklua/actions/workflows/test.yml)
 [![site](https://github.com/seaofvoices/darklua/actions/workflows/site.yml/badge.svg)](https://darklua.com/)
 [![version](https://img.shields.io/crates/v/darklua)](https://crates.io/crates/darklua)
@@ -5,9 +7,13 @@
 [![GitHub all releases](https://img.shields.io/github/downloads/seaofvoices/darklua/total)](https://github.com/seaofvoices/darklua/releases)
 [![GitHub top language](https://img.shields.io/github/languages/top/seaofvoices/darklua)](https://www.rust-lang.org/)
 
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/seaofvoices)
+
+</div>
+
 # darklua
 
-Transform Lua 5.1 and Roblox Lua scripts using rules.
+Transform Lua 5.1 and Roblox Luau code using configurable rules.
 
 # [Documentation](https://darklua.com/docs)
 
@@ -19,20 +25,20 @@ You can try darklua directly into your browser! Check out https://darklua.com/tr
 
 # [Installation](https://darklua.com/docs/installation/)
 
+## [Rokit](https://github.com/rojo-rbx/rokit)
+
+When using [Rokit](https://github.com/rojo-rbx/rokit), install darklua with the command:
+
+```bash
+rokit add seaofvoices/darklua
+```
+
 ## [Foreman](https://github.com/Roblox/foreman)
 
-If you are already using Foreman, then installing darklua is as simple as adding this line in the foreman.toml file:
+If you are already using Foreman, then installing darklua is as simple as adding this line in the `foreman.toml` file:
 
 ```toml
-darklua = { github = "seaofvoices/darklua", version = "=0.13.1" }
-```
-
-## [Aftman](https://github.com/LPGhatguy/aftman)
-
-With Aftman, run:
-
-```
-aftman add seaofvoices/darklua
+darklua = { github = "seaofvoices/darklua", version = "=0.16.0" }
 ```
 
 # License

--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -37,7 +37,7 @@ fn parse_code(c: &mut criterion::Criterion) {
 
     for (name, content) in inputs {
         let mut group = c.benchmark_group(name);
-        group.throughput(criterion::Throughput::Bytes(content.as_bytes().len() as u64));
+        group.throughput(criterion::Throughput::Bytes(content.len() as u64));
 
         let parser = darklua_core::Parser::default();
         group.bench_function("parse-without-tokens", |b| {

--- a/site/content/docs/installation/index.md
+++ b/site/content/docs/installation/index.md
@@ -5,12 +5,20 @@ group: Guides
 order: 1
 ---
 
+## Rokit
+
+When using [Rokit](https://github.com/rojo-rbx/rokit), install darklua with the following command:
+
+```bash
+rokit add seaofvoices/darklua
+```
+
 ## Foreman
 
 If you are already using [Foreman](https://github.com/Roblox/foreman), then installing darklua is as simple as adding this line in the `foreman.toml` file:
 
 ```toml
-darklua = { github = "seaofvoices/darklua", version = "=0.13.1" }
+darklua = { github = "seaofvoices/darklua", version = "=0.16.0" }
 ```
 
 ## Download a Release

--- a/site/darklua-wasm/Cargo.toml
+++ b/site/darklua-wasm/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.100"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -23,7 +23,7 @@ wasm-bindgen = "0.2.95"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
-js-sys = "0.3.72"
+js-sys = "0.3.77"
 darklua = { path = "../..", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 json5 = "0.4.1"
@@ -35,3 +35,12 @@ wasm-bindgen-test = "0.3.45"
 # Tell `rustc` to optimize for small code size.
 opt-level = "z"
 strip = true
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = [
+    "-Oz",
+    # for Rust 1.87.0
+    # https://github.com/rust-lang/rust/issues/141048
+    "--enable-bulk-memory",
+    "--enable-nontrapping-float-to-int",
+]

--- a/src/ast_converter.rs
+++ b/src/ast_converter.rs
@@ -613,7 +613,7 @@ impl<'a> AstConverter<'a> {
                 }
                 ConvertWork::MakePrefixFromExpression { prefix } => match self.pop_expression()? {
                     Expression::Parenthese(parenthese) => {
-                        self.prefixes.push(Prefix::Parenthese(*parenthese));
+                        self.prefixes.push(Prefix::Parenthese(parenthese));
                     }
                     _ => {
                         return Err(ConvertError::Prefix {
@@ -1684,7 +1684,7 @@ impl<'a> AstConverter<'a> {
                     }
                     Ok(entry.into())
                 }
-                ast::Field::NoKey(_) => Ok(TableEntry::Value(self.pop_expression()?)),
+                ast::Field::NoKey(_) => Ok(TableEntry::from_value(self.pop_expression()?)),
                 _ => Err(ConvertError::TableEntry {
                     entry: field.to_string(),
                 }),
@@ -1710,7 +1710,7 @@ impl<'a> AstConverter<'a> {
     ) -> Result<FunctionCall, ConvertError> {
         let prefix = self.make_prefix_with_suffixes(call.suffixes())?;
         match prefix {
-            Prefix::Call(call) => Ok(call),
+            Prefix::Call(call) => Ok(*call),
             _ => panic!(
                 "FunctionCall should convert to a call statement, but got {:#?}",
                 prefix,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,7 +59,7 @@ impl Command {
 ///
 /// For specific help about each command, run `darklua <command> --help`
 ///
-/// Site: https://darklua.com
+/// Site: <https://darklua.com>
 pub struct Darklua {
     #[command(flatten)]
     global_options: GlobalOptions,

--- a/src/frontend/configuration.rs
+++ b/src/frontend/configuration.rs
@@ -22,6 +22,7 @@ fn get_default_column_span() -> usize {
     DEFAULT_COLUMN_SPAN
 }
 
+/// Configuration for processing files (rules, generator, bundling).
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Configuration {
@@ -36,8 +37,7 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    /// Creates a configuration object without any rules and with the default
-    /// generator
+    /// Creates a configuration object without any rules and with the default generator.
     pub fn empty() -> Self {
         Self {
             rules: Vec::new(),
@@ -47,35 +47,41 @@ impl Configuration {
         }
     }
 
+    /// Sets the generator parameters for this configuration.
     #[inline]
     pub fn with_generator(mut self, generator: GeneratorParameters) -> Self {
         self.generator = generator;
         self
     }
 
+    /// Sets the generator parameters for this configuration.
     #[inline]
     pub fn set_generator(&mut self, generator: GeneratorParameters) {
         self.generator = generator;
     }
 
+    /// Adds a rule to this configuration.
     #[inline]
     pub fn with_rule(mut self, rule: impl Into<Box<dyn Rule>>) -> Self {
         self.push_rule(rule);
         self
     }
 
+    /// Sets the bundle configuration for this configuration.
     #[inline]
     pub fn with_bundle_configuration(mut self, configuration: BundleConfiguration) -> Self {
         self.bundle = Some(configuration);
         self
     }
 
+    /// Sets the location of this configuration.
     #[inline]
     pub fn with_location(mut self, location: impl Into<PathBuf>) -> Self {
         self.location = Some(location.into());
         self
     }
 
+    /// Adds a rule to this configuration.
     #[inline]
     pub fn push_rule(&mut self, rule: impl Into<Box<dyn Rule>>) {
         self.rules.push(rule.into());
@@ -153,16 +159,25 @@ impl std::fmt::Debug for Configuration {
     }
 }
 
+/// Parameters for configuring the Lua code generator.
+///
+/// This enum defines different modes for generating Lua code, each with its own
+/// formatting characteristics.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "name")]
 pub enum GeneratorParameters {
+    /// Retains the original line structure of the input code.
     #[serde(alias = "retain-lines")]
     RetainLines,
+    /// Generates dense, compact code with a specified column span.
     Dense {
+        /// The maximum number of characters per line.
         #[serde(default = "get_default_column_span")]
         column_span: usize,
     },
+    /// Attempts to generate readable code, with a specified column span.
     Readable {
+        /// The maximum number of characters per line.
         #[serde(default = "get_default_column_span")]
         column_span: usize,
     },
@@ -175,12 +190,14 @@ impl Default for GeneratorParameters {
 }
 
 impl GeneratorParameters {
+    /// Creates a new dense generator with default column span.
     pub fn default_dense() -> Self {
         Self::Dense {
             column_span: DEFAULT_COLUMN_SPAN,
         }
     }
 
+    /// Creates a new readable generator with default column span.
     pub fn default_readable() -> Self {
         Self::Readable {
             column_span: DEFAULT_COLUMN_SPAN,
@@ -233,6 +250,10 @@ impl FromStr for GeneratorParameters {
     }
 }
 
+/// Configuration for bundling modules.
+///
+/// This struct defines how modules should be bundled together, including
+/// how requires are handled.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct BundleConfiguration {
@@ -245,6 +266,7 @@ pub struct BundleConfiguration {
 }
 
 impl BundleConfiguration {
+    /// Creates a new bundle configuration with the specified require mode.
     pub fn new(require_mode: impl Into<BundleRequireMode>) -> Self {
         Self {
             require_mode: require_mode.into(),
@@ -253,11 +275,13 @@ impl BundleConfiguration {
         }
     }
 
+    /// Sets the modules identifier for this bundle configuration.
     pub fn with_modules_identifier(mut self, modules_identifier: impl Into<String>) -> Self {
         self.modules_identifier = Some(modules_identifier.into());
         self
     }
 
+    /// Adds a module to exclude from bundling.
     pub fn with_exclude(mut self, exclude: impl Into<String>) -> Self {
         self.excludes.insert(exclude.into());
         self

--- a/src/frontend/error.rs
+++ b/src/frontend/error.rs
@@ -68,8 +68,14 @@ enum ErrorKind {
     },
 }
 
+/// A type alias for `Result<T, DarkluaError>`.
 pub type DarkluaResult<T> = Result<T, DarkluaError>;
 
+/// The main error type for the darklua library.
+///
+/// This error type represents all possible errors that can occur during
+/// the processing of Lua files. It includes errors from parsing, file I/O,
+/// configuration, and rule application.
 #[derive(Debug, Clone)]
 pub struct DarkluaError {
     kind: Box<ErrorKind>,
@@ -214,6 +220,7 @@ impl DarkluaError {
         })
     }
 
+    /// Creates a custom error with the given message.
     pub fn custom(message: impl Into<Cow<'static, str>>) -> Self {
         Self::new(ErrorKind::Custom {
             message: message.into(),

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -24,7 +24,32 @@ use crate::{
     utils::normalize_path,
 };
 
-/// Convert serializable data into a Lua module
+/// Convert serializable data into a Lua module.
+///
+/// This function takes any value that implements `Serialize` and converts it into a Lua module
+/// that returns the serialized data. The resulting Lua code will be a module that returns
+/// a table containing the serialized data.
+///
+/// # Example
+///
+/// ```rust
+/// # use serde::Serialize;
+/// # use darklua_core::convert_data;
+/// #[derive(Serialize)]
+/// struct ExampleData {
+///     name: String,
+///     value: i32,
+/// }
+///
+/// let config = ExampleData {
+///     name: "test".to_string(),
+///     value: 42,
+/// };
+///
+/// let lua_code = convert_data(config).unwrap();
+///
+/// assert_eq!(lua_code, "return{name='test',value=42}");
+/// ```
 pub fn convert_data(value: impl Serialize) -> Result<String, DarkluaError> {
     let expression = to_expression(&value).map_err(DarkluaError::from)?;
 
@@ -36,6 +61,10 @@ pub fn convert_data(value: impl Serialize) -> Result<String, DarkluaError> {
     Ok(generator.into_string())
 }
 
+/// Process resources according to the given options.
+///
+/// This function is the main entry point for processing resources. It creates a [`WorkerTree`],
+/// collects work items based on the provided resources and options, and then processes them.
 pub fn process(resources: &Resources, options: Options) -> DarkluaResult<WorkerTree> {
     let mut worker_tree = WorkerTree::default();
 

--- a/src/frontend/options.rs
+++ b/src/frontend/options.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use super::configuration::{Configuration, GeneratorParameters};
 
+/// Options for configuring the darklua process function. This is not
+/// the [`Configuration`] data itself.
 #[derive(Debug)]
 pub struct Options {
     input: PathBuf,
@@ -13,6 +15,7 @@ pub struct Options {
 }
 
 impl Options {
+    /// Creates a new options instance with the specified input path.
     pub fn new(input: impl Into<PathBuf>) -> Self {
         Self {
             input: input.into(),
@@ -24,51 +27,68 @@ impl Options {
         }
     }
 
+    /// Sets the path to the configuration file.
     pub fn with_configuration_at(mut self, config: impl Into<PathBuf>) -> Self {
         self.config_path = Some(config.into());
         self
     }
 
+    /// Sets the configuration directly.
     pub fn with_configuration(mut self, config: Configuration) -> Self {
         self.config = Some(config);
         self
     }
 
+    /// Sets the output path.
     pub fn with_output(mut self, output: impl Into<PathBuf>) -> Self {
         self.output = Some(output.into());
         self
     }
 
+    /// Enables fail-fast mode.
+    ///
+    /// When fail-fast is enabled, processing will stop immediately when an error occurs.
     pub fn fail_fast(mut self) -> Self {
         self.fail_fast = true;
         self
     }
 
+    /// Sets a generator override for the configuration.
+    ///
+    /// This will override any generator settings in the configuration file.
     pub fn with_generator_override(mut self, generator: impl Into<GeneratorParameters>) -> Self {
         self.config_generator_override = Some(generator.into());
         self
     }
 
+    /// Gets the input path.
     pub fn input(&self) -> &Path {
         &self.input
     }
 
+    /// Gets the output path, if set.
     pub fn output(&self) -> Option<&Path> {
         self.output.as_ref().map(AsRef::as_ref)
     }
 
+    /// Checks if fail-fast mode is enabled.
     pub fn should_fail_fast(&self) -> bool {
         self.fail_fast
     }
 
+    /// Gets the configuration file path, if set.
     pub fn configuration_path(&self) -> Option<&Path> {
         self.config_path.as_ref().map(AsRef::as_ref)
     }
 
+    /// Gets the generator override, if set.
     pub fn generator_override(&self) -> Option<&GeneratorParameters> {
         self.config_generator_override.as_ref()
     }
 
+    /// Takes the configuration, if set.
+    ///
+    /// This removes the configuration from the options and returns it.
     pub fn take_configuration(&mut self) -> Option<Configuration> {
         self.config.take()
     }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1010,7 +1010,7 @@ mod $mod_name {
 
         snapshot_node!($mod_name, $generator, prefix, write_prefix => (
             identifier => Prefix::from_name("foo"),
-            identifier_in_parenthese => Prefix::Parenthese(ParentheseExpression::new(Expression::identifier("foo"))),
+            identifier_in_parenthese => Prefix::from(ParentheseExpression::new(Expression::identifier("foo"))),
         ));
 
         snapshot_node!($mod_name, $generator, string, write_expression => (
@@ -1059,11 +1059,11 @@ mod $mod_name {
         snapshot_node!($mod_name, $generator, table, write_expression => (
             empty => TableExpression::default(),
             list_with_single_value => TableExpression::new(vec![
-                TableEntry::Value(Expression::from(true)),
+                TableEntry::from_value(Expression::from(true)),
             ]),
             list_with_two_values => TableExpression::new(vec![
-                TableEntry::Value(Expression::from(true)),
-                TableEntry::Value(Expression::from(false)),
+                TableEntry::from_value(Expression::from(true)),
+                TableEntry::from_value(Expression::from(false)),
             ]),
             with_field_entry => TableExpression::new(vec![
                 TableFieldEntry::new("field", true).into(),
@@ -1072,7 +1072,7 @@ mod $mod_name {
                 TableIndexEntry::new(false, true).into(),
             ]),
             mixed_table => TableExpression::new(vec![
-                TableEntry::Value(Expression::from(true)),
+                TableEntry::from_value(Expression::from(true)),
                 TableFieldEntry::new("field", true).into(),
                 TableIndexEntry::new(false, true).into(),
             ]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,57 @@
-//! Transform Lua scripts.
+//! Darklua is a utility for transforming and processing Lua and Luau code. It provides
+//! a set of tools for parsing and modifying Lua/Luau code.
+//!
+//! If you are looking for a command-line tool, please visit [darklua.com](https://darklua.com/docs/installation/)
+//! or [github.com/seaofvoices/darklua](https://github.com/seaofvoices/darklua)
+//! for installation and usage instructions.
+//!
+//! This documentation site is for the darklua library itself.
+//!
+//! # Library Usage
+//!
+//! To start using darklua in your own project, add the following to your `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! darklua = "0.16.0"
+//! ```
+//!
+//! This library is designed for developers who want to integrate Lua/Luau transformation capabilities
+//! into their own applications.
+//!
+//! Please note that the library is developed primarily for the darklua command line tool. There may be
+//! some rough edges, but it should be stable enough for most use cases.
+//!
+//! # Running Darklua in Memory
+//!
+//! The following example shows how to run darklua in memory, without writing to the file system.
+//!
+//! Note that the library name is `darklua_core` and **not** `darklua`.
+//!
+//! ```rust
+//! use std::path::Path;
+//! use darklua_core::{Configuration, Options, Resources, rules::{RemoveEmptyDo, Rule}};
+//!
+//! let resources = Resources::from_memory();
+//! resources.write("project-path/src/main.lua", "do end print('Hello, world!')");
+//! let input_path = Path::new("project-path/src");
+//!
+//! let remove_empty_do: Box<dyn Rule> = Box::new(RemoveEmptyDo::default());
+//! let config = Configuration::empty().with_rule(remove_empty_do);
+//!
+//! let process_result = darklua_core::process(
+//!     &resources,
+//!     Options::new(&input_path)
+//!         .with_configuration(config),
+//! );
+//!
+//! process_result.expect("failed to process with darklua");
+//!
+//! assert_eq!(
+//!     resources.get("project-path/src/main.lua").expect("failed to get output"),
+//!     "print('Hello, world!')"
+//! );
+//! ```
 
 mod ast_converter;
 mod frontend;

--- a/src/nodes/arguments.rs
+++ b/src/nodes/arguments.rs
@@ -2,6 +2,7 @@ use std::iter;
 
 use crate::nodes::{Expression, StringExpression, TableExpression, Token};
 
+/// Tokens associated with tuple arguments.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TupleArgumentsTokens {
     pub opening_parenthese: Token,
@@ -16,6 +17,7 @@ impl TupleArgumentsTokens {
     );
 }
 
+/// Represents a list of arguments enclosed in parentheses.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TupleArguments {
     values: Vec<Expression>,
@@ -23,6 +25,7 @@ pub struct TupleArguments {
 }
 
 impl TupleArguments {
+    /// Creates a new tuple of arguments with the given expressions.
     pub fn new(values: Vec<Expression>) -> Self {
         Self {
             values,
@@ -30,46 +33,55 @@ impl TupleArguments {
         }
     }
 
+    /// Converts this tuple into expressions.
     #[inline]
     pub fn to_expressions(self) -> Vec<Expression> {
         self.values
     }
 
+    /// Sets the tokens for this tuple.
     pub fn with_tokens(mut self, tokens: TupleArgumentsTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this tuple.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TupleArgumentsTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this tuple, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TupleArgumentsTokens> {
         self.tokens.as_ref()
     }
 
+    /// Adds an argument to this tuple.
     pub fn with_argument<T: Into<Expression>>(mut self, argument: T) -> Self {
         self.values.push(argument.into());
         self
     }
 
+    /// Returns the number of arguments in this tuple.
     #[inline]
     pub fn len(&self) -> usize {
         self.values.len()
     }
 
+    /// Returns whether this tuple has no arguments.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
 
+    /// Returns an iterator over the argument expressions.
     #[inline]
     pub fn iter_values(&self) -> impl Iterator<Item = &Expression> {
         self.values.iter()
     }
 
+    /// Returns a mutable iterator over the argument expressions.
     #[inline]
     pub fn iter_mut_values(&mut self) -> impl Iterator<Item = &mut Expression> {
         self.values.iter_mut()
@@ -97,14 +109,19 @@ impl iter::FromIterator<Expression> for TupleArguments {
     }
 }
 
+/// Represents the different ways arguments can be passed to a function call.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Arguments {
+    /// Multiple arguments in parentheses: `func(arg1, arg2)`
     Tuple(TupleArguments),
+    /// A single string argument without parentheses: `func "string"`
     String(StringExpression),
+    /// A single table argument without parentheses: `func {key=value}`
     Table(TableExpression),
 }
 
 impl Arguments {
+    /// Converts these arguments into a vector of expressions.
     pub fn to_expressions(self) -> Vec<Expression> {
         match self {
             Self::Tuple(expressions) => expressions.to_expressions(),
@@ -113,10 +130,12 @@ impl Arguments {
         }
     }
 
+    /// Adds an argument to these arguments, converting to a tuple if needed.
     pub fn with_argument<T: Into<Expression>>(self, argument: T) -> Self {
         TupleArguments::from(self).with_argument(argument).into()
     }
 
+    /// Removes all comments from these arguments.
     pub fn clear_comments(&mut self) {
         match self {
             Arguments::Tuple(tuple) => tuple.clear_comments(),
@@ -124,6 +143,7 @@ impl Arguments {
         }
     }
 
+    /// Removes all whitespace from these arguments.
     pub fn clear_whitespaces(&mut self) {
         match self {
             Arguments::Tuple(tuple) => tuple.clear_whitespaces(),
@@ -131,6 +151,7 @@ impl Arguments {
         }
     }
 
+    /// Replaces referenced tokens with the actual content from the source code.
     pub(crate) fn replace_referenced_tokens(&mut self, code: &str) {
         match self {
             Arguments::Tuple(tuple) => tuple.replace_referenced_tokens(code),
@@ -138,6 +159,7 @@ impl Arguments {
         }
     }
 
+    /// Shifts token line numbers by the specified amount.
     pub(crate) fn shift_token_line(&mut self, amount: isize) {
         match self {
             Arguments::Tuple(tuple) => tuple.shift_token_line(amount),
@@ -145,6 +167,7 @@ impl Arguments {
         }
     }
 
+    /// Filters comments using the provided predicate.
     pub(crate) fn filter_comments(&mut self, filter: impl Fn(&super::Trivia) -> bool) {
         match self {
             Arguments::Tuple(tuple) => tuple.filter_comments(filter),

--- a/src/nodes/expressions/binary.rs
+++ b/src/nodes/expressions/binary.rs
@@ -1,22 +1,39 @@
 use crate::nodes::{Expression, FunctionReturnType, Token, Type};
 
+/// Represents binary operators used in a binary expression.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinaryOperator {
+    /// Logical AND operator (`and`)
     And,
+    /// Logical OR operator (`or`)
     Or,
+    /// Equality operator (`==`)
     Equal,
+    /// Inequality operator (`~=`)
     NotEqual,
+    /// Less than operator (`<`)
     LowerThan,
+    /// Less than or equal operator (`<=`)
     LowerOrEqualThan,
+    /// Greater than operator (`>`)
     GreaterThan,
+    /// Greater than or equal operator (`>=`)
     GreaterOrEqualThan,
+    /// Addition operator (`+`)
     Plus,
+    /// Subtraction operator (`-`)
     Minus,
+    /// Multiplication operator (`*`)
     Asterisk,
+    /// Division operator (`/`)
     Slash,
+    /// Integer division operator (`//`)
     DoubleSlash,
+    /// Modulo operator (`%`)
     Percent,
+    /// Exponentiation operator (`^`)
     Caret,
+    /// String concatenation operator (`..`)
     Concat,
 }
 
@@ -111,26 +128,39 @@ fn ends_with_type_cast_to_type_name_without_type_parameters(expression: &Express
 }
 
 impl BinaryOperator {
+    /// Checks if this operator has higher precedence than another operator.
     #[inline]
     pub fn precedes(&self, other: Self) -> bool {
         self.get_precedence() > other.get_precedence()
     }
 
+    /// Checks if this operator has higher precedence than unary expressions.
+    ///
+    /// Currently only the exponentiation operator (`^`) has this property.
     #[inline]
     pub fn precedes_unary_expression(&self) -> bool {
         matches!(self, Self::Caret)
     }
 
+    /// Determines if this operator is left associative.
+    ///
+    /// Left associative operators like `+` evaluate expressions from left to right:
+    /// `a + b + c` is evaluated as `(a + b) + c`.
     #[inline]
     pub fn is_left_associative(&self) -> bool {
         !matches!(self, Self::Caret | Self::Concat)
     }
 
+    /// Determines if this operator is right associative.
+    ///
+    /// Right associative operators like `^` evaluate expressions from right to left:
+    /// `a ^ b ^ c` is evaluated as `a ^ (b ^ c)`.
     #[inline]
     pub fn is_right_associative(&self) -> bool {
         matches!(self, Self::Caret | Self::Concat)
     }
 
+    /// Determines if the left operand needs parentheses when generating code.
     pub fn left_needs_parentheses(&self, left: &Expression) -> bool {
         let needs_parentheses = match left {
             Expression::Binary(left) => {
@@ -150,6 +180,7 @@ impl BinaryOperator {
                 && ends_with_type_cast_to_type_name_without_type_parameters(left))
     }
 
+    /// Determines if the right operand needs parentheses when generating code.
     pub fn right_needs_parentheses(&self, right: &Expression) -> bool {
         match right {
             Expression::Binary(right) => {
@@ -164,6 +195,7 @@ impl BinaryOperator {
         }
     }
 
+    /// Returns the string representation of this operator.
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::And => "and",
@@ -185,6 +217,7 @@ impl BinaryOperator {
         }
     }
 
+    /// Returns the precedence level of this operator (higher value = higher precedence).
     fn get_precedence(&self) -> u8 {
         match self {
             Self::Or => 0,
@@ -203,6 +236,7 @@ impl BinaryOperator {
     }
 }
 
+/// Represents a binary operation in expressions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BinaryExpression {
     operator: BinaryOperator,
@@ -212,6 +246,7 @@ pub struct BinaryExpression {
 }
 
 impl BinaryExpression {
+    /// Creates a new binary expression with the given operator and operands.
     pub fn new<T: Into<Expression>, U: Into<Expression>>(
         operator: BinaryOperator,
         left: T,
@@ -225,46 +260,55 @@ impl BinaryExpression {
         }
     }
 
+    /// Associates a token with this expression.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Associates a token with this expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a mutable reference to the left operand.
     #[inline]
     pub fn mutate_left(&mut self) -> &mut Expression {
         &mut self.left
     }
 
+    /// Returns a mutable reference to the right operand.
     #[inline]
     pub fn mutate_right(&mut self) -> &mut Expression {
         &mut self.right
     }
 
+    /// Returns a reference to the left operand.
     #[inline]
     pub fn left(&self) -> &Expression {
         &self.left
     }
 
+    /// Returns a reference to the right operand.
     #[inline]
     pub fn right(&self) -> &Expression {
         &self.right
     }
 
+    /// Returns the binary operator.
     #[inline]
     pub fn operator(&self) -> BinaryOperator {
         self.operator
     }
 
+    /// Changes the operator and updates the associated token's content if present.
     #[inline]
     pub fn set_operator(&mut self, operator: BinaryOperator) {
         if self.operator == operator {

--- a/src/nodes/expressions/field.rs
+++ b/src/nodes/expressions/field.rs
@@ -1,5 +1,10 @@
 use crate::nodes::{Identifier, Prefix, Token};
 
+/// Represents a field access expression.
+///
+/// A field access expression accesses a member of a table using dot notation,
+/// such as `table.field`. It consists of a prefix (the table being accessed)
+/// and a field identifier.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FieldExpression {
     prefix: Prefix,
@@ -8,6 +13,7 @@ pub struct FieldExpression {
 }
 
 impl FieldExpression {
+    /// Creates a new field access expression.
     pub fn new<IntoPrefix: Into<Prefix>, IntoIdentifier: Into<Identifier>>(
         prefix: IntoPrefix,
         field: IntoIdentifier,
@@ -19,31 +25,37 @@ impl FieldExpression {
         }
     }
 
+    /// Attaches a token to this field expression and returns the updated expression.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Attaches a token to this field expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the token attached to this field expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a reference to the prefix of this field expression.
     #[inline]
     pub fn get_prefix(&self) -> &Prefix {
         &self.prefix
     }
 
+    /// Returns a reference to the field identifier of this field expression.
     #[inline]
     pub fn get_field(&self) -> &Identifier {
         &self.field
     }
 
+    /// Returns a mutable reference to the prefix of this field expression.
     pub fn mutate_prefix(&mut self) -> &mut Prefix {
         &mut self.prefix
     }

--- a/src/nodes/expressions/function.rs
+++ b/src/nodes/expressions/function.rs
@@ -3,6 +3,16 @@ use crate::nodes::{
     TypedIdentifier,
 };
 
+/// Represents a function expression.
+///
+/// A function expression defines an anonymous function with parameters,
+/// a body, and optional features like variadics, return types, and generic parameters.
+///
+/// ```lua
+/// local add = function(a: number, b: number): number
+///     return a + b
+/// end
+/// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FunctionExpression {
     block: Block,
@@ -15,6 +25,7 @@ pub struct FunctionExpression {
 }
 
 impl FunctionExpression {
+    /// Creates a new function expression with the given block, parameters, and variadic flag.
     pub fn new(block: Block, parameters: Vec<TypedIdentifier>, is_variadic: bool) -> Self {
         Self {
             block,
@@ -27,6 +38,7 @@ impl FunctionExpression {
         }
     }
 
+    /// Creates a new function expression from a block with no parameters.
     pub fn from_block<B: Into<Block>>(block: B) -> Self {
         Self {
             block: block.into(),
@@ -39,52 +51,66 @@ impl FunctionExpression {
         }
     }
 
+    /// Sets the parameters of this function expression.
     pub fn with_parameters(mut self, parameters: Vec<TypedIdentifier>) -> Self {
         self.parameters = parameters;
         self
     }
 
+    /// Adds a parameter to this function expression.
     pub fn with_parameter(mut self, parameter: impl Into<TypedIdentifier>) -> Self {
         self.parameters.push(parameter.into());
         self
     }
 
+    /// Sets the variadic type of this function expression.
+    ///
+    /// This also marks the function as variadic if it is not already.
     pub fn with_variadic_type(mut self, r#type: impl Into<FunctionVariadicType>) -> Self {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
         self
     }
 
+    /// Sets the return type of this function expression.
     pub fn with_return_type(mut self, return_type: impl Into<FunctionReturnType>) -> Self {
         self.return_type = Some(return_type.into());
         self
     }
 
+    /// Sets the return type of this function expression.
     #[inline]
     pub fn set_return_type(&mut self, return_type: impl Into<FunctionReturnType>) {
         self.return_type = Some(return_type.into());
     }
 
+    /// Returns a reference to the return type of this function expression, if any.
     #[inline]
     pub fn get_return_type(&self) -> Option<&FunctionReturnType> {
         self.return_type.as_ref()
     }
 
+    /// Returns whether this function expression has a return type.
     #[inline]
     pub fn has_return_type(&self) -> bool {
         self.return_type.is_some()
     }
 
+    /// Returns a mutable reference to the return type of this function expression, if any.
     #[inline]
     pub fn mutate_return_type(&mut self) -> Option<&mut FunctionReturnType> {
         self.return_type.as_mut()
     }
 
+    /// Marks this function expression as variadic and returns the updated expression.
     pub fn variadic(mut self) -> Self {
         self.is_variadic = true;
         self
     }
 
+    /// Sets whether this function expression is variadic.
+    ///
+    /// If set to false, the variadic type is cleared if present.
     pub fn set_variadic(&mut self, is_variadic: bool) {
         self.is_variadic = is_variadic;
         if !is_variadic && self.variadic_type.is_some() {
@@ -92,106 +118,131 @@ impl FunctionExpression {
         }
     }
 
+    /// Sets the variadic type of this function expression.
+    ///
+    /// This also marks the function as variadic if it is not already.
     pub fn set_variadic_type(&mut self, r#type: impl Into<FunctionVariadicType>) {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
     }
 
+    /// Returns a reference to the variadic type of this function expression, if any.
     #[inline]
     pub fn get_variadic_type(&self) -> Option<&FunctionVariadicType> {
         self.variadic_type.as_ref()
     }
 
+    /// Returns whether this function expression has a variadic type.
     #[inline]
     pub fn has_variadic_type(&self) -> bool {
         self.variadic_type.is_some()
     }
 
+    /// Returns a mutable reference to the variadic type of this function expression, if any.
     #[inline]
     pub fn mutate_variadic_type(&mut self) -> Option<&mut FunctionVariadicType> {
         self.variadic_type.as_mut()
     }
 
+    /// Sets the generic parameters of this function expression and returns the updated expression.
     pub fn with_generic_parameters(mut self, generic_parameters: GenericParameters) -> Self {
         self.generic_parameters = Some(generic_parameters);
         self
     }
 
+    /// Sets the generic parameters of this function expression.
     #[inline]
     pub fn set_generic_parameters(&mut self, generic_parameters: GenericParameters) {
         self.generic_parameters = Some(generic_parameters);
     }
 
+    /// Returns a reference to the generic parameters of this function expression, if any.
     #[inline]
     pub fn get_generic_parameters(&self) -> Option<&GenericParameters> {
         self.generic_parameters.as_ref()
     }
 
+    /// Returns whether this function expression has generic parameters.
     #[inline]
     pub fn is_generic(&self) -> bool {
         self.generic_parameters.is_some()
     }
 
+    /// Associates a token with this function expression.
     pub fn with_tokens(mut self, tokens: FunctionBodyTokens) -> Self {
         self.tokens = Some(tokens.into());
         self
     }
 
+    /// Associates a token with this function expression.
     #[inline]
     pub fn set_tokens(&mut self, tokens: FunctionBodyTokens) {
         self.tokens = Some(tokens.into());
     }
 
+    /// Returns a reference to the token attached to this function expression, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionBodyTokens> {
         self.tokens.as_ref().map(|tokens| tokens.as_ref())
     }
 
+    /// Returns a reference to the block of this function expression.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns a reference to the parameters of this function expression.
     #[inline]
     pub fn get_parameters(&self) -> &Vec<TypedIdentifier> {
         &self.parameters
     }
 
+    /// Returns an iterator over the parameters of this function expression.
     #[inline]
     pub fn iter_parameters(&self) -> impl Iterator<Item = &TypedIdentifier> {
         self.parameters.iter()
     }
 
+    /// Returns a mutable iterator over the parameters of this function expression.
     #[inline]
     pub fn iter_mut_parameters(&mut self) -> impl Iterator<Item = &mut TypedIdentifier> {
         self.parameters.iter_mut()
     }
 
+    /// Returns whether this function expression is variadic.
     #[inline]
     pub fn is_variadic(&self) -> bool {
         self.is_variadic
     }
 
+    /// Returns a mutable reference to the block of this function expression.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns a mutable reference to the parameters of this function expression.
     #[inline]
     pub fn mutate_parameters(&mut self) -> &mut Vec<TypedIdentifier> {
         &mut self.parameters
     }
 
+    /// Returns the number of parameters of this function expression.
     #[inline]
     pub fn parameters_count(&self) -> usize {
         self.parameters.len()
     }
 
+    /// Returns whether this function expression has parameters.
     #[inline]
     pub fn has_parameters(&self) -> bool {
         !self.parameters.is_empty()
     }
 
+    /// Removes all type information from this function expression.
+    ///
+    /// This includes return type, variadic type, generic parameters, and parameter types.
     pub fn clear_types(&mut self) {
         self.return_type.take();
         self.variadic_type.take();

--- a/src/nodes/expressions/if_expression.rs
+++ b/src/nodes/expressions/if_expression.rs
@@ -2,6 +2,7 @@ use crate::nodes::Token;
 
 use super::Expression;
 
+/// Represents an if expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfExpression {
     condition: Expression,
@@ -12,6 +13,7 @@ pub struct IfExpression {
 }
 
 impl IfExpression {
+    /// Creates a new if expression with the given condition, result, and else result.
     pub fn new<E: Into<Expression>, E2: Into<Expression>, E3: Into<Expression>>(
         condition: E,
         result: E2,
@@ -26,11 +28,13 @@ impl IfExpression {
         }
     }
 
+    /// Attaches tokens to this if expression.
     pub fn with_tokens(mut self, tokens: IfExpressionTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Adds an elseif branch to this if expression.
     pub fn with_branch<E: Into<Expression>, E2: Into<Expression>>(
         mut self,
         condition: E,
@@ -41,66 +45,79 @@ impl IfExpression {
         self
     }
 
+    /// Adds an elseif branch to this if expression.
     #[inline]
     pub fn push_branch(&mut self, branch: ElseIfExpressionBranch) {
         self.branches.push(branch);
     }
 
+    /// Attaches tokens to this if expression.
     #[inline]
     pub fn set_tokens(&mut self, tokens: IfExpressionTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns a reference to the tokens attached to this if expression, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&IfExpressionTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a reference to the condition of this if expression.
     #[inline]
     pub fn get_condition(&self) -> &Expression {
         &self.condition
     }
 
+    /// Returns a mutable reference to the condition of this if expression.
     #[inline]
     pub fn mutate_condition(&mut self) -> &mut Expression {
         &mut self.condition
     }
 
+    /// Returns a reference to the result of this if expression (returned when condition is true).
     #[inline]
     pub fn get_result(&self) -> &Expression {
         &self.result
     }
 
+    /// Returns a mutable reference to the result of this if expression.
     #[inline]
     pub fn mutate_result(&mut self) -> &mut Expression {
         &mut self.result
     }
 
+    /// Returns a reference to the else result of this if expression.
     #[inline]
     pub fn get_else_result(&self) -> &Expression {
         &self.else_result
     }
 
+    /// Returns a mutable reference to the else result of this if expression.
     #[inline]
     pub fn mutate_else_result(&mut self) -> &mut Expression {
         &mut self.else_result
     }
 
+    /// Returns whether this if expression has any elseif branches.
     #[inline]
     pub fn has_elseif_branch(&self) -> bool {
         !self.branches.is_empty()
     }
 
+    /// Returns an iterator over the elseif branches of this if expression.
     #[inline]
     pub fn iter_branches(&self) -> impl Iterator<Item = &ElseIfExpressionBranch> {
         self.branches.iter()
     }
 
+    /// Removes all elseif branches from this if expression.
     #[inline]
     pub fn clear_elseif_branches(&mut self) {
         self.branches.clear();
     }
 
+    /// Retains only the elseif branches that satisfy the predicate.
     #[inline]
     pub fn retain_elseif_branches_mut(
         &mut self,
@@ -109,6 +126,7 @@ impl IfExpression {
         self.branches.retain_mut(filter);
     }
 
+    /// Removes an elseif branch at the specified index and returns it.
     pub fn remove_branch(&mut self, index: usize) -> Option<ElseIfExpressionBranch> {
         if index < self.branches.len() {
             Some(self.branches.remove(index))
@@ -117,6 +135,7 @@ impl IfExpression {
         }
     }
 
+    /// Returns a mutable iterator over the elseif branches of this if expression.
     #[inline]
     pub fn iter_mut_branches(&mut self) -> impl Iterator<Item = &mut ElseIfExpressionBranch> {
         self.branches.iter_mut()
@@ -125,6 +144,9 @@ impl IfExpression {
     super::impl_token_fns!(iter = [tokens, branches]);
 }
 
+/// Represents an elseif branch in an if expression.
+///
+/// Each branch has a condition and a result expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ElseIfExpressionBranch {
     condition: Expression,
@@ -133,6 +155,7 @@ pub struct ElseIfExpressionBranch {
 }
 
 impl ElseIfExpressionBranch {
+    /// Creates a new elseif branch with the given condition and result.
     pub fn new<E: Into<Expression>, E2: Into<Expression>>(condition: E, result: E2) -> Self {
         Self {
             condition: condition.into(),
@@ -141,36 +164,43 @@ impl ElseIfExpressionBranch {
         }
     }
 
+    /// Attaches tokens to this elseif branch.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ElseIfExpressionBranchTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns a reference to the tokens attached to this elseif branch, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ElseIfExpressionBranchTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a reference to the condition of this elseif branch.
     #[inline]
     pub fn get_condition(&self) -> &Expression {
         &self.condition
     }
 
+    /// Returns a mutable reference to the condition of this elseif branch.
     #[inline]
     pub fn mutate_condition(&mut self) -> &mut Expression {
         &mut self.condition
     }
 
+    /// Returns a reference to the result of this elseif branch.
     #[inline]
     pub fn get_result(&self) -> &Expression {
         &self.result
     }
 
+    /// Returns a mutable reference to the result of this elseif branch.
     #[inline]
     pub fn mutate_result(&mut self) -> &mut Expression {
         &mut self.result
     }
 
+    /// Consumes this branch and returns a tuple of (condition, result).
     pub fn into_expressions(self) -> (Expression, Expression) {
         (self.condition, self.result)
     }
@@ -178,10 +208,14 @@ impl ElseIfExpressionBranch {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains token information for an if expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfExpressionTokens {
+    /// The 'if' keyword token
     pub r#if: Token,
+    /// The 'then' keyword token
     pub then: Token,
+    /// The 'else' keyword token
     pub r#else: Token,
 }
 
@@ -189,9 +223,12 @@ impl IfExpressionTokens {
     super::impl_token_fns!(target = [r#if, then, r#else]);
 }
 
+/// Contains token information for an elseif branch in an if expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ElseIfExpressionBranchTokens {
+    /// The 'elseif' keyword token
     pub elseif: Token,
+    /// The 'then' keyword token
     pub then: Token,
 }
 

--- a/src/nodes/expressions/index.rs
+++ b/src/nodes/expressions/index.rs
@@ -1,8 +1,11 @@
 use crate::nodes::{Expression, Prefix, Token};
 
+/// Contains token information for an index expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IndexExpressionTokens {
+    /// The opening bracket token
     pub opening_bracket: Token,
+    /// The closing bracket token
     pub closing_bracket: Token,
 }
 
@@ -10,6 +13,11 @@ impl IndexExpressionTokens {
     super::impl_token_fns!(target = [opening_bracket, closing_bracket]);
 }
 
+/// Represents a table index access expression.
+///
+/// An index expression accesses a value in a table using square bracket notation,
+/// such as `table[key]`. It consists of a prefix (the table being accessed)
+/// and an index expression that evaluates to the key.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IndexExpression {
     prefix: Prefix,
@@ -18,6 +26,7 @@ pub struct IndexExpression {
 }
 
 impl IndexExpression {
+    /// Creates a new index expression with the given prefix and index expression.
     pub fn new<P: Into<Prefix>, E: Into<Expression>>(prefix: P, expression: E) -> Self {
         Self {
             prefix: prefix.into(),
@@ -26,36 +35,43 @@ impl IndexExpression {
         }
     }
 
+    /// Attaches tokens to this index expression.
     pub fn with_tokens(mut self, tokens: IndexExpressionTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Attaches tokens to this index expression.
     #[inline]
     pub fn set_tokens(&mut self, tokens: IndexExpressionTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns a reference to the tokens attached to this index expression, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&IndexExpressionTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a reference to the prefix of this index expression.
     #[inline]
     pub fn get_prefix(&self) -> &Prefix {
         &self.prefix
     }
 
+    /// Returns a reference to the index expression of this index expression.
     #[inline]
     pub fn get_index(&self) -> &Expression {
         &self.index
     }
 
+    /// Returns a mutable reference to the prefix of this index expression.
     #[inline]
     pub fn mutate_prefix(&mut self) -> &mut Prefix {
         &mut self.prefix
     }
 
+    /// Returns a mutable reference to the index expression of this index expression.
     #[inline]
     pub fn mutate_index(&mut self) -> &mut Expression {
         &mut self.index

--- a/src/nodes/expressions/interpolated_string.rs
+++ b/src/nodes/expressions/interpolated_string.rs
@@ -75,7 +75,7 @@ impl StringSegment {
 /// when the interpolated string is evaluated.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValueSegment {
-    value: Expression,
+    value: Box<Expression>,
     tokens: Option<ValueSegmentTokens>,
 }
 
@@ -83,7 +83,7 @@ impl ValueSegment {
     /// Creates a new value segment with the given expression.
     pub fn new(value: impl Into<Expression>) -> Self {
         Self {
-            value: value.into(),
+            value: Box::new(value.into()),
             tokens: None,
         }
     }

--- a/src/nodes/expressions/interpolated_string.rs
+++ b/src/nodes/expressions/interpolated_string.rs
@@ -4,6 +4,10 @@ use crate::nodes::{StringError, Token, Trivia};
 
 use super::{string_utils, Expression};
 
+/// Represents a string segment in an interpolated string.
+///
+/// String segments are the literal text parts of an interpolated string,
+/// appearing between expression segments.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringSegment {
     value: String,
@@ -11,10 +15,12 @@ pub struct StringSegment {
 }
 
 impl StringSegment {
+    /// Creates a new string segment from a string value, processing escape sequences.
     pub fn new(value: impl AsRef<str>) -> Result<Self, StringError> {
         string_utils::read_escaped_string(value.as_ref().char_indices(), None).map(Self::from_value)
     }
 
+    /// Creates a new string segment from a string value without processing escapes.
     pub fn from_value(value: impl Into<String>) -> Self {
         Self {
             value: value.into(),
@@ -22,19 +28,23 @@ impl StringSegment {
         }
     }
 
+    /// Attaches a token to this string segment and returns the updated segment.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Attaches a token to this string segment.
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the token attached to this string segment, if any.
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a reference to the string value of this segment.
     pub fn get_value(&self) -> &str {
         self.value.as_str()
     }
@@ -44,11 +54,13 @@ impl StringSegment {
         self.token = None;
     }
 
+    /// Returns the length of the string value in this segment.
     #[inline]
     pub fn len(&self) -> usize {
         self.value.len()
     }
 
+    /// Returns whether the string value in this segment is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.value.is_empty()
@@ -57,6 +69,10 @@ impl StringSegment {
     super::impl_token_fns!(iter = [token]);
 }
 
+/// Represents an expression segment in an interpolated string.
+///
+/// Value segments contain expressions that are evaluated and converted to strings
+/// when the interpolated string is evaluated.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValueSegment {
     value: Expression,
@@ -64,6 +80,7 @@ pub struct ValueSegment {
 }
 
 impl ValueSegment {
+    /// Creates a new value segment with the given expression.
     pub fn new(value: impl Into<Expression>) -> Self {
         Self {
             value: value.into(),
@@ -71,23 +88,28 @@ impl ValueSegment {
         }
     }
 
+    /// Attaches tokens to this value segment.
     pub fn with_tokens(mut self, tokens: ValueSegmentTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Attaches tokens to this value segment.
     pub fn set_tokens(&mut self, tokens: ValueSegmentTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns a reference to the tokens attached to this value segment, if any.
     pub fn get_tokens(&self) -> Option<&ValueSegmentTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a reference to the expression in this value segment.
     pub fn get_expression(&self) -> &Expression {
         &self.value
     }
 
+    /// Returns a mutable reference to the expression in this value segment.
     pub fn mutate_expression(&mut self) -> &mut Expression {
         &mut self.value
     }
@@ -95,9 +117,12 @@ impl ValueSegment {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains token information for a value segment in an interpolated string.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ValueSegmentTokens {
+    /// The opening brace token (`{`)
     pub opening_brace: Token,
+    /// The closing brace token (`}`)
     pub closing_brace: Token,
 }
 
@@ -105,13 +130,17 @@ impl ValueSegmentTokens {
     super::impl_token_fns!(target = [opening_brace, closing_brace]);
 }
 
+/// Represents a segment in an interpolated string.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InterpolationSegment {
+    /// A literal string segment
     String(StringSegment),
+    /// An expression value segment
     Value(ValueSegment),
 }
 
 impl InterpolationSegment {
+    /// Clears all comments from the tokens in this node.
     pub fn clear_comments(&mut self) {
         match self {
             InterpolationSegment::String(segment) => segment.clear_comments(),
@@ -119,6 +148,7 @@ impl InterpolationSegment {
         }
     }
 
+    /// Clears all whitespaces information from the tokens in this node.
     pub fn clear_whitespaces(&mut self) {
         match self {
             InterpolationSegment::String(segment) => segment.clear_whitespaces(),
@@ -184,6 +214,7 @@ impl From<String> for InterpolationSegment {
     }
 }
 
+/// Represents an interpolated string expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InterpolatedStringExpression {
     segments: Vec<InterpolationSegment>,
@@ -191,6 +222,7 @@ pub struct InterpolatedStringExpression {
 }
 
 impl InterpolatedStringExpression {
+    /// Creates a new interpolated string expression with the given segments.
     pub fn new(segments: Vec<InterpolationSegment>) -> Self {
         Self {
             segments,
@@ -198,43 +230,55 @@ impl InterpolatedStringExpression {
         }
     }
 
+    /// Creates an empty interpolated string expression with no segments.
     pub fn empty() -> Self {
         Self::new(Vec::default())
     }
 
+    /// Adds a segment to this interpolated string expression and returns the updated expression.
     pub fn with_segment(mut self, segment: impl Into<InterpolationSegment>) -> Self {
         self.push_segment(segment);
         self
     }
 
+    /// Attaches tokens to this interpolated string expression.
     pub fn with_tokens(mut self, tokens: InterpolatedStringTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Returns a reference to the tokens attached to this interpolated string expression, if any.
     pub fn get_tokens(&self) -> Option<&InterpolatedStringTokens> {
         self.tokens.as_ref()
     }
 
+    /// Attaches tokens to this interpolated string expression.
     pub fn set_tokens(&mut self, tokens: InterpolatedStringTokens) {
         self.tokens = Some(tokens);
     }
 
     super::impl_token_fns!(iter = [tokens, segments]);
 
+    /// Returns an iterator over the segments in this interpolated string expression.
     pub fn iter_segments(&self) -> impl Iterator<Item = &InterpolationSegment> {
         self.segments.iter()
     }
 
+    /// Returns a mutable iterator over the segments in this interpolated string expression.
     pub fn iter_mut_segments(&mut self) -> impl Iterator<Item = &mut InterpolationSegment> {
         self.segments.iter_mut()
     }
 
+    /// Returns the number of segments in this interpolated string expression.
     #[inline]
     pub fn len(&self) -> usize {
         self.segments.len()
     }
 
+    /// Returns whether this interpolated string expression is empty.
+    ///
+    /// An interpolated string is considered empty if it has no segments or all of its
+    /// string segments are empty and it has no value segments.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.segments.iter().all(|segment| match segment {
@@ -243,6 +287,7 @@ impl InterpolatedStringExpression {
         })
     }
 
+    /// Adds a segment to this interpolated string expression.
     pub fn push_segment(&mut self, segment: impl Into<InterpolationSegment>) {
         let new_segment = segment.into();
         match new_segment {
@@ -272,9 +317,12 @@ impl FromIterator<InterpolationSegment> for InterpolatedStringExpression {
     }
 }
 
+/// Contains token information for an interpolated string expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InterpolatedStringTokens {
+    /// The opening backtick token
     pub opening_tick: Token,
+    /// The closing backtick token
     pub closing_tick: Token,
 }
 

--- a/src/nodes/expressions/mod.rs
+++ b/src/nodes/expressions/mod.rs
@@ -34,43 +34,66 @@ use super::impl_token_fns;
 
 use std::num::FpCategory;
 
+/// Represents all possible expressions.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Expression {
+    /// A binary operation (e.g., `a + b`, `x == y`)
     Binary(Box<BinaryExpression>),
+    /// A function call (e.g., `print("Hello")`)
     Call(Box<FunctionCall>),
+    /// The `false` keyword
     False(Option<Token>),
+    /// A field access (e.g., `object.field`)
     Field(Box<FieldExpression>),
+    /// A function definition (e.g., `function(...) ... end`)
     Function(FunctionExpression),
+    /// An identifier (e.g., variable name)
     Identifier(Identifier),
+    /// An if expression (e.g., `if a then b else c`)
     If(Box<IfExpression>),
+    /// A table index access (e.g., `table[key]`)
     Index(Box<IndexExpression>),
+    /// The `nil` keyword
     Nil(Option<Token>),
+    /// A numeric literal (e.g., `42`, `3.14`)
     Number(NumberExpression),
+    /// An expression in parentheses (e.g., `(1 + 2)`)
     Parenthese(Box<ParentheseExpression>),
+    /// A string literal (e.g., `"hello"`)
     String(StringExpression),
+    /// An interpolated string (e.g., `` `Hello ${name}` ``)
     InterpolatedString(InterpolatedStringExpression),
+    /// A table constructor (e.g., `{key = value, [expr] = value}`)
     Table(TableExpression),
+    /// The `true` keyword
     True(Option<Token>),
+    /// A unary operation (e.g., `-x`, `not condition`)
     Unary(Box<UnaryExpression>),
+    /// The variable arguments symbol (`...`)
     VariableArguments(Option<Token>),
+    /// A type cast expression (e.g., `value :: Type`)
     TypeCast(TypeCastExpression),
 }
 
 impl Expression {
+    /// Creates a new nil expression.
     #[inline]
     pub fn nil() -> Self {
         Self::Nil(None)
     }
 
+    /// Creates a new variable arguments expression.
     #[inline]
     pub fn variable_arguments() -> Self {
         Self::VariableArguments(None)
     }
 
+    /// Creates a new identifier expression.
     pub fn identifier<S: Into<Identifier>>(identifier: S) -> Self {
         Self::Identifier(identifier.into())
     }
 
+    /// Wraps this expression in parentheses.
     pub fn in_parentheses(self) -> Self {
         Self::Parenthese(ParentheseExpression::new(self).into())
     }

--- a/src/nodes/expressions/mod.rs
+++ b/src/nodes/expressions/mod.rs
@@ -46,7 +46,7 @@ pub enum Expression {
     /// A field access (e.g., `object.field`)
     Field(Box<FieldExpression>),
     /// A function definition (e.g., `function(...) ... end`)
-    Function(FunctionExpression),
+    Function(Box<FunctionExpression>),
     /// An identifier (e.g., variable name)
     Identifier(Identifier),
     /// An if expression (e.g., `if a then b else c`)
@@ -236,7 +236,7 @@ impl From<FieldExpression> for Expression {
 
 impl From<FunctionExpression> for Expression {
     fn from(function: FunctionExpression) -> Self {
-        Expression::Function(function)
+        Expression::Function(Box::new(function))
     }
 }
 
@@ -285,11 +285,11 @@ impl From<BinaryNumber> for Expression {
 impl From<Prefix> for Expression {
     fn from(prefix: Prefix) -> Self {
         match prefix {
-            Prefix::Call(call) => Self::Call(Box::new(call)),
+            Prefix::Call(call) => Self::Call(call),
             Prefix::Field(field) => Self::Field(field),
             Prefix::Identifier(name) => Self::Identifier(name),
             Prefix::Index(index) => Self::Index(index),
-            Prefix::Parenthese(expression) => expression.into(),
+            Prefix::Parenthese(expression) => (*expression).into(),
         }
     }
 }

--- a/src/nodes/expressions/number.rs
+++ b/src/nodes/expressions/number.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use crate::nodes::{Token, Trivia};
 
+/// Represents a decimal number.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DecimalNumber {
     float: f64,
@@ -13,6 +14,7 @@ pub struct DecimalNumber {
 impl Eq for DecimalNumber {}
 
 impl DecimalNumber {
+    /// Creates a new decimal number with the given floating-point value.
     pub fn new(value: f64) -> Self {
         Self {
             float: value,
@@ -21,11 +23,13 @@ impl DecimalNumber {
         }
     }
 
+    /// Attaches a token to this decimal number.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Attaches a token to this decimal number.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
@@ -36,31 +40,40 @@ impl DecimalNumber {
         self.token.as_ref()
     }
 
+    /// Sets an exponent for this decimal number and returns the updated number.
+    ///
+    /// The `is_uppercase` parameter determines whether the exponent uses uppercase 'E'
+    /// or lowercase 'e' notation.
     pub fn with_exponent(mut self, exponent: i64, is_uppercase: bool) -> Self {
         self.exponent.replace((exponent, is_uppercase));
         self
     }
 
+    /// Sets whether the exponent notation should use uppercase 'E' or lowercase 'e'.
     #[inline]
     pub fn set_uppercase(&mut self, is_uppercase: bool) {
         self.exponent = self.exponent.map(|(exponent, _)| (exponent, is_uppercase));
     }
 
+    /// Returns the raw floating-point value of this decimal number.
     #[inline]
     pub(crate) fn get_raw_float(&self) -> f64 {
         self.float
     }
 
+    /// Returns whether the exponent notation uses uppercase 'E', if an exponent is present.
     #[inline]
     pub fn is_uppercase(&self) -> Option<bool> {
         self.exponent.map(|(_, uppercase)| uppercase)
     }
 
+    /// Returns the exponent value, if one is present.
     #[inline]
     pub fn get_exponent(&self) -> Option<i64> {
         self.exponent.map(|(exponent, _)| exponent)
     }
 
+    /// Computes the actual numerical value represented by this decimal number.
     pub fn compute_value(&self) -> f64 {
         self.float
     }
@@ -68,6 +81,10 @@ impl DecimalNumber {
     super::impl_token_fns!(iter = [token]);
 }
 
+/// Represents a hexadecimal number.
+///
+/// Hexadecimal numbers are prefixed with '0x' or '0X' and can include
+/// optional binary exponents.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HexNumber {
     integer: u64,
@@ -77,6 +94,10 @@ pub struct HexNumber {
 }
 
 impl HexNumber {
+    /// Creates a new hexadecimal number with the given integer value.
+    ///
+    /// The `is_x_uppercase` parameter determines whether the hexadecimal prefix
+    /// uses uppercase 'X' (0X) or lowercase 'x' (0x).
     pub fn new(integer: u64, is_x_uppercase: bool) -> Self {
         Self {
             integer,
@@ -86,51 +107,64 @@ impl HexNumber {
         }
     }
 
+    /// Attaches a token to this hexadecimal number and returns the updated number.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Attaches a token to this hexadecimal number.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the token attached to this hexadecimal number, if any.
     #[inline]
     fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Sets a binary exponent for this hexadecimal number and returns the updated number.
+    ///
+    /// The `is_uppercase` parameter determines whether the exponent uses uppercase 'P'
+    /// or lowercase 'p' notation.
     pub fn with_exponent(mut self, exponent: u32, is_uppercase: bool) -> Self {
         self.exponent.replace((exponent, is_uppercase));
         self
     }
 
+    /// Sets whether the hexadecimal prefix and exponent notation should use uppercase letters.
     pub fn set_uppercase(&mut self, is_uppercase: bool) {
         self.exponent = self.exponent.map(|(value, _)| (value, is_uppercase));
         self.is_x_uppercase = is_uppercase;
     }
 
+    /// Returns whether the hexadecimal prefix uses uppercase 'X' (0X) or lowercase 'x' (0x).
     #[inline]
     pub fn is_x_uppercase(&self) -> bool {
         self.is_x_uppercase
     }
 
+    /// Returns whether the exponent notation uses uppercase 'P', if an exponent is present.
     #[inline]
     pub fn is_exponent_uppercase(&self) -> Option<bool> {
         self.exponent.map(|(_, uppercase)| uppercase)
     }
 
+    /// Returns the raw integer value of this hexadecimal number.
     #[inline]
     pub fn get_raw_integer(&self) -> u64 {
         self.integer
     }
 
+    /// Returns the exponent value, if one is present.
     #[inline]
     pub fn get_exponent(&self) -> Option<u32> {
         self.exponent.map(|(value, _)| value)
     }
 
+    /// Computes the actual numerical value represented by this hexadecimal number.
     pub fn compute_value(&self) -> f64 {
         if let Some((exponent, _)) = self.exponent {
             (self.integer * 2_u64.pow(exponent)) as f64
@@ -142,6 +176,9 @@ impl HexNumber {
     super::impl_token_fns!(iter = [token]);
 }
 
+/// Represents a binary number.
+///
+/// Binary numbers are prefixed with '0b' or '0B' and consist of 0s and 1s.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BinaryNumber {
     value: u64,
@@ -150,6 +187,10 @@ pub struct BinaryNumber {
 }
 
 impl BinaryNumber {
+    /// Creates a new binary number with the given value.
+    ///
+    /// The `is_b_uppercase` parameter determines whether the binary prefix
+    /// uses uppercase 'B' (0B) or lowercase 'b' (0b).
     pub fn new(value: u64, is_b_uppercase: bool) -> Self {
         Self {
             value,
@@ -158,34 +199,41 @@ impl BinaryNumber {
         }
     }
 
+    /// Attaches a token to this binary number.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Attaches a token to this binary number.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the token attached to this binary number, if any.
     #[inline]
     fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Sets whether the binary prefix should use uppercase 'B' (0B) or lowercase 'b' (0b).
     pub fn set_uppercase(&mut self, is_uppercase: bool) {
         self.is_b_uppercase = is_uppercase;
     }
 
+    /// Returns whether the binary prefix uses uppercase 'B' (0B) or lowercase 'b' (0b).
     #[inline]
     pub fn is_b_uppercase(&self) -> bool {
         self.is_b_uppercase
     }
 
+    /// Computes the actual numerical value represented by this binary number.
     pub fn compute_value(&self) -> f64 {
         self.value as f64
     }
 
+    /// Returns the raw integer value of this binary number.
     #[inline]
     pub fn get_raw_value(&self) -> u64 {
         self.value
@@ -194,14 +242,19 @@ impl BinaryNumber {
     super::impl_token_fns!(iter = [token]);
 }
 
+/// Represents a numeric literal expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NumberExpression {
+    /// A decimal number (e.g., `123.45`, `1e10`)
     Decimal(DecimalNumber),
+    /// A hexadecimal number (e.g., `0xFF`, `0x1p2`)
     Hex(HexNumber),
+    /// A binary number (e.g., `0b101`, `0B1010`)
     Binary(BinaryNumber),
 }
 
 impl NumberExpression {
+    /// Sets whether the number notation should use uppercase letters.
     pub fn set_uppercase(&mut self, is_uppercase: bool) {
         match self {
             Self::Decimal(number) => number.set_uppercase(is_uppercase),
@@ -210,6 +263,7 @@ impl NumberExpression {
         }
     }
 
+    /// Computes the actual numerical value represented by this number expression.
     pub fn compute_value(&self) -> f64 {
         match self {
             Self::Decimal(decimal) => decimal.compute_value(),
@@ -218,6 +272,7 @@ impl NumberExpression {
         }
     }
 
+    /// Attaches a token to this number expression.
     pub fn with_token(mut self, token: Token) -> Self {
         match &mut self {
             NumberExpression::Decimal(number) => number.set_token(token),
@@ -227,6 +282,7 @@ impl NumberExpression {
         self
     }
 
+    /// Attaches a token to this number expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         match self {
@@ -236,6 +292,7 @@ impl NumberExpression {
         }
     }
 
+    /// Returns a reference to the token attached to this number expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         match self {
@@ -245,6 +302,7 @@ impl NumberExpression {
         }
     }
 
+    /// Clears all comments from the tokens in this node.
     pub fn clear_comments(&mut self) {
         match self {
             NumberExpression::Decimal(number) => number.clear_comments(),
@@ -253,6 +311,7 @@ impl NumberExpression {
         }
     }
 
+    /// Clears all whitespaces information from the tokens in this node.
     pub fn clear_whitespaces(&mut self) {
         match self {
             NumberExpression::Decimal(number) => number.clear_whitespaces(),
@@ -304,6 +363,18 @@ impl From<BinaryNumber> for NumberExpression {
     }
 }
 
+/// An error that can occur when parsing a number.
+///
+/// # Example
+/// ```rust
+/// # use darklua_core::nodes::NumberExpression;
+/// let number: NumberExpression = "123.45".parse().unwrap();
+/// let hex_number: NumberExpression = "0xFF".parse().unwrap();
+/// let binary_number: NumberExpression = "0b1010".parse().unwrap();
+///
+/// // Invalid numbers will return a NumberParsingError
+/// assert!("abc".parse::<NumberExpression>().is_err());
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NumberParsingError {
     InvalidHexadecimalNumber,

--- a/src/nodes/expressions/parenthese.rs
+++ b/src/nodes/expressions/parenthese.rs
@@ -1,8 +1,11 @@
 use crate::nodes::{Expression, Token};
 
+/// Contains token information for a parenthesized expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParentheseTokens {
+    /// The left (opening) parenthesis token
     pub left_parenthese: Token,
+    /// The right (closing) parenthesis token
     pub right_parenthese: Token,
 }
 
@@ -10,6 +13,7 @@ impl ParentheseTokens {
     super::impl_token_fns!(target = [left_parenthese, right_parenthese]);
 }
 
+/// Represents a parenthesized expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParentheseExpression {
     expression: Expression,
@@ -17,6 +21,7 @@ pub struct ParentheseExpression {
 }
 
 impl ParentheseExpression {
+    /// Creates a new parenthesized expression containing the given expression.
     pub fn new<E: Into<Expression>>(expression: E) -> Self {
         Self {
             expression: expression.into(),
@@ -24,36 +29,43 @@ impl ParentheseExpression {
         }
     }
 
+    /// Returns a reference to the inner expression contained in the parentheses.
     #[inline]
     pub fn inner_expression(&self) -> &Expression {
         &self.expression
     }
 
+    /// Consumes this parenthesized expression and returns the inner expression.
     #[inline]
     pub fn into_inner_expression(self) -> Expression {
         self.expression
     }
 
+    /// Returns a mutable reference to the inner expression contained in the parentheses.
     #[inline]
     pub fn mutate_inner_expression(&mut self) -> &mut Expression {
         &mut self.expression
     }
 
+    /// Attaches tokens to this parenthesized expression.
     pub fn with_tokens(mut self, tokens: ParentheseTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Attaches tokens to this parenthesized expression.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ParentheseTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns a reference to the tokens attached to this parenthesized expression, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ParentheseTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens attached to this parenthesized expression, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut ParentheseTokens> {
         self.tokens.as_mut()

--- a/src/nodes/expressions/prefix.rs
+++ b/src/nodes/expressions/prefix.rs
@@ -9,7 +9,7 @@ use crate::nodes::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Prefix {
     /// A function call expression (e.g., `func()`)
-    Call(FunctionCall),
+    Call(Box<FunctionCall>),
     /// A field access expression (e.g., `object.field`)
     Field(Box<FieldExpression>),
     /// A simple name/variable (e.g., `variable_name`)
@@ -17,7 +17,7 @@ pub enum Prefix {
     /// An indexed access expression (e.g., `table[key]`)
     Index(Box<IndexExpression>),
     /// A parenthesized expression (e.g., `(expression)`)
-    Parenthese(ParentheseExpression),
+    Parenthese(Box<ParentheseExpression>),
 }
 
 impl Prefix {
@@ -30,11 +30,11 @@ impl Prefix {
 impl From<Expression> for Prefix {
     fn from(expression: Expression) -> Self {
         match expression {
-            Expression::Call(call) => Prefix::Call(*call),
+            Expression::Call(call) => Prefix::Call(call),
             Expression::Field(field) => Prefix::Field(field),
             Expression::Identifier(identifier) => Prefix::Identifier(identifier),
             Expression::Index(index) => Prefix::Index(index),
-            Expression::Parenthese(parenthese) => Prefix::Parenthese(*parenthese),
+            Expression::Parenthese(parenthese) => Prefix::Parenthese(parenthese),
             Expression::Binary(_)
             | Expression::False(_)
             | Expression::Function(_)
@@ -48,7 +48,7 @@ impl From<Expression> for Prefix {
             | Expression::TypeCast(_)
             | Expression::Unary(_)
             | Expression::VariableArguments(_) => {
-                Prefix::Parenthese(ParentheseExpression::new(expression))
+                Prefix::Parenthese(Box::new(ParentheseExpression::new(expression)))
             }
         }
     }
@@ -56,7 +56,7 @@ impl From<Expression> for Prefix {
 
 impl From<FunctionCall> for Prefix {
     fn from(call: FunctionCall) -> Self {
-        Self::Call(call)
+        Self::Call(Box::new(call))
     }
 }
 
@@ -92,6 +92,6 @@ impl From<Box<IndexExpression>> for Prefix {
 
 impl From<ParentheseExpression> for Prefix {
     fn from(expression: ParentheseExpression) -> Self {
-        Self::Parenthese(expression)
+        Self::Parenthese(Box::new(expression))
     }
 }

--- a/src/nodes/expressions/prefix.rs
+++ b/src/nodes/expressions/prefix.rs
@@ -2,16 +2,26 @@ use crate::nodes::{
     Expression, FieldExpression, FunctionCall, Identifier, IndexExpression, ParentheseExpression,
 };
 
+/// Represents a prefix expression.
+///
+/// Prefix expressions form the base for more complex expressions like method calls
+/// and property access chains.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Prefix {
+    /// A function call expression (e.g., `func()`)
     Call(FunctionCall),
+    /// A field access expression (e.g., `object.field`)
     Field(Box<FieldExpression>),
+    /// A simple name/variable (e.g., `variable_name`)
     Identifier(Identifier),
+    /// An indexed access expression (e.g., `table[key]`)
     Index(Box<IndexExpression>),
+    /// A parenthesized expression (e.g., `(expression)`)
     Parenthese(ParentheseExpression),
 }
 
 impl Prefix {
+    /// Creates a new prefix from a name/identifier.
     pub fn from_name<S: Into<Identifier>>(name: S) -> Self {
         Self::Identifier(name.into())
     }

--- a/src/nodes/expressions/string.rs
+++ b/src/nodes/expressions/string.rs
@@ -4,6 +4,10 @@ use crate::nodes::{StringError, Token};
 
 use super::string_utils;
 
+/// Represents a string literal in Lua source code.
+///
+/// String literals in Lua can be written with single quotes, double quotes,
+/// or with long brackets (`[[...]]` or `[=[...]=]` etc.) for multi-line strings.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringExpression {
     value: String,
@@ -11,6 +15,17 @@ pub struct StringExpression {
 }
 
 impl StringExpression {
+    /// Creates a new `StringExpression` from a raw Lua string literal.
+    ///
+    /// Handles quoted strings (with either ' or " delimiters), long bracket strings,
+    /// and processes escape sequences in quoted strings.
+    ///
+    /// ```
+    /// # use darklua_core::nodes::StringExpression;
+    /// let single_quoted = StringExpression::new("'hello'").unwrap();
+    /// let double_quoted = StringExpression::new("\"world\"").unwrap();
+    /// let bracket_string = StringExpression::new("[[multi\nline]]").unwrap();
+    /// ```
     pub fn new(string: &str) -> Result<Self, StringError> {
         if string.starts_with('[') {
             return string
@@ -51,6 +66,7 @@ impl StringExpression {
         }
     }
 
+    /// Creates an empty string expression.
     pub fn empty() -> Self {
         Self {
             value: "".to_owned(),
@@ -58,6 +74,7 @@ impl StringExpression {
         }
     }
 
+    /// Creates a new `StringExpression` from a string value.
     pub fn from_value<T: Into<String>>(value: T) -> Self {
         Self {
             value: value.into(),
@@ -65,39 +82,51 @@ impl StringExpression {
         }
     }
 
+    /// Attaches a token to this string expression.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for this string expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this string expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns the string value.
     #[inline]
     pub fn get_value(&self) -> &str {
         &self.value
     }
 
+    /// Consumes the string expression and returns the inner string value.
     #[inline]
     pub fn into_value(self) -> String {
         self.value
     }
 
+    /// Checks if the string contains newline characters.
     pub fn is_multiline(&self) -> bool {
         self.value.contains('\n')
     }
 
+    /// Checks if the string contains single quotes.
+    ///
+    /// Useful when determining the best quote style to use when serializing the string.
     pub fn has_single_quote(&self) -> bool {
         self.find_not_escaped('\'').is_some()
     }
 
+    /// Checks if the string contains double quotes.
+    ///
+    /// Useful when determining the best quote style to use when serializing the string.
     pub fn has_double_quote(&self) -> bool {
         self.find_not_escaped('"').is_some()
     }

--- a/src/nodes/expressions/string_utils.rs
+++ b/src/nodes/expressions/string_utils.rs
@@ -6,6 +6,7 @@ enum StringErrorKind {
     MalformedEscapeSequence { position: usize, message: String },
 }
 
+/// Represents an error that occurred while parsing a string.
 #[derive(Debug, Clone)]
 pub struct StringError {
     kind: StringErrorKind,

--- a/src/nodes/expressions/table.rs
+++ b/src/nodes/expressions/table.rs
@@ -5,15 +5,18 @@ use crate::{
 
 use super::StringExpression;
 
+/// Represents a field entry in a table literal where the key is an identifier.
+///
+/// This corresponds to the form: `{ field = value }`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableFieldEntry {
     field: Identifier,
     value: Expression,
-    /// The token for the `=` operator symbol.
     token: Option<Token>,
 }
 
 impl TableFieldEntry {
+    /// Creates a new table field entry with the given field name and value.
     pub fn new<I: Into<Identifier>, E: Into<Expression>>(field: I, value: E) -> Self {
         Self {
             field: field.into(),
@@ -22,36 +25,43 @@ impl TableFieldEntry {
         }
     }
 
+    /// Attaches a token to this field entry.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for this field entry.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this field entry, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns the field name.
     #[inline]
     pub fn get_field(&self) -> &Identifier {
         &self.field
     }
 
+    /// Returns a mutable reference to the field name.
     #[inline]
     pub fn mutate_field(&mut self) -> &mut Identifier {
         &mut self.field
     }
 
+    /// Returns the field value.
     #[inline]
     pub fn get_value(&self) -> &Expression {
         &self.value
     }
 
+    /// Returns a mutable reference to the field value.
     #[inline]
     pub fn mutate_value(&mut self) -> &mut Expression {
         &mut self.value
@@ -63,10 +73,14 @@ impl TableFieldEntry {
     );
 }
 
+/// Contains tokens for a table index entry.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableIndexEntryTokens {
+    /// Token for the opening bracket `[`
     pub opening_bracket: Token,
+    /// Token for the closing bracket `]`
     pub closing_bracket: Token,
+    /// Token for the equals sign `=`
     pub equal: Token,
 }
 
@@ -74,6 +88,7 @@ impl TableIndexEntryTokens {
     super::impl_token_fns!(target = [opening_bracket, closing_bracket, equal]);
 }
 
+/// Represents an index entry in a table literal where the key is a computed expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableIndexEntry {
     key: Expression,
@@ -82,6 +97,7 @@ pub struct TableIndexEntry {
 }
 
 impl TableIndexEntry {
+    /// Creates a new table index entry with the given key and value.
     pub fn new<T: Into<Expression>, U: Into<Expression>>(key: T, value: U) -> Self {
         Self {
             key: key.into(),
@@ -90,36 +106,43 @@ impl TableIndexEntry {
         }
     }
 
+    /// Attaches tokens to this index entry and returns the modified entry.
     pub fn with_tokens(mut self, tokens: TableIndexEntryTokens) -> Self {
         self.tokens = Some(tokens.into());
         self
     }
 
+    /// Sets the tokens for this index entry.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TableIndexEntryTokens) {
         self.tokens = Some(tokens.into());
     }
 
+    /// Returns the tokens associated with this index entry, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TableIndexEntryTokens> {
         self.tokens.as_ref().map(|tokens| tokens.as_ref())
     }
 
+    /// Returns the key expression.
     #[inline]
     pub fn get_key(&self) -> &Expression {
         &self.key
     }
 
+    /// Returns a mutable reference to the key expression.
     #[inline]
     pub fn mutate_key(&mut self) -> &mut Expression {
         &mut self.key
     }
 
+    /// Returns the value expression.
     #[inline]
     pub fn get_value(&self) -> &Expression {
         &self.value
     }
 
+    /// Returns a mutable reference to the value expression.
     #[inline]
     pub fn mutate_value(&mut self) -> &mut Expression {
         &mut self.value
@@ -128,16 +151,22 @@ impl TableIndexEntry {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Represents a single entry in a table literal.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TableEntry {
+    /// A named field entry (e.g., `{ field = value }`)
     Field(TableFieldEntry),
+    /// A computed index entry (e.g., `{ [expr] = value }`)
     Index(TableIndexEntry),
+    /// A value entry for array-like tables (e.g., `{ value }`)
     Value(Expression),
 }
 
 impl TableEntry {
-    /// Creates a field entry if the provided key is a valid identifier, otherwise it
-    /// creates an index entry.
+    /// Creates a table entry from a string key and value.
+    ///
+    /// If the key is a valid Lua identifier, a `Field` entry is created.
+    /// Otherwise, an `Index` entry with a string key is created.
     pub fn from_string_key_and_value(key: impl Into<String>, value: impl Into<Expression>) -> Self {
         let key = key.into();
         let value = value.into();
@@ -156,6 +185,7 @@ impl TableEntry {
         }
     }
 
+    /// Clears all comments from the tokens in this node.
     pub fn clear_comments(&mut self) {
         match self {
             TableEntry::Field(entry) => entry.clear_comments(),
@@ -164,6 +194,7 @@ impl TableEntry {
         }
     }
 
+    /// Clears all whitespaces information from the tokens in this node.
     pub fn clear_whitespaces(&mut self) {
         match self {
             TableEntry::Field(entry) => entry.clear_whitespaces(),
@@ -209,10 +240,14 @@ impl From<TableIndexEntry> for TableEntry {
     }
 }
 
+/// Contains tokens for a table expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableTokens {
+    /// Token for the opening brace `{`
     pub opening_brace: Token,
+    /// Token for the closing brace `}`
     pub closing_brace: Token,
+    /// Tokens for the separators between entries (commas and/or semicolons)
     pub separators: Vec<Token>,
 }
 
@@ -223,6 +258,7 @@ impl TableTokens {
     );
 }
 
+/// Represents a table expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableExpression {
     entries: Vec<TableEntry>,
@@ -230,6 +266,7 @@ pub struct TableExpression {
 }
 
 impl TableExpression {
+    /// Creates a new table expression with the given entries.
     pub fn new(entries: Vec<TableEntry>) -> Self {
         Self {
             entries,
@@ -237,56 +274,67 @@ impl TableExpression {
         }
     }
 
+    /// Attaches tokens to this table expression.
     pub fn with_tokens(mut self, tokens: TableTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this table expression.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TableTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this table expression, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TableTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the entries in this table expression.
     #[inline]
     pub fn get_entries(&self) -> &Vec<TableEntry> {
         &self.entries
     }
 
+    /// Returns an iterator over the entries in this table expression.
     #[inline]
     pub fn iter_entries(&self) -> impl Iterator<Item = &TableEntry> {
         self.entries.iter()
     }
 
+    /// Returns a mutable iterator over the entries in this table expression.
     #[inline]
     pub fn iter_mut_entries(&mut self) -> impl Iterator<Item = &mut TableEntry> {
         self.entries.iter_mut()
     }
 
+    /// Returns the number of entries in this table expression.
     #[inline]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
+    /// Returns whether this table expression is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
+    /// Returns a mutable reference to the entries in this table expression.
     #[inline]
     pub fn mutate_entries(&mut self) -> &mut Vec<TableEntry> {
         &mut self.entries
     }
 
+    /// Appends a new entry to this table expression.
     pub fn append_entry<T: Into<TableEntry>>(mut self, entry: T) -> Self {
         self.entries.push(entry.into());
         self
     }
 
+    /// Appends a new field entry to this table expression.
     pub fn append_field<S: Into<Identifier>, E: Into<Expression>>(
         mut self,
         key: S,
@@ -296,6 +344,7 @@ impl TableExpression {
         self
     }
 
+    /// Appends a new index entry to this table expression.
     pub fn append_index<T: Into<Expression>, U: Into<Expression>>(
         mut self,
         key: T,
@@ -306,6 +355,7 @@ impl TableExpression {
         self
     }
 
+    /// Appends a new value entry to this table expression.
     pub fn append_array_value<E: Into<Expression>>(mut self, value: E) -> Self {
         self.entries.push(TableEntry::Value(value.into()));
         self

--- a/src/nodes/expressions/type_cast.rs
+++ b/src/nodes/expressions/type_cast.rs
@@ -6,7 +6,7 @@ use crate::nodes::{Expression, Token, Type};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeCastExpression {
     expression: Box<Expression>,
-    r#type: Type,
+    r#type: Box<Type>,
     token: Option<Token>,
 }
 
@@ -15,7 +15,7 @@ impl TypeCastExpression {
     pub fn new(expression: impl Into<Expression>, r#type: impl Into<Type>) -> Self {
         Self {
             expression: Box::new(expression.into()),
-            r#type: r#type.into(),
+            r#type: Box::new(r#type.into()),
             token: None,
         }
     }

--- a/src/nodes/expressions/type_cast.rs
+++ b/src/nodes/expressions/type_cast.rs
@@ -1,5 +1,8 @@
 use crate::nodes::{Expression, Token, Type};
 
+/// Represents a type cast expression.
+///
+/// This corresponds to expressions like: `expression :: type`
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeCastExpression {
     expression: Box<Expression>,
@@ -8,6 +11,7 @@ pub struct TypeCastExpression {
 }
 
 impl TypeCastExpression {
+    /// Creates a new type cast expression with the given expression and type.
     pub fn new(expression: impl Into<Expression>, r#type: impl Into<Type>) -> Self {
         Self {
             expression: Box::new(expression.into()),
@@ -16,41 +20,52 @@ impl TypeCastExpression {
         }
     }
 
+    /// Returns the expression being cast.
     pub fn get_expression(&self) -> &Expression {
         &self.expression
     }
 
+    /// Returns a mutable reference to the expression being cast.
     pub fn mutate_expression(&mut self) -> &mut Expression {
         &mut self.expression
     }
 
+    /// Consumes the type cast expression and returns the inner expression.
     pub fn into_inner_expression(self) -> Expression {
         *self.expression
     }
 
+    /// Returns the type being cast to.
     pub fn get_type(&self) -> &Type {
         &self.r#type
     }
 
+    /// Returns a mutable reference to the type being cast to.
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.r#type
     }
 
+    /// Attaches a token to this type cast expression.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for this type cast expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this type cast expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Determines if the given expression requires parentheses when used as the subject of a type cast.
+    ///
+    /// Some expressions require parentheses to ensure correct operator precedence when type cast.
     pub fn needs_parentheses(expression: &Expression) -> bool {
         matches!(
             expression,

--- a/src/nodes/expressions/unary.rs
+++ b/src/nodes/expressions/unary.rs
@@ -1,13 +1,18 @@
 use crate::nodes::{Expression, Token};
 
+/// Represents the type of operator in a unary expression.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnaryOperator {
+    /// The length operator (`#`)
     Length,
+    /// The minus operator (`-`)
     Minus,
+    /// The not operator (`not`)
     Not,
 }
 
 impl UnaryOperator {
+    /// Returns the string representation of this operator.
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::Length => "#",
@@ -17,6 +22,7 @@ impl UnaryOperator {
     }
 }
 
+/// Represents a unary operation applied to an expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnaryExpression {
     operator: UnaryOperator,
@@ -25,6 +31,7 @@ pub struct UnaryExpression {
 }
 
 impl UnaryExpression {
+    /// Creates a new unary expression with the given operator and expression.
     pub fn new<E: Into<Expression>>(operator: UnaryOperator, expression: E) -> Self {
         Self {
             operator,
@@ -33,31 +40,37 @@ impl UnaryExpression {
         }
     }
 
+    /// Attaches a token to this unary expression.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for this unary expression.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this unary expression, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns the expression being operated on.
     #[inline]
     pub fn get_expression(&self) -> &Expression {
         &self.expression
     }
 
+    /// Returns a mutable reference to the expression being operated on.
     #[inline]
     pub fn mutate_expression(&mut self) -> &mut Expression {
         &mut self.expression
     }
 
+    /// Returns the operator of this unary expression.
     #[inline]
     pub fn operator(&self) -> UnaryOperator {
         self.operator

--- a/src/nodes/function_body.rs
+++ b/src/nodes/function_body.rs
@@ -224,16 +224,24 @@ impl FunctionBuilder {
     }
 }
 
+/// Represents the token information associated with a function body.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionBodyTokens {
+    /// The 'function' keyword token.
     pub function: Token,
+    /// The opening parenthesis token for parameter list.
     pub opening_parenthese: Token,
+    /// The closing parenthesis token for parameter list.
     pub closing_parenthese: Token,
+    /// The 'end' keyword token that terminates the function definition.
     pub end: Token,
+    /// Tokens for commas separating parameters.
     pub parameter_commas: Vec<Token>,
+    /// The '...' token for variadic functions, if present.
     pub variable_arguments: Option<Token>,
-
+    /// The colon token before the variadic type annotation, if present.
     pub variable_arguments_colon: Option<Token>,
+    /// The colon token before the return type annotation, if present.
     pub return_type_colon: Option<Token>,
 }
 

--- a/src/nodes/function_call.rs
+++ b/src/nodes/function_call.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{Arguments, Expression, Identifier, Prefix, Token};
 
+/// Tokens associated with a function call.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionCallTokens {
     pub colon: Option<Token>,
@@ -9,6 +10,7 @@ impl FunctionCallTokens {
     super::impl_token_fns!(iter = [colon]);
 }
 
+/// Represents a function call expression (e.g., `func()`, `obj:method()`, `a.b.c()`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionCall {
     prefix: Box<Prefix>,
@@ -18,6 +20,7 @@ pub struct FunctionCall {
 }
 
 impl FunctionCall {
+    /// Creates a new function call with the given prefix, arguments, and optional method.
     pub fn new(prefix: Prefix, arguments: Arguments, method: Option<Identifier>) -> Self {
         Self {
             prefix: Box::new(prefix),
@@ -27,6 +30,7 @@ impl FunctionCall {
         }
     }
 
+    /// Creates a new function call with the given name.
     pub fn from_name<T: Into<Identifier>>(name: T) -> Self {
         Self {
             prefix: Box::new(name.into().into()),
@@ -36,6 +40,7 @@ impl FunctionCall {
         }
     }
 
+    /// Creates a new function call with the given prefix.
     pub fn from_prefix<T: Into<Prefix>>(prefix: T) -> Self {
         Self {
             prefix: Box::new(prefix.into()),
@@ -45,71 +50,85 @@ impl FunctionCall {
         }
     }
 
+    /// Sets the tokens for this function call.
     pub fn with_tokens(mut self, tokens: FunctionCallTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this function call.
     #[inline]
     pub fn set_tokens(&mut self, tokens: FunctionCallTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this function call, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionCallTokens> {
         self.tokens.as_ref()
     }
 
+    /// Sets the arguments for this function call.
     pub fn with_arguments<A: Into<Arguments>>(mut self, arguments: A) -> Self {
         self.arguments = arguments.into();
         self
     }
 
+    /// Adds an argument to this function call.
     pub fn with_argument<T: Into<Expression>>(mut self, argument: T) -> Self {
         self.arguments = self.arguments.with_argument(argument);
         self
     }
 
+    /// Sets the method name for this function call (for method calls like `obj:method()`).
     pub fn with_method<IntoString: Into<Identifier>>(mut self, method: IntoString) -> Self {
         self.method.replace(method.into());
         self
     }
 
+    /// Returns the arguments of this function call.
     #[inline]
     pub fn get_arguments(&self) -> &Arguments {
         &self.arguments
     }
 
+    /// Returns the method name, if this is a method call.
     #[inline]
     pub fn get_method(&self) -> Option<&Identifier> {
         self.method.as_ref()
     }
 
+    /// Returns the prefix (what is being called) of this function call.
     #[inline]
     pub fn get_prefix(&self) -> &Prefix {
         &self.prefix
     }
 
+    /// Removes and returns the method name, if any.
     #[inline]
     pub fn take_method(&mut self) -> Option<Identifier> {
         self.method.take()
     }
 
+    /// Sets the arguments for this function call.
     #[inline]
     pub fn set_arguments(&mut self, arguments: Arguments) {
         self.arguments = arguments;
     }
 
+    /// Sets the method name for this function call.
     #[inline]
     pub fn set_method(&mut self, method: Identifier) {
         self.method.replace(method);
     }
 
+    /// Returns a mutable reference to the arguments.
     #[inline]
     pub fn mutate_arguments(&mut self) -> &mut Arguments {
         &mut self.arguments
     }
 
+    /// Returns a mutable reference to the prefix.
     #[inline]
     pub fn mutate_prefix(&mut self) -> &mut Prefix {
         &mut self.prefix

--- a/src/nodes/identifier.rs
+++ b/src/nodes/identifier.rs
@@ -2,6 +2,7 @@ use crate::nodes::Token;
 
 use super::{Type, TypedIdentifier};
 
+/// Represents an identifier (variable name).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Identifier {
     name: String,
@@ -9,6 +10,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
+    /// Creates a new identifier with the given name.
     pub fn new<S: Into<String>>(name: S) -> Self {
         Self {
             name: name.into(),
@@ -16,40 +18,50 @@ impl Identifier {
         }
     }
 
+    /// Converts this identifier into a typed identifier.
     pub fn with_type(self, r#type: impl Into<Type>) -> TypedIdentifier {
         TypedIdentifier::from(self).with_type(r#type.into())
     }
 
+    /// Attaches token information to this identifier.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token information for this identifier.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the token information attached to this identifier, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a mutable reference to the token information attached to this identifier, if any.
     #[inline]
     pub fn mutate_token(&mut self) -> Option<&mut Token> {
         self.token.as_mut()
     }
 
+    /// Returns a reference to the name of this identifier.
     #[inline]
     pub fn get_name(&self) -> &String {
         &self.name
     }
 
+    /// Returns a mutable reference to the name of this identifier.
     #[inline]
     pub fn mutate_name(&mut self) -> &mut String {
         &mut self.name
     }
 
+    /// Changes the name of this identifier.
+    ///
+    /// If token information is attached, it's updated to reflect the new name.
     #[inline]
     pub fn set_name<IntoString: Into<String>>(&mut self, name: IntoString) {
         let name = name.into();
@@ -59,6 +71,7 @@ impl Identifier {
         self.name = name;
     }
 
+    /// Consumes the identifier and returns just the name as a String.
     #[inline]
     pub fn into_name(self) -> String {
         self.name

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -30,6 +30,7 @@ macro_rules! impl_token_fns {
         $(iter = [ $( $iter_field:ident),* $(,)? ])?
         $(iter_flatten = [ $( $iter_flatten_field:ident),* $(,)? ])?
     ) => {
+        /// Clears all comments from the tokens in this node.
         pub fn clear_comments(&mut self) {
             $(
                 self.$field.clear_comments();
@@ -46,6 +47,7 @@ macro_rules! impl_token_fns {
             )*)?
         }
 
+        /// Clears all whitespaces information from the tokens in this node.
         pub fn clear_whitespaces(&mut self) {
             $(
                 self.$field.clear_whitespaces();

--- a/src/nodes/statements/assign.rs
+++ b/src/nodes/statements/assign.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{Expression, Token, Variable};
 
+/// Tokens associated with an assignment statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssignTokens {
     pub equal: Token,
@@ -14,6 +15,7 @@ impl AssignTokens {
     );
 }
 
+/// Represents a variable assignment statement (e.g., `a, b = 1, 2`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssignStatement {
     variables: Vec<Variable>,
@@ -22,6 +24,7 @@ pub struct AssignStatement {
 }
 
 impl AssignStatement {
+    /// Creates a new assignment statement with the given variables and values.
     pub fn new(variables: Vec<Variable>, values: Vec<Expression>) -> Self {
         Self {
             variables,
@@ -30,6 +33,7 @@ impl AssignStatement {
         }
     }
 
+    /// Creates a new assignment statement with a single variable and value.
     pub fn from_variable<V: Into<Variable>, E: Into<Expression>>(variable: V, value: E) -> Self {
         Self {
             variables: vec![variable.into()],
@@ -38,51 +42,61 @@ impl AssignStatement {
         }
     }
 
+    /// Returns the number of variables in the assignment.
     #[inline]
     pub fn variables_len(&self) -> usize {
         self.variables.len()
     }
 
+    /// Returns the number of values in the assignment.
     #[inline]
     pub fn values_len(&self) -> usize {
         self.values.len()
     }
 
+    /// Returns the list of variables.
     #[inline]
     pub fn get_variables(&self) -> &Vec<Variable> {
         &self.variables
     }
 
+    /// Returns an iterator over the variables.
     #[inline]
     pub fn iter_variables(&self) -> impl Iterator<Item = &Variable> {
         self.variables.iter()
     }
 
+    /// Returns a mutable iterator over the variables.
     #[inline]
     pub fn iter_mut_variables(&mut self) -> impl Iterator<Item = &mut Variable> {
         self.variables.iter_mut()
     }
 
+    /// Returns the last value in the assignment, if any.
     #[inline]
     pub fn last_value(&self) -> Option<&Expression> {
         self.values.last()
     }
 
+    /// Returns an iterator over the values.
     #[inline]
     pub fn iter_values(&self) -> impl Iterator<Item = &Expression> {
         self.values.iter()
     }
 
+    /// Returns a mutable iterator over the values.
     #[inline]
     pub fn iter_mut_values(&mut self) -> impl Iterator<Item = &mut Expression> {
         self.values.iter_mut()
     }
 
+    /// Returns a mutable reference to the variables vector.
     #[inline]
     pub fn mutate_variables(&mut self) -> &mut Vec<Variable> {
         &mut self.variables
     }
 
+    /// Adds a new variable and value to the assignment.
     pub fn append_assignment<V: Into<Variable>, E: Into<Expression>>(
         mut self,
         variable: V,
@@ -93,16 +107,19 @@ impl AssignStatement {
         self
     }
 
+    /// Sets the tokens for this assignment statement.
     pub fn with_tokens(mut self, tokens: AssignTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this assignment statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: AssignTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this assignment statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&AssignTokens> {
         self.tokens.as_ref()

--- a/src/nodes/statements/compound_assign.rs
+++ b/src/nodes/statements/compound_assign.rs
@@ -1,18 +1,28 @@
 use crate::nodes::{BinaryOperator, Expression, Token, Variable};
 
+/// Represents compound assignment operators (e.g., `+=`, `-=`, etc.).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompoundOperator {
+    /// Addition and assignment (`+=`)
     Plus,
+    /// Subtraction and assignment (`-=`)
     Minus,
+    /// Multiplication and assignment (`*=`)
     Asterisk,
+    /// Division and assignment (`/=`)
     Slash,
+    /// Floor division and assignment (`//=`)
     DoubleSlash,
+    /// Modulo and assignment (`%=`)
     Percent,
+    /// Exponentiation and assignment (`^=`)
     Caret,
+    /// Concatenation and assignment (`..=`)
     Concat,
 }
 
 impl CompoundOperator {
+    /// Returns the string representation of the operator.
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::Plus => "+=",
@@ -26,6 +36,7 @@ impl CompoundOperator {
         }
     }
 
+    /// Converts this compound operator to its corresponding binary operator.
     pub fn to_binary_operator(&self) -> BinaryOperator {
         match self {
             Self::Plus => BinaryOperator::Plus,
@@ -40,8 +51,10 @@ impl CompoundOperator {
     }
 }
 
+/// Tokens associated with a compound assignment statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompoundAssignTokens {
+    /// The operator token for the compound assignment.
     pub operator: Token,
 }
 
@@ -49,6 +62,7 @@ impl CompoundAssignTokens {
     super::impl_token_fns!(target = [operator]);
 }
 
+/// Represents a compound assignment statement (e.g., `a += 1`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompoundAssignStatement {
     operator: CompoundOperator,
@@ -58,6 +72,7 @@ pub struct CompoundAssignStatement {
 }
 
 impl CompoundAssignStatement {
+    /// Creates a new compound assignment statement.
     pub fn new<V: Into<Variable>, E: Into<Expression>>(
         operator: CompoundOperator,
         variable: V,
@@ -71,46 +86,55 @@ impl CompoundAssignStatement {
         }
     }
 
+    /// Sets the tokens for this compound assignment statement.
     pub fn with_tokens(mut self, tokens: CompoundAssignTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this compound assignment statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: CompoundAssignTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this compound assignment statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&CompoundAssignTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the compound operator used in this statement.
     #[inline]
     pub fn get_operator(&self) -> CompoundOperator {
         self.operator
     }
 
+    /// Returns the variable being assigned to.
     #[inline]
     pub fn get_variable(&self) -> &Variable {
         &self.variable
     }
 
+    /// Returns the value expression in the assignment.
     #[inline]
     pub fn get_value(&self) -> &Expression {
         &self.value
     }
 
+    /// Extracts the variable and value from this statement.
     #[inline]
     pub fn extract_assignment(self) -> (Variable, Expression) {
         (self.variable, self.value)
     }
 
+    /// Returns a mutable reference to the variable.
     #[inline]
     pub fn mutate_variable(&mut self) -> &mut Variable {
         &mut self.variable
     }
 
+    /// Returns a mutable reference to the value expression.
     #[inline]
     pub fn mutate_value(&mut self) -> &mut Expression {
         &mut self.value

--- a/src/nodes/statements/do_statement.rs
+++ b/src/nodes/statements/do_statement.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{Block, Token};
 
+/// Tokens associated with a do statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DoTokens {
     pub r#do: Token,
@@ -10,6 +11,7 @@ impl DoTokens {
     super::impl_token_fns!(target = [r#do, end]);
 }
 
+/// Represents a do statement (e.g., `do ... end`).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct DoStatement {
     block: Block,
@@ -17,6 +19,7 @@ pub struct DoStatement {
 }
 
 impl DoStatement {
+    /// Creates a new do statement with the given block.
     pub fn new(block: Block) -> Self {
         Self {
             block,
@@ -24,31 +27,37 @@ impl DoStatement {
         }
     }
 
+    /// Returns the block contained within the do statement.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Sets the tokens for this do statement.
     pub fn with_tokens(mut self, tokens: DoTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this do statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: DoTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this do statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&DoTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut DoTokens> {
         self.tokens.as_mut()

--- a/src/nodes/statements/function.rs
+++ b/src/nodes/statements/function.rs
@@ -3,9 +3,12 @@ use crate::nodes::{
     Identifier, Token, TypedIdentifier,
 };
 
+/// Tokens associated with a function name.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionNameTokens {
+    /// The tokens for the periods in the function name.
     pub periods: Vec<Token>,
+    /// The token for the colon in the function name when a method is present.
     pub colon: Option<Token>,
 }
 
@@ -13,6 +16,10 @@ impl FunctionNameTokens {
     super::impl_token_fns!(iter = [periods, colon]);
 }
 
+/// Represents the name portion of a function statement.
+///
+/// Function names can include table fields and methods
+/// ([e.g., `module.table:method`]).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionName {
     name: Identifier,
@@ -22,6 +29,7 @@ pub struct FunctionName {
 }
 
 impl FunctionName {
+    /// Creates a new function name with fields and an optional method.
     pub fn new(name: Identifier, field_names: Vec<Identifier>, method: Option<Identifier>) -> Self {
         Self {
             name,
@@ -31,6 +39,7 @@ impl FunctionName {
         }
     }
 
+    /// Creates a new function name from a single identifier.
     pub fn from_name<S: Into<Identifier>>(name: S) -> Self {
         Self {
             name: name.into(),
@@ -40,70 +49,84 @@ impl FunctionName {
         }
     }
 
+    /// Sets the tokens for this function name.
     pub fn with_tokens(mut self, tokens: FunctionNameTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this function name.
     #[inline]
     pub fn set_tokens(&mut self, tokens: FunctionNameTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this function name, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionNameTokens> {
         self.tokens.as_ref()
     }
 
+    /// Adds a field to this function name.
     pub fn with_field<S: Into<Identifier>>(mut self, field: S) -> Self {
         self.field_names.push(field.into());
         self
     }
 
+    /// Sets the field names for this function name.
     pub fn with_fields(mut self, field_names: Vec<Identifier>) -> Self {
         self.field_names = field_names;
         self
     }
 
+    /// Sets a method for this function name.
     pub fn with_method<S: Into<Identifier>>(mut self, method: S) -> Self {
         self.method.replace(method.into());
         self
     }
 
+    /// Adds a field to this function name.
     pub fn push_field<S: Into<Identifier>>(&mut self, field: S) {
         self.field_names.push(field.into());
     }
 
+    /// Removes and returns the method, if any.
     #[inline]
     pub fn remove_method(&mut self) -> Option<Identifier> {
         self.method.take()
     }
 
+    /// Returns the method, if any.
     #[inline]
     pub fn get_method(&self) -> Option<&Identifier> {
         self.method.as_ref()
     }
 
+    /// Returns whether this function name has a method component.
     #[inline]
     pub fn has_method(&self) -> bool {
         self.method.is_some()
     }
 
+    /// Returns the base name.
     #[inline]
     pub fn get_name(&self) -> &Identifier {
         &self.name
     }
 
+    /// Sets the base name.
     #[inline]
     pub fn set_name(&mut self, name: Identifier) {
         self.name = name;
     }
 
+    /// Returns the field names.
     #[inline]
     pub fn get_field_names(&self) -> &Vec<Identifier> {
         &self.field_names
     }
 
+    /// Returns a mutable reference to the base identifier.
     #[inline]
     pub fn mutate_identifier(&mut self) -> &mut Identifier {
         &mut self.name
@@ -112,6 +135,7 @@ impl FunctionName {
     super::impl_token_fns!(iter = [tokens, field_names, method]);
 }
 
+/// Represents a function declaration statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionStatement {
     name: FunctionName,
@@ -125,6 +149,7 @@ pub struct FunctionStatement {
 }
 
 impl FunctionStatement {
+    /// Creates a new function statement with the given name, block, parameters, and variadic flag.
     pub fn new(
         name: FunctionName,
         block: Block,
@@ -143,6 +168,7 @@ impl FunctionStatement {
         }
     }
 
+    /// Creates a new function statement from a single identifier and a block.
     pub fn from_name<S: Into<String>, B: Into<Block>>(name: S, block: B) -> Self {
         Self {
             name: FunctionName::from_name(name),
@@ -156,151 +182,184 @@ impl FunctionStatement {
         }
     }
 
+    /// Sets the tokens for this function statement.
     pub fn with_tokens(mut self, tokens: FunctionBodyTokens) -> Self {
         self.tokens = Some(tokens.into());
         self
     }
 
+    /// Sets the tokens for this function statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: FunctionBodyTokens) {
         self.tokens = Some(tokens.into());
     }
 
+    /// Returns the tokens for this function statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionBodyTokens> {
         self.tokens.as_deref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut FunctionBodyTokens> {
         self.tokens.as_deref_mut()
     }
 
+    /// Adds a parameter to this function.
     pub fn with_parameter(mut self, parameter: impl Into<TypedIdentifier>) -> Self {
         self.parameters.push(parameter.into());
         self
     }
 
+    /// Marks this function as variadic.
     pub fn variadic(mut self) -> Self {
         self.is_variadic = true;
         self
     }
 
+    /// Sets the variadic type for this function.
     pub fn with_variadic_type(mut self, r#type: impl Into<FunctionVariadicType>) -> Self {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
         self
     }
 
+    /// Sets the variadic type for this function.
     pub fn set_variadic_type(&mut self, r#type: impl Into<FunctionVariadicType>) {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
     }
 
+    /// Returns the variadic type, if any.
     #[inline]
     pub fn get_variadic_type(&self) -> Option<&FunctionVariadicType> {
         self.variadic_type.as_ref()
     }
 
+    /// Returns whether this function has a variadic type.
     #[inline]
     pub fn has_variadic_type(&self) -> bool {
         self.variadic_type.is_some()
     }
 
+    /// Returns a mutable reference to the variadic type, if any.
     #[inline]
     pub fn mutate_variadic_type(&mut self) -> Option<&mut FunctionVariadicType> {
         self.variadic_type.as_mut()
     }
 
+    /// Sets the return type for this function.
     pub fn with_return_type(mut self, return_type: impl Into<FunctionReturnType>) -> Self {
         self.return_type = Some(return_type.into());
         self
     }
 
+    /// Sets the return type for this function.
     pub fn set_return_type(&mut self, return_type: impl Into<FunctionReturnType>) {
         self.return_type = Some(return_type.into());
     }
 
+    /// Returns the return type, if any.
     #[inline]
     pub fn get_return_type(&self) -> Option<&FunctionReturnType> {
         self.return_type.as_ref()
     }
 
+    /// Returns whether this function has a return type.
     #[inline]
     pub fn has_return_type(&self) -> bool {
         self.return_type.is_some()
     }
 
+    /// Returns a mutable reference to the return type, if any.
     #[inline]
     pub fn mutate_return_type(&mut self) -> Option<&mut FunctionReturnType> {
         self.return_type.as_mut()
     }
 
+    /// Sets the generic parameters for this function.
     pub fn with_generic_parameters(mut self, generic_parameters: GenericParameters) -> Self {
         self.generic_parameters = Some(generic_parameters);
         self
     }
 
+    /// Sets the generic parameters for this function.
     #[inline]
     pub fn set_generic_parameters(&mut self, generic_parameters: GenericParameters) {
         self.generic_parameters = Some(generic_parameters);
     }
 
+    /// Returns the generic parameters, if any.
     #[inline]
     pub fn get_generic_parameters(&self) -> Option<&GenericParameters> {
         self.generic_parameters.as_ref()
     }
 
+    /// Returns a reference to the function's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns a reference to the function's name.
     #[inline]
     pub fn get_name(&self) -> &FunctionName {
         &self.name
     }
 
+    /// Returns the number of parameters in this function.
     #[inline]
     pub fn parameters_count(&self) -> usize {
         self.parameters.len()
     }
 
+    /// Returns a reference to the function's parameters.
     #[inline]
     pub fn get_parameters(&self) -> &Vec<TypedIdentifier> {
         &self.parameters
     }
 
+    /// Returns an iterator over the function's parameters.
     #[inline]
     pub fn iter_parameters(&self) -> impl Iterator<Item = &TypedIdentifier> {
         self.parameters.iter()
     }
 
+    /// Returns a mutable iterator over the function's parameters.
     #[inline]
     pub fn iter_mut_parameters(&mut self) -> impl Iterator<Item = &mut TypedIdentifier> {
         self.parameters.iter_mut()
     }
 
+    /// Returns whether this function is variadic.
     #[inline]
     pub fn is_variadic(&self) -> bool {
         self.is_variadic
     }
 
+    /// Returns a mutable reference to the function's block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns a mutable reference to the function's name.
     #[inline]
     pub fn mutate_function_name(&mut self) -> &mut FunctionName {
         &mut self.name
     }
 
+    /// Returns a mutable reference to the function's parameters.
     #[inline]
     pub fn mutate_parameters(&mut self) -> &mut Vec<TypedIdentifier> {
         &mut self.parameters
     }
 
+    /// Removes the method from the function name and adds it as a
+    /// field, inserting 'self' as the first parameter.
+    ///
+    /// If the method is not present, this does nothing.
     pub fn remove_method(&mut self) {
         if let Some(method_name) = self.name.remove_method() {
             self.name.push_field(method_name);
@@ -308,11 +367,14 @@ impl FunctionStatement {
         }
     }
 
+    /// Returns whether this function has any parameters.
     #[inline]
     pub fn has_parameters(&self) -> bool {
         !self.parameters.is_empty()
     }
 
+    /// Removes all type information from the function, including return
+    /// type, variadic type, generic parameters, and parameter types.
     pub fn clear_types(&mut self) {
         self.return_type.take();
         self.variadic_type.take();

--- a/src/nodes/statements/generic_for.rs
+++ b/src/nodes/statements/generic_for.rs
@@ -1,12 +1,15 @@
 use crate::nodes::{Block, Expression, Token, TypedIdentifier};
 
+/// Tokens associated with a generic for statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericForTokens {
     pub r#for: Token,
     pub r#in: Token,
     pub r#do: Token,
     pub end: Token,
+    /// The tokens for the commas between identifiers.
     pub identifier_commas: Vec<Token>,
+    /// The tokens for the commas between values.
     pub value_commas: Vec<Token>,
 }
 
@@ -17,6 +20,7 @@ impl GenericForTokens {
     );
 }
 
+/// Represents a generic for loop statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericForStatement {
     identifiers: Vec<TypedIdentifier>,
@@ -26,6 +30,7 @@ pub struct GenericForStatement {
 }
 
 impl GenericForStatement {
+    /// Creates a new generic for statement.
     pub fn new<B: Into<Block>>(
         identifiers: Vec<TypedIdentifier>,
         expressions: Vec<Expression>,
@@ -39,81 +44,97 @@ impl GenericForStatement {
         }
     }
 
+    /// Sets the tokens for this generic for statement.
     pub fn with_tokens(mut self, tokens: GenericForTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this generic for statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: GenericForTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this generic for statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&GenericForTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut GenericForTokens> {
         self.tokens.as_mut()
     }
 
+    /// Returns the loop's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns the list of identifiers that receive iterator values.
     #[inline]
     pub fn get_identifiers(&self) -> &Vec<TypedIdentifier> {
         &self.identifiers
     }
 
+    /// Returns an iterator over the identifiers.
     #[inline]
     pub fn iter_identifiers(&self) -> impl Iterator<Item = &TypedIdentifier> {
         self.identifiers.iter()
     }
 
+    /// Returns the list of expressions that produce the iterator values.
     #[inline]
     pub fn get_expressions(&self) -> &Vec<Expression> {
         &self.expressions
     }
 
+    /// Returns an iterator over the expressions.
     #[inline]
     pub fn iter_expressions(&self) -> impl Iterator<Item = &Expression> {
         self.expressions.iter()
     }
 
+    /// Returns a mutable iterator over the identifiers.
     #[inline]
     pub fn iter_mut_identifiers(&mut self) -> impl Iterator<Item = &mut TypedIdentifier> {
         self.identifiers.iter_mut()
     }
 
+    /// Returns a mutable iterator over the expressions.
     #[inline]
     pub fn iter_mut_expressions(&mut self) -> impl Iterator<Item = &mut Expression> {
         self.expressions.iter_mut()
     }
 
+    /// Returns a mutable reference to the expressions vector.
     #[inline]
     pub fn mutate_expressions(&mut self) -> &mut Vec<Expression> {
         &mut self.expressions
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns the number of identifiers.
     #[inline]
     pub fn identifiers_len(&self) -> usize {
         self.identifiers.len()
     }
 
+    /// Returns the number of expressions.
     #[inline]
     pub fn expressions_len(&self) -> usize {
         self.expressions.len()
     }
 
+    /// Removes type annotations from all identifiers.
     pub fn clear_types(&mut self) {
         for identifier in &mut self.identifiers {
             identifier.remove_type();

--- a/src/nodes/statements/if_statement.rs
+++ b/src/nodes/statements/if_statement.rs
@@ -2,6 +2,7 @@ use std::mem;
 
 use crate::nodes::{Block, Expression, Token};
 
+/// Tokens associated with an if branch.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfBranchTokens {
     pub elseif: Token,
@@ -12,6 +13,7 @@ impl IfBranchTokens {
     super::impl_token_fns!(target = [elseif, then]);
 }
 
+/// Represents a conditional branch in an if statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfBranch {
     condition: Expression,
@@ -20,6 +22,7 @@ pub struct IfBranch {
 }
 
 impl IfBranch {
+    /// Creates a new if branch with the given condition and block.
     pub fn new<E: Into<Expression>, B: Into<Block>>(condition: E, block: B) -> Self {
         Self {
             condition: condition.into(),
@@ -28,6 +31,7 @@ impl IfBranch {
         }
     }
 
+    /// Creates a new if branch with the given condition and an empty block.
     pub fn empty<E: Into<Expression>>(condition: E) -> Self {
         Self {
             condition: condition.into(),
@@ -36,41 +40,49 @@ impl IfBranch {
         }
     }
 
+    /// Sets the tokens for this if branch.
     pub fn with_tokens(mut self, tokens: IfBranchTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this if branch.
     #[inline]
     pub fn set_tokens(&mut self, tokens: IfBranchTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this if branch, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&IfBranchTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the block of code for this branch.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns the condition for this branch.
     #[inline]
     pub fn get_condition(&self) -> &Expression {
         &self.condition
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Takes ownership of the block, leaving an empty block in its place.
     #[inline]
     pub fn take_block(&mut self) -> Block {
         mem::take(&mut self.block)
     }
 
+    /// Returns a mutable reference to the condition.
     #[inline]
     pub fn mutate_condition(&mut self) -> &mut Expression {
         &mut self.condition
@@ -79,6 +91,7 @@ impl IfBranch {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Tokens associated with an if statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfStatementTokens {
     pub r#if: Token,
@@ -94,6 +107,7 @@ impl IfStatementTokens {
     );
 }
 
+/// Represents an if statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IfStatement {
     branches: Vec<IfBranch>,
@@ -102,6 +116,7 @@ pub struct IfStatement {
 }
 
 impl IfStatement {
+    /// Creates a new if statement with the given branches and optional else block.
     pub fn new(branches: Vec<IfBranch>, else_block: Option<Block>) -> Self {
         Self {
             branches,
@@ -110,6 +125,7 @@ impl IfStatement {
         }
     }
 
+    /// Creates a new if statement with a single condition and block.
     pub fn create(condition: impl Into<Expression>, block: impl Into<Block>) -> Self {
         Self {
             branches: vec![IfBranch::new(condition, block)],
@@ -118,31 +134,37 @@ impl IfStatement {
         }
     }
 
+    /// Sets the tokens for this if statement.
     pub fn with_tokens(mut self, tokens: IfStatementTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this if statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: IfStatementTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this if statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&IfStatementTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut IfStatementTokens> {
         self.tokens.as_mut()
     }
 
+    /// Adds a branch to this if statement.
     pub fn with_branch(mut self, branch: IfBranch) -> Self {
         self.branches.push(branch);
         self
     }
 
+    /// Adds a new branch with the given condition and block.
     pub fn with_new_branch(
         mut self,
         condition: impl Into<Expression>,
@@ -152,11 +174,13 @@ impl IfStatement {
         self
     }
 
+    /// Adds an else block to this if statement.
     pub fn with_else_block<B: Into<Block>>(mut self, block: B) -> Self {
         self.else_block.replace(block.into());
         self
     }
 
+    /// Returns mutable references to all blocks in this if statement.
     pub fn mutate_all_blocks(&mut self) -> Vec<&mut Block> {
         let mut blocks: Vec<&mut Block> = self
             .branches
@@ -171,57 +195,68 @@ impl IfStatement {
         blocks
     }
 
+    /// Returns the branches of this if statement.
     #[inline]
     pub fn get_branches(&self) -> &Vec<IfBranch> {
         &self.branches
     }
 
+    /// Returns an iterator over the branches.
     #[inline]
     pub fn iter_branches(&self) -> impl Iterator<Item = &IfBranch> {
         self.branches.iter()
     }
 
+    /// Returns the number of branches.
     #[inline]
     pub fn branch_count(&self) -> usize {
         self.branches.len()
     }
 
+    /// Returns a mutable reference to the branches.
     #[inline]
     pub fn mutate_branches(&mut self) -> &mut Vec<IfBranch> {
         &mut self.branches
     }
 
+    /// Adds a new branch with the given condition and block.
     #[inline]
     pub fn push_new_branch(&mut self, condition: impl Into<Expression>, block: impl Into<Block>) {
         self.branches
             .push(IfBranch::new(condition.into(), block.into()));
     }
 
+    /// Adds a branch to this if statement.
     #[inline]
     pub fn push_branch(&mut self, branch: IfBranch) {
         self.branches.push(branch);
     }
 
+    /// Returns the else block, if any.
     #[inline]
     pub fn get_else_block(&self) -> Option<&Block> {
         self.else_block.as_ref()
     }
 
+    /// Returns a mutable reference to the else block option.
     #[inline]
     pub fn mutate_else_block(&mut self) -> &mut Option<Block> {
         &mut self.else_block
     }
 
+    /// Sets the else block.
     #[inline]
     pub fn set_else_block(&mut self, block: impl Into<Block>) {
         self.else_block = Some(block.into());
     }
 
+    /// Removes the else block, if any.
     #[inline]
     pub fn take_else_block(&mut self) -> Option<Block> {
         self.else_block.take()
     }
 
+    /// Filters branches in-place, ensuring at least one branch remains.
     pub fn retain_branches_mut(&mut self, filter: impl FnMut(&mut IfBranch) -> bool) -> bool {
         self.branches.retain_mut(filter);
         if self.branches.is_empty() {

--- a/src/nodes/statements/last_statement.rs
+++ b/src/nodes/statements/last_statement.rs
@@ -1,8 +1,10 @@
 use crate::nodes::{Expression, Token};
 
+/// Tokens associated with a return statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReturnTokens {
     pub r#return: Token,
+    /// The tokens for the commas between expressions.
     pub commas: Vec<Token>,
 }
 
@@ -13,6 +15,7 @@ impl ReturnTokens {
     );
 }
 
+/// Represents a return statement.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ReturnStatement {
     expressions: Vec<Expression>,
@@ -20,6 +23,7 @@ pub struct ReturnStatement {
 }
 
 impl ReturnStatement {
+    /// Creates a new return statement with the given expressions.
     pub fn new(expressions: Vec<Expression>) -> Self {
         Self {
             expressions,
@@ -31,7 +35,7 @@ impl ReturnStatement {
     /// ```rust
     /// # use darklua_core::nodes::{Expression, ReturnStatement};
     ///
-    /// let statement = ReturnStatement::one(Expression::from(true));
+    /// let statement = ReturnStatement::one(true);
     ///
     /// // unknown case
     /// assert_eq!(statement.len(), 1);
@@ -43,51 +47,61 @@ impl ReturnStatement {
         }
     }
 
+    /// Adds an expression to this return statement.
     pub fn with_expression<E: Into<Expression>>(mut self, expression: E) -> Self {
         self.expressions.push(expression.into());
         self
     }
 
+    /// Returns an iterator over the expressions.
     #[inline]
     pub fn iter_expressions(&self) -> impl Iterator<Item = &Expression> {
         self.expressions.iter()
     }
 
+    /// Converts this return statement into an iterator over its expressions.
     #[inline]
     pub fn into_iter_expressions(self) -> impl Iterator<Item = Expression> {
         self.expressions.into_iter()
     }
 
+    /// Returns a mutable iterator over the expressions.
     #[inline]
     pub fn iter_mut_expressions(&mut self) -> impl Iterator<Item = &mut Expression> {
         self.expressions.iter_mut()
     }
 
+    /// Returns whether this return statement has no expressions.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.expressions.is_empty()
     }
 
+    /// Returns the number of expressions.
     #[inline]
     pub fn len(&self) -> usize {
         self.expressions.len()
     }
 
+    /// Sets the tokens for this return statement.
     pub fn with_tokens(mut self, tokens: ReturnTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this return statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ReturnTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this return statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ReturnTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut ReturnTokens> {
         self.tokens.as_mut()
@@ -96,6 +110,7 @@ impl ReturnStatement {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Represents a statement that can appear as the last statement in a block.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LastStatement {
     Break(Option<Token>),
@@ -104,11 +119,13 @@ pub enum LastStatement {
 }
 
 impl LastStatement {
+    /// Creates a new break statement without a token.
     #[inline]
     pub fn new_break() -> Self {
         Self::Break(None)
     }
 
+    /// Creates a new continue statement without a token.
     #[inline]
     pub fn new_continue() -> Self {
         Self::Continue(None)

--- a/src/nodes/statements/local_assign.rs
+++ b/src/nodes/statements/local_assign.rs
@@ -1,10 +1,14 @@
 use crate::nodes::{Expression, Token, TypedIdentifier};
 
+/// Tokens associated with a local variable assignment statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalAssignTokens {
     pub local: Token,
+    /// The token for the equal sign, if any.
     pub equal: Option<Token>,
+    /// The tokens for the commas between variables.
     pub variable_commas: Vec<Token>,
+    /// The tokens for the commas between values.
     pub value_commas: Vec<Token>,
 }
 
@@ -15,6 +19,7 @@ impl LocalAssignTokens {
     );
 }
 
+/// Represents a local variable assignment statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalAssignStatement {
     variables: Vec<TypedIdentifier>,
@@ -23,6 +28,7 @@ pub struct LocalAssignStatement {
 }
 
 impl LocalAssignStatement {
+    /// Creates a new local assignment statement with the given variables and values.
     pub fn new(variables: Vec<TypedIdentifier>, values: Vec<Expression>) -> Self {
         Self {
             variables,
@@ -31,6 +37,7 @@ impl LocalAssignStatement {
         }
     }
 
+    /// Creates a new local assignment statement with a single variable and no values.
     pub fn from_variable<S: Into<TypedIdentifier>>(variable: S) -> Self {
         Self {
             variables: vec![variable.into()],
@@ -39,45 +46,54 @@ impl LocalAssignStatement {
         }
     }
 
+    /// Sets the tokens for this local assignment statement.
     pub fn with_tokens(mut self, tokens: LocalAssignTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this local assignment statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: LocalAssignTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this local assignment statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&LocalAssignTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut LocalAssignTokens> {
         self.tokens.as_mut()
     }
 
+    /// Adds a variable to this local assignment statement.
     pub fn with_variable<S: Into<TypedIdentifier>>(mut self, variable: S) -> Self {
         self.variables.push(variable.into());
         self
     }
 
+    /// Adds a value to this local assignment statement.
     pub fn with_value<E: Into<Expression>>(mut self, value: E) -> Self {
         self.values.push(value.into());
         self
     }
 
+    /// Converts this statement into a tuple of variables and values.
     pub fn into_assignments(self) -> (Vec<TypedIdentifier>, Vec<Expression>) {
         (self.variables, self.values)
     }
 
+    /// Adds a new variable-value pair to this local assignment statement.
     pub fn append_assignment<S: Into<TypedIdentifier>>(&mut self, variable: S, value: Expression) {
         self.variables.push(variable.into());
         self.values.push(value);
     }
 
+    /// Applies a function to each variable-value pair.
     pub fn for_each_assignment<F>(&mut self, mut callback: F)
     where
         F: FnMut(&mut TypedIdentifier, Option<&mut Expression>),
@@ -88,61 +104,73 @@ impl LocalAssignStatement {
             .for_each(|variable| callback(variable, values.next()));
     }
 
+    /// Returns the list of variables.
     #[inline]
     pub fn get_variables(&self) -> &Vec<TypedIdentifier> {
         &self.variables
     }
 
+    /// Returns an iterator over the variables.
     #[inline]
     pub fn iter_variables(&self) -> impl Iterator<Item = &TypedIdentifier> {
         self.variables.iter()
     }
 
+    /// Returns a mutable iterator over the variables.
     #[inline]
     pub fn iter_mut_variables(&mut self) -> impl Iterator<Item = &mut TypedIdentifier> {
         self.variables.iter_mut()
     }
 
+    /// Appends variables from another vector.
     #[inline]
     pub fn append_variables(&mut self, variables: &mut Vec<TypedIdentifier>) {
         self.variables.append(variables);
     }
 
+    /// Extends the values with elements from an iterator.
     #[inline]
     pub fn extend_values<T: IntoIterator<Item = Expression>>(&mut self, iter: T) {
         self.values.extend(iter);
     }
 
+    /// Returns a mutable iterator over the values.
     #[inline]
     pub fn iter_mut_values(&mut self) -> impl Iterator<Item = &mut Expression> {
         self.values.iter_mut()
     }
 
+    /// Returns an iterator over the values.
     #[inline]
     pub fn iter_values(&self) -> impl Iterator<Item = &Expression> {
         self.values.iter()
     }
 
+    /// Adds a variable to this local assignment statement.
     #[inline]
     pub fn push_variable(&mut self, variable: impl Into<TypedIdentifier>) {
         self.variables.push(variable.into());
     }
 
+    /// Adds a value to this local assignment statement.
     #[inline]
     pub fn push_value(&mut self, value: impl Into<Expression>) {
         self.values.push(value.into());
     }
 
+    /// Appends values from another vector.
     #[inline]
     pub fn append_values(&mut self, values: &mut Vec<Expression>) {
         self.values.append(values);
     }
 
+    /// Returns the last value, if any.
     #[inline]
     pub fn last_value(&self) -> Option<&Expression> {
         self.values.last()
     }
 
+    /// Removes and returns the last value, adjusting tokens as needed.
     pub fn pop_value(&mut self) -> Option<Expression> {
         let value = self.values.pop();
         if let Some(tokens) = &mut self.tokens {
@@ -161,6 +189,7 @@ impl LocalAssignStatement {
         value
     }
 
+    /// Removes and returns the value at the given index, adjusting tokens as needed.
     pub fn remove_value(&mut self, index: usize) -> Option<Expression> {
         if index < self.values.len() {
             let value = self.values.remove(index);
@@ -180,6 +209,9 @@ impl LocalAssignStatement {
         }
     }
 
+    /// Removes and returns the variable at the given index, adjusting tokens as needed.
+    ///
+    /// Returns None if there is only one variable or if the index is out of bounds.
     pub fn remove_variable(&mut self, index: usize) -> Option<TypedIdentifier> {
         let len = self.variables.len();
 
@@ -198,21 +230,25 @@ impl LocalAssignStatement {
         }
     }
 
+    /// Returns the number of values.
     #[inline]
     pub fn values_len(&self) -> usize {
         self.values.len()
     }
 
+    /// Returns the number of variables.
     #[inline]
     pub fn variables_len(&self) -> usize {
         self.variables.len()
     }
 
+    /// Returns whether this statement has any values.
     #[inline]
     pub fn has_values(&self) -> bool {
         !self.values.is_empty()
     }
 
+    /// Removes type annotations from all variables.
     pub fn clear_types(&mut self) {
         for variable in &mut self.variables {
             variable.remove_type();

--- a/src/nodes/statements/local_function.rs
+++ b/src/nodes/statements/local_function.rs
@@ -3,6 +3,7 @@ use crate::nodes::{
     Identifier, Token, TypedIdentifier,
 };
 
+/// Tokens associated with a local function statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalFunctionTokens {
     pub local: Token,
@@ -27,6 +28,7 @@ impl std::ops::DerefMut for LocalFunctionTokens {
     }
 }
 
+/// Represents a local function declaration statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LocalFunctionStatement {
     identifier: Identifier,
@@ -40,6 +42,7 @@ pub struct LocalFunctionStatement {
 }
 
 impl LocalFunctionStatement {
+    /// Creates a new local function statement.
     pub fn new(
         identifier: impl Into<Identifier>,
         block: Block,
@@ -58,6 +61,7 @@ impl LocalFunctionStatement {
         }
     }
 
+    /// Creates a new local function statement with a given name and block.
     pub fn from_name(identifier: impl Into<Identifier>, block: impl Into<Block>) -> Self {
         Self {
             identifier: identifier.into(),
@@ -71,146 +75,179 @@ impl LocalFunctionStatement {
         }
     }
 
+    /// Sets the tokens for this local function statement.
     pub fn with_tokens(mut self, tokens: LocalFunctionTokens) -> Self {
         self.tokens = Some(tokens.into());
         self
     }
 
+    /// Sets the tokens for this local function statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: LocalFunctionTokens) {
         self.tokens = Some(tokens.into());
     }
 
+    /// Returns the tokens for this local function statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&LocalFunctionTokens> {
         self.tokens.as_deref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut LocalFunctionTokens> {
         self.tokens.as_deref_mut()
     }
 
+    /// Adds a parameter to this function.
     pub fn with_parameter(mut self, parameter: impl Into<TypedIdentifier>) -> Self {
         self.parameters.push(parameter.into());
         self
     }
 
+    /// Marks this function as variadic.
     pub fn variadic(mut self) -> Self {
         self.is_variadic = true;
         self
     }
 
+    /// Sets the variadic type for this function.
+    ///
+    /// If the function is not already variadic, this will make it variadic.
     pub fn with_variadic_type(mut self, r#type: impl Into<FunctionVariadicType>) -> Self {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
         self
     }
 
+    /// Sets the variadic type for this function.
+    ///
+    /// If the function is not already variadic, this will make it variadic.
     pub fn set_variadic_type(&mut self, r#type: impl Into<FunctionVariadicType>) {
         self.is_variadic = true;
         self.variadic_type = Some(r#type.into());
     }
 
+    /// Returns the variadic type, if any.
     #[inline]
     pub fn get_variadic_type(&self) -> Option<&FunctionVariadicType> {
         self.variadic_type.as_ref()
     }
 
+    /// Returns whether this function has a variadic type.
     #[inline]
     pub fn has_variadic_type(&self) -> bool {
         self.variadic_type.is_some()
     }
 
+    /// Returns a mutable reference to the variadic type, if any.
     #[inline]
     pub fn mutate_variadic_type(&mut self) -> Option<&mut FunctionVariadicType> {
         self.variadic_type.as_mut()
     }
 
+    /// Sets the return type for this function.
     pub fn with_return_type(mut self, return_type: impl Into<FunctionReturnType>) -> Self {
         self.return_type = Some(return_type.into());
         self
     }
 
+    /// Sets the return type for this function.
     pub fn set_return_type(&mut self, return_type: impl Into<FunctionReturnType>) {
         self.return_type = Some(return_type.into());
     }
 
+    /// Returns the return type, if any.
     #[inline]
     pub fn get_return_type(&self) -> Option<&FunctionReturnType> {
         self.return_type.as_ref()
     }
 
+    /// Returns whether this function has a return type.
     #[inline]
     pub fn has_return_type(&self) -> bool {
         self.return_type.is_some()
     }
 
+    /// Returns a mutable reference to the return type, if any.
     #[inline]
     pub fn mutate_return_type(&mut self) -> Option<&mut FunctionReturnType> {
         self.return_type.as_mut()
     }
 
+    /// Sets the generic parameters for this function.
     pub fn with_generic_parameters(mut self, generic_parameters: GenericParameters) -> Self {
         self.generic_parameters = Some(generic_parameters);
         self
     }
 
+    /// Sets the generic parameters for this function.
     #[inline]
     pub fn set_generic_parameters(&mut self, generic_parameters: GenericParameters) {
         self.generic_parameters = Some(generic_parameters);
     }
 
+    /// Returns the generic parameters, if any.
     #[inline]
     pub fn get_generic_parameters(&self) -> Option<&GenericParameters> {
         self.generic_parameters.as_ref()
     }
 
+    /// Returns a mutable reference to the parameters.
     #[inline]
     pub fn mutate_parameters(&mut self) -> &mut Vec<TypedIdentifier> {
         &mut self.parameters
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns a mutable reference to the identifier.
     #[inline]
     pub fn mutate_identifier(&mut self) -> &mut Identifier {
         &mut self.identifier
     }
 
+    /// Returns the function's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns the function's parameters.
     #[inline]
     pub fn get_parameters(&self) -> &Vec<TypedIdentifier> {
         &self.parameters
     }
 
+    /// Returns an iterator over the parameters.
     #[inline]
     pub fn iter_parameters(&self) -> impl Iterator<Item = &TypedIdentifier> {
         self.parameters.iter()
     }
 
+    /// Returns a mutable iterator over the parameters.
     #[inline]
     pub fn iter_mut_parameters(&mut self) -> impl Iterator<Item = &mut TypedIdentifier> {
         self.parameters.iter_mut()
     }
 
+    /// Returns the function's identifier.
     #[inline]
     pub fn get_identifier(&self) -> &Identifier {
         &self.identifier
     }
 
+    /// Returns the function's name.
     #[inline]
     pub fn get_name(&self) -> &str {
         self.identifier.get_name()
     }
 
+    /// Returns whether this function has a parameter with the given name.
     #[inline]
     pub fn has_parameter(&self, name: &str) -> bool {
         self.parameters
@@ -218,21 +255,25 @@ impl LocalFunctionStatement {
             .any(|parameter| parameter.get_name() == name)
     }
 
+    /// Returns whether this function has parameters.
     #[inline]
     pub fn has_parameters(&self) -> bool {
         !self.parameters.is_empty()
     }
 
+    /// Returns whether this function is variadic.
     #[inline]
     pub fn is_variadic(&self) -> bool {
         self.is_variadic
     }
 
+    /// Returns the number of parameters.
     #[inline]
     pub fn parameters_count(&self) -> usize {
         self.parameters.len()
     }
 
+    /// Removes all type annotations from this function.
     pub fn clear_types(&mut self) {
         self.return_type.take();
         self.variadic_type.take();

--- a/src/nodes/statements/mod.rs
+++ b/src/nodes/statements/mod.rs
@@ -30,20 +30,34 @@ use crate::nodes::FunctionCall;
 
 use super::impl_token_fns;
 
+/// Represents all possible statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Statement {
+    /// An assignment statement (e.g., `a = 1`)
     Assign(AssignStatement),
+    /// A do statement (e.g., `do ... end`)
     Do(DoStatement),
+    /// A function call statement (e.g., `print("Hello")`)
     Call(FunctionCall),
+    /// A compound assignment statement (e.g., `a += 1`)
     CompoundAssign(CompoundAssignStatement),
+    /// A function declaration statement (e.g., `function name() ... end`)
     Function(FunctionStatement),
+    /// A generic for loop (e.g., `for k, v in pairs(t) do ... end`)
     GenericFor(GenericForStatement),
+    /// An if statement (e.g., `if condition then ... elseif ... else ... end`)
     If(IfStatement),
+    /// A local variable assignment (e.g., `local a, b = 1, 2`)
     LocalAssign(LocalAssignStatement),
+    /// A local function declaration (e.g., `local function name() ... end`)
     LocalFunction(LocalFunctionStatement),
+    /// A numeric for loop (e.g., `for i = 1, 10, 2 do ... end`)
     NumericFor(Box<NumericForStatement>),
+    /// A repeat loop (e.g., `repeat ... until condition`)
     Repeat(RepeatStatement),
+    /// A while loop (e.g., `while condition do ... end`)
     While(WhileStatement),
+    /// A type declaration statement (e.g., `type T = string | number`)
     TypeDeclaration(TypeDeclarationStatement),
 }
 

--- a/src/nodes/statements/mod.rs
+++ b/src/nodes/statements/mod.rs
@@ -42,7 +42,7 @@ pub enum Statement {
     /// A compound assignment statement (e.g., `a += 1`)
     CompoundAssign(CompoundAssignStatement),
     /// A function declaration statement (e.g., `function name() ... end`)
-    Function(FunctionStatement),
+    Function(Box<FunctionStatement>),
     /// A generic for loop (e.g., `for k, v in pairs(t) do ... end`)
     GenericFor(GenericForStatement),
     /// An if statement (e.g., `if condition then ... elseif ... else ... end`)
@@ -50,7 +50,7 @@ pub enum Statement {
     /// A local variable assignment (e.g., `local a, b = 1, 2`)
     LocalAssign(LocalAssignStatement),
     /// A local function declaration (e.g., `local function name() ... end`)
-    LocalFunction(LocalFunctionStatement),
+    LocalFunction(Box<LocalFunctionStatement>),
     /// A numeric for loop (e.g., `for i = 1, 10, 2 do ... end`)
     NumericFor(Box<NumericForStatement>),
     /// A repeat loop (e.g., `repeat ... until condition`)
@@ -87,7 +87,7 @@ impl From<FunctionCall> for Statement {
 
 impl From<FunctionStatement> for Statement {
     fn from(function: FunctionStatement) -> Statement {
-        Statement::Function(function)
+        Statement::Function(Box::new(function))
     }
 }
 
@@ -111,7 +111,7 @@ impl From<LocalAssignStatement> for Statement {
 
 impl From<LocalFunctionStatement> for Statement {
     fn from(function: LocalFunctionStatement) -> Statement {
-        Statement::LocalFunction(function)
+        Statement::LocalFunction(Box::new(function))
     }
 }
 

--- a/src/nodes/statements/numeric_for.rs
+++ b/src/nodes/statements/numeric_for.rs
@@ -1,12 +1,15 @@
 use crate::nodes::{Block, Expression, Token, TypedIdentifier};
 
+/// Tokens associated with a numeric for statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NumericForTokens {
     pub r#for: Token,
     pub equal: Token,
     pub r#do: Token,
     pub end: Token,
+    /// The token for the comma between the start and end values.
     pub end_comma: Token,
+    /// The token for the comma between the end and step values.
     pub step_comma: Option<Token>,
 }
 
@@ -17,6 +20,7 @@ impl NumericForTokens {
     );
 }
 
+/// Represents a numeric for loop statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NumericForStatement {
     identifier: TypedIdentifier,
@@ -28,6 +32,7 @@ pub struct NumericForStatement {
 }
 
 impl NumericForStatement {
+    /// Creates a new numeric for statement.
     pub fn new<
         S: Into<TypedIdentifier>,
         E1: Into<Expression>,
@@ -50,81 +55,97 @@ impl NumericForStatement {
         }
     }
 
+    /// Sets the tokens for this numeric for statement.
     pub fn with_tokens(mut self, tokens: NumericForTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this numeric for statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: NumericForTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this numeric for statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&NumericForTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut NumericForTokens> {
         self.tokens.as_mut()
     }
 
+    /// Returns the loop's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns the start expression for the range.
     #[inline]
     pub fn get_start(&self) -> &Expression {
         &self.start
     }
 
+    /// Returns a mutable reference to the start expression.
     #[inline]
     pub fn mutate_start(&mut self) -> &mut Expression {
         &mut self.start
     }
 
+    /// Returns the end expression for the range.
     #[inline]
     pub fn get_end(&self) -> &Expression {
         &self.end
     }
 
+    /// Returns a mutable reference to the end expression.
     #[inline]
     pub fn mutate_end(&mut self) -> &mut Expression {
         &mut self.end
     }
 
+    /// Returns the step expression for the range, if any.
     #[inline]
     pub fn get_step(&self) -> Option<&Expression> {
         self.step.as_ref()
     }
 
+    /// Returns a mutable reference to the step expression option.
     #[inline]
     pub fn mutate_step(&mut self) -> &mut Option<Expression> {
         &mut self.step
     }
 
+    /// Returns the loop variable identifier.
     #[inline]
     pub fn get_identifier(&self) -> &TypedIdentifier {
         &self.identifier
     }
 
+    /// Returns a mutable reference to the loop variable identifier.
     #[inline]
     pub fn mutate_identifier(&mut self) -> &mut TypedIdentifier {
         &mut self.identifier
     }
 
+    /// Sets the loop variable identifier.
     #[inline]
     pub fn set_identifier<S: Into<TypedIdentifier>>(&mut self, identifier: S) {
         self.identifier = identifier.into();
     }
 
+    /// Removes type annotations from the loop variable.
     pub fn clear_types(&mut self) {
         self.identifier.remove_type();
     }

--- a/src/nodes/statements/repeat_statement.rs
+++ b/src/nodes/statements/repeat_statement.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{Block, Expression, Token};
 
+/// Tokens associated with a repeat statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RepeatTokens {
     pub repeat: Token,
@@ -10,6 +11,7 @@ impl RepeatTokens {
     super::impl_token_fns!(target = [repeat, until]);
 }
 
+/// Represents a repeat loop statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RepeatStatement {
     block: Block,
@@ -18,6 +20,7 @@ pub struct RepeatStatement {
 }
 
 impl RepeatStatement {
+    /// Creates a new repeat statement with the given block and condition.
     pub fn new<B: Into<Block>, E: Into<Expression>>(block: B, condition: E) -> Self {
         Self {
             block: block.into(),
@@ -26,46 +29,55 @@ impl RepeatStatement {
         }
     }
 
+    /// Returns the loop's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns the until condition for this repeat loop.
     #[inline]
     pub fn get_condition(&self) -> &Expression {
         &self.condition
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns a mutable reference to the condition.
     #[inline]
     pub fn mutate_condition(&mut self) -> &mut Expression {
         &mut self.condition
     }
 
+    /// Returns mutable references to both the block and condition.
     #[inline]
     pub(crate) fn mutate_block_and_condition(&mut self) -> (&mut Block, &mut Expression) {
         (&mut self.block, &mut self.condition)
     }
 
+    /// Sets the tokens for this repeat statement.
     pub fn with_tokens(mut self, tokens: RepeatTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this repeat statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: RepeatTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this repeat statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&RepeatTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut RepeatTokens> {
         self.tokens.as_mut()

--- a/src/nodes/statements/type_declaration.rs
+++ b/src/nodes/statements/type_declaration.rs
@@ -2,6 +2,7 @@ use crate::nodes::{
     GenericParameterMutRef, GenericParametersWithDefaults, Identifier, Token, Trivia, Type,
 };
 
+/// Tokens associated with a type declaration statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeDeclarationTokens {
     pub r#type: Token,
@@ -16,6 +17,7 @@ impl TypeDeclarationTokens {
     );
 }
 
+/// Represents a type declaration statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeDeclarationStatement {
     name: Identifier,
@@ -26,6 +28,7 @@ pub struct TypeDeclarationStatement {
 }
 
 impl TypeDeclarationStatement {
+    /// Creates a new type declaration with the given name and type.
     pub fn new(name: impl Into<Identifier>, r#type: impl Into<Type>) -> Self {
         Self {
             name: name.into(),
@@ -36,6 +39,7 @@ impl TypeDeclarationStatement {
         }
     }
 
+    /// Sets the generic parameters for this type declaration.
     pub fn with_generic_parameters(
         mut self,
         generic_parameters: GenericParametersWithDefaults,
@@ -44,31 +48,37 @@ impl TypeDeclarationStatement {
         self
     }
 
+    /// Sets the generic parameters for this type declaration.
     #[inline]
     pub fn set_generic_parameters(&mut self, generic_parameters: GenericParametersWithDefaults) {
         self.generic_parameters = Some(generic_parameters);
     }
 
+    /// Returns the generic parameters, if any.
     #[inline]
     pub fn get_generic_parameters(&self) -> Option<&GenericParametersWithDefaults> {
         self.generic_parameters.as_ref()
     }
 
+    /// Returns a mutable reference to the generic parameters, if any.
     #[inline]
     pub fn mutate_generic_parameters(&mut self) -> Option<&mut GenericParametersWithDefaults> {
         self.generic_parameters.as_mut()
     }
 
+    /// Marks this type declaration as exported.
     pub fn export(mut self) -> Self {
         self.exported = true;
         self
     }
 
+    /// Marks this type declaration as exported.
     #[inline]
     pub fn set_exported(&mut self) {
         self.exported = true;
     }
 
+    /// Removes the exported status from this type declaration.
     #[inline]
     pub fn remove_exported(&mut self) {
         self.exported = false;
@@ -77,51 +87,61 @@ impl TypeDeclarationStatement {
         }
     }
 
+    /// Returns whether this type declaration is exported.
     #[inline]
     pub fn is_exported(&self) -> bool {
         self.exported
     }
 
+    /// Returns the declared type.
     #[inline]
     pub fn get_type(&self) -> &Type {
         &self.r#type
     }
 
+    /// Returns a mutable reference to the declared type.
     #[inline]
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.r#type
     }
 
+    /// Returns the name of this type declaration.
     #[inline]
     pub fn get_name(&self) -> &Identifier {
         &self.name
     }
 
+    /// Returns a mutable reference to the name.
     #[inline]
     pub fn mutate_name(&mut self) -> &mut Identifier {
         &mut self.name
     }
 
+    /// Sets the tokens for this type declaration.
     pub fn with_tokens(mut self, tokens: TypeDeclarationTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens for this type declaration.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TypeDeclarationTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this type declaration, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TypeDeclarationTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut TypeDeclarationTokens> {
         self.tokens.as_mut()
     }
 
+    /// Clears all comments from the tokens in this node.
     pub fn clear_comments(&mut self) {
         self.name.clear_comments();
         if let Some(tokens) = &mut self.tokens {
@@ -149,6 +169,7 @@ impl TypeDeclarationStatement {
         }
     }
 
+    /// Clears all whitespaces information from the tokens in this node.
     pub fn clear_whitespaces(&mut self) {
         self.name.clear_whitespaces();
         if let Some(tokens) = &mut self.tokens {

--- a/src/nodes/statements/type_declaration.rs
+++ b/src/nodes/statements/type_declaration.rs
@@ -21,7 +21,7 @@ impl TypeDeclarationTokens {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeDeclarationStatement {
     name: Identifier,
-    r#type: Type,
+    r#type: Box<Type>,
     exported: bool,
     generic_parameters: Option<GenericParametersWithDefaults>,
     tokens: Option<TypeDeclarationTokens>,
@@ -32,7 +32,7 @@ impl TypeDeclarationStatement {
     pub fn new(name: impl Into<Identifier>, r#type: impl Into<Type>) -> Self {
         Self {
             name: name.into(),
-            r#type: r#type.into(),
+            r#type: Box::new(r#type.into()),
             exported: false,
             generic_parameters: None,
             tokens: None,

--- a/src/nodes/statements/while_statement.rs
+++ b/src/nodes/statements/while_statement.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{token::Token, Block, Expression};
 
+/// Tokens associated with a while statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WhileTokens {
     pub r#while: Token,
@@ -11,6 +12,7 @@ impl WhileTokens {
     super::impl_token_fns!(target = [r#while, r#do, end]);
 }
 
+/// Represents a while loop statement.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WhileStatement {
     block: Block,
@@ -19,6 +21,7 @@ pub struct WhileStatement {
 }
 
 impl WhileStatement {
+    /// Creates a new while statement with the given block and condition.
     pub fn new<B: Into<Block>, E: Into<Expression>>(block: B, condition: E) -> Self {
         Self {
             block: block.into(),
@@ -27,41 +30,49 @@ impl WhileStatement {
         }
     }
 
+    /// Sets the tokens for this while statement.
     pub fn with_tokens(mut self, tokens: WhileTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Returns the loop's block.
     #[inline]
     pub fn get_block(&self) -> &Block {
         &self.block
     }
 
+    /// Returns the condition for this while loop.
     #[inline]
     pub fn get_condition(&self) -> &Expression {
         &self.condition
     }
 
+    /// Returns a mutable reference to the block.
     #[inline]
     pub fn mutate_block(&mut self) -> &mut Block {
         &mut self.block
     }
 
+    /// Returns a mutable reference to the condition.
     #[inline]
     pub fn mutate_condition(&mut self) -> &mut Expression {
         &mut self.condition
     }
 
+    /// Sets the tokens for this while statement.
     #[inline]
     pub fn set_tokens(&mut self, tokens: WhileTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens for this while statement, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&WhileTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut WhileTokens> {
         self.tokens.as_mut()

--- a/src/nodes/typed_identifier.rs
+++ b/src/nodes/typed_identifier.rs
@@ -1,5 +1,10 @@
 use crate::nodes::{Identifier, Token, Type};
 
+/// Represents an identifier with an optional type annotation.
+///
+/// TypedIdentifier extends the basic Identifier to support Luau's type system, where
+/// variables and parameters can have explicit type annotations. It stores the
+/// identifier itself, the optional type, and the colon token for source preservation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypedIdentifier {
     name: Identifier,
@@ -8,6 +13,7 @@ pub struct TypedIdentifier {
 }
 
 impl TypedIdentifier {
+    /// Creates a new TypedIdentifier with the given name and no type.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: Identifier::new(name.into()),
@@ -16,46 +22,56 @@ impl TypedIdentifier {
         }
     }
 
+    /// Sets the type for this identifier and returns the updated typed identifier.
     pub fn with_type(mut self, type_value: impl Into<Type>) -> Self {
         self.r#type = Some(type_value.into());
         self
     }
 
+    /// Attaches a colon token to this typed identifier and returns the updated identifier.
     pub fn with_colon_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the colon token for this typed identifier.
     #[inline]
     pub fn set_colon_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns a reference to the colon token of this typed identifier, if any.
     #[inline]
     pub fn get_colon_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a reference to the underlying identifier.
     #[inline]
     pub fn get_identifier(&self) -> &Identifier {
         &self.name
     }
 
+    /// Returns a reference to the type of this identifier, if any.
     #[inline]
     pub fn get_type(&self) -> Option<&Type> {
         self.r#type.as_ref()
     }
 
+    /// Checks if this identifier has a type annotation.
     #[inline]
     pub fn has_type(&self) -> bool {
         self.r#type.is_some()
     }
 
+    /// Returns a mutable reference to the type of this identifier, if any.
     #[inline]
     pub fn mutate_type(&mut self) -> Option<&mut Type> {
         self.r#type.as_mut()
     }
 
+    /// Removes and returns the type annotation of this identifier, if any.
+    /// Also removes the colon token, if any.
     pub fn remove_type(&mut self) -> Option<Type> {
         self.token.take();
         self.r#type.take()

--- a/src/nodes/types/array.rs
+++ b/src/nodes/types/array.rs
@@ -2,6 +2,7 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents an array type annotation (e.g. `{ ElementType }`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArrayType {
     inner_type: Box<Type>,
@@ -9,6 +10,7 @@ pub struct ArrayType {
 }
 
 impl ArrayType {
+    /// Creates a new array type with the specified element type.
     pub fn new(element_type: impl Into<Type>) -> Self {
         Self {
             inner_type: Box::new(element_type.into()),
@@ -16,25 +18,30 @@ impl ArrayType {
         }
     }
 
+    /// Associates tokens with this array type.
     pub fn with_tokens(mut self, tokens: ArrayTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this array type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ArrayTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this array type, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ArrayTypeTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the element type of this array.
     pub fn get_element_type(&self) -> &Type {
         &self.inner_type
     }
 
+    /// Returns a mutable reference to the element type of this array.
     pub fn mutate_element_type(&mut self) -> &mut Type {
         &mut self.inner_type
     }
@@ -42,9 +49,14 @@ impl ArrayType {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains the tokens that define the array type syntax.
+///
+/// These tokens represent the opening and closing braces in an array type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArrayTypeTokens {
+    /// The opening brace token.
     pub opening_brace: Token,
+    /// The closing brace token.
     pub closing_brace: Token,
 }
 

--- a/src/nodes/types/expression_type.rs
+++ b/src/nodes/types/expression_type.rs
@@ -1,5 +1,6 @@
 use crate::nodes::{Expression, Token};
 
+/// Represents a `typeof(expression)` type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExpressionType {
     expression: Box<Expression>,
@@ -7,6 +8,7 @@ pub struct ExpressionType {
 }
 
 impl ExpressionType {
+    /// Creates a new `typeof` type with the given expression.
     pub fn new(expression: impl Into<Expression>) -> Self {
         Self {
             expression: Box::new(expression.into()),
@@ -14,26 +16,31 @@ impl ExpressionType {
         }
     }
 
+    /// Returns the expression whose type is being referenced.
     #[inline]
     pub fn get_expression(&self) -> &Expression {
         &self.expression
     }
 
+    /// Returns a mutable reference to the expression whose type is being referenced.
     #[inline]
     pub fn mutate_expression(&mut self) -> &mut Expression {
         &mut self.expression
     }
 
+    /// Associates tokens with this expression type and returns the modified type.
     pub fn with_tokens(mut self, tokens: ExpressionTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this expression type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ExpressionTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this expression type, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ExpressionTypeTokens> {
         self.tokens.as_ref()
@@ -42,10 +49,16 @@ impl ExpressionType {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains the tokens that define the `typeof` expression syntax.
+///
+/// These tokens represent the `typeof` keyword and the parentheses around the expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExpressionTypeTokens {
+    /// The `typeof` keyword token.
     pub r#typeof: Token,
+    /// The opening parenthesis token.
     pub opening_parenthese: Token,
+    /// The closing parenthesis token.
     pub closing_parenthese: Token,
 }
 

--- a/src/nodes/types/function.rs
+++ b/src/nodes/types/function.rs
@@ -2,6 +2,7 @@ use crate::nodes::{Identifier, Token};
 
 use super::{GenericParameters, GenericTypePack, Type, TypePack, VariadicTypePack};
 
+/// Represents a single argument in a function type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionArgumentType {
     argument_type: Type,
@@ -16,6 +17,7 @@ impl<T: Into<Type>> From<T> for FunctionArgumentType {
 }
 
 impl FunctionArgumentType {
+    /// Creates a new function argument with the specified type.
     pub fn new(argument_type: impl Into<Type>) -> Self {
         Self {
             argument_type: argument_type.into(),
@@ -24,45 +26,54 @@ impl FunctionArgumentType {
         }
     }
 
+    /// Associates a name with this argument.
     pub fn with_name(mut self, name: impl Into<Identifier>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    /// Sets the name of this argument.
     pub fn set_name(&mut self, name: impl Into<Identifier>) {
         self.name = Some(name.into());
     }
 
+    /// Returns the type of this argument.
     #[inline]
     pub fn get_type(&self) -> &Type {
         &self.argument_type
     }
 
+    /// Returns a mutable reference to the type of this argument.
     #[inline]
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.argument_type
     }
 
+    /// Returns the name of this argument, if any.
     #[inline]
     pub fn get_name(&self) -> Option<&Identifier> {
         self.name.as_ref()
     }
 
+    /// Returns a mutable reference to the name of this argument, if any.
     #[inline]
     pub fn mutate_name(&mut self) -> Option<&mut Identifier> {
         self.name.as_mut()
     }
 
+    /// Associates a token with this argument.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token associated with this argument.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this argument, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
@@ -71,11 +82,16 @@ impl FunctionArgumentType {
     super::impl_token_fns!(iter = [name, token]);
 }
 
+/// Represents the return type of a function type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FunctionReturnType {
+    /// A single type return value.
     Type(Box<Type>),
+    /// A pack of types as return values.
     TypePack(TypePack),
+    /// A generic type pack as return values.
     GenericTypePack(GenericTypePack),
+    /// A variadic type pack as return values.
     VariadicTypePack(VariadicTypePack),
 }
 
@@ -108,9 +124,12 @@ impl From<VariadicTypePack> for FunctionReturnType {
     }
 }
 
+/// Represents a variadic argument type in a function annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VariadicArgumentType {
+    /// A generic type pack used as a variadic argument.
     GenericTypePack(GenericTypePack),
+    /// A variadic type pack used as a variadic argument.
     VariadicTypePack(VariadicTypePack),
 }
 
@@ -126,6 +145,7 @@ impl From<VariadicTypePack> for VariadicArgumentType {
     }
 }
 
+/// Represents a function type annotation in Luau.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionType {
     arguments: Vec<FunctionArgumentType>,
@@ -136,6 +156,7 @@ pub struct FunctionType {
 }
 
 impl FunctionType {
+    /// Creates a new function type with the specified return type.
     pub fn new(return_type: impl Into<FunctionReturnType>) -> Self {
         Self {
             arguments: Vec::new(),
@@ -146,26 +167,31 @@ impl FunctionType {
         }
     }
 
+    /// Associates generic parameters with this function type and returns the modified type.
     pub fn with_generic_parameters(mut self, generic_parameters: GenericParameters) -> Self {
         self.generic_parameters = Some(generic_parameters);
         self
     }
 
+    /// Sets the generic parameters of this function type.
     #[inline]
     pub fn set_generic_parameters(&mut self, generic_parameters: GenericParameters) {
         self.generic_parameters = Some(generic_parameters);
     }
 
+    /// Returns the generic parameters of this function type, if any.
     #[inline]
     pub fn get_generic_parameters(&self) -> Option<&GenericParameters> {
         self.generic_parameters.as_ref()
     }
 
+    /// Adds an argument to this function type and returns the modified type.
     pub fn with_argument(mut self, argument: impl Into<FunctionArgumentType>) -> Self {
         self.arguments.push(argument.into());
         self
     }
 
+    /// Adds a named argument to this function type and returns the modified type.
     pub fn with_named_argument(
         mut self,
         name: impl Into<Identifier>,
@@ -176,69 +202,83 @@ impl FunctionType {
         self
     }
 
+    /// Adds an argument to this function type.
     pub fn push_argument(&mut self, argument: impl Into<FunctionArgumentType>) {
         self.arguments.push(argument.into());
     }
 
+    /// Sets this function type to accept variadic arguments of the specified type.
     pub fn with_variadic_type(mut self, variadic_type: impl Into<VariadicArgumentType>) -> Self {
         self.variadic_argument_type = Some(variadic_type.into());
         self
     }
 
+    /// Sets the variadic argument type of this function type.
     pub fn set_variadic_type(&mut self, variadic_type: impl Into<VariadicArgumentType>) {
         self.variadic_argument_type = Some(variadic_type.into());
     }
 
+    /// Returns the variadic argument type of this function, if any.
     #[inline]
     pub fn get_variadic_argument_type(&self) -> Option<&VariadicArgumentType> {
         self.variadic_argument_type.as_ref()
     }
 
+    /// Returns whether this function type has a variadic argument type.
     #[inline]
     pub fn has_variadic_argument_type(&self) -> bool {
         self.variadic_argument_type.is_some()
     }
 
+    /// Returns a mutable reference to the variadic argument type of this function, if any.
     #[inline]
     pub fn mutate_variadic_argument_type(&mut self) -> Option<&mut VariadicArgumentType> {
         self.variadic_argument_type.as_mut()
     }
 
+    /// Returns an iterator over the arguments of this function type.
     #[inline]
     pub fn iter_arguments(&self) -> impl Iterator<Item = &FunctionArgumentType> {
         self.arguments.iter()
     }
 
+    /// Returns a mutable iterator over the arguments of this function type.
     #[inline]
     pub fn iter_mut_arguments(&mut self) -> impl Iterator<Item = &mut FunctionArgumentType> {
         self.arguments.iter_mut()
     }
 
+    /// Returns the number of arguments for this function type.
     #[inline]
     pub fn argument_len(&self) -> usize {
         self.arguments.len()
     }
 
+    /// Returns the return type of this function.
     #[inline]
     pub fn get_return_type(&self) -> &FunctionReturnType {
         &self.return_type
     }
 
+    /// Returns a mutable reference to the return type of this function.
     #[inline]
     pub fn mutate_return_type(&mut self) -> &mut FunctionReturnType {
         &mut self.return_type
     }
 
+    /// Associates tokens with this function type and returns the modified type.
     pub fn with_tokens(mut self, tokens: FunctionTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this function type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: FunctionTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this function type, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&FunctionTypeTokens> {
         self.tokens.as_ref()
@@ -247,11 +287,16 @@ impl FunctionType {
     super::impl_token_fns!(iter = [tokens, generic_parameters, arguments]);
 }
 
+/// Represents the tokens associated with a function type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionTypeTokens {
+    /// The opening parenthesis token.
     pub opening_parenthese: Token,
+    /// The closing parenthesis token.
     pub closing_parenthese: Token,
+    /// The arrow token (->).
     pub arrow: Token,
+    /// The comma tokens between arguments.
     pub commas: Vec<Token>,
 }
 

--- a/src/nodes/types/function.rs
+++ b/src/nodes/types/function.rs
@@ -88,9 +88,9 @@ pub enum FunctionReturnType {
     /// A single type return value.
     Type(Box<Type>),
     /// A pack of types as return values.
-    TypePack(TypePack),
+    TypePack(Box<TypePack>),
     /// A generic type pack as return values.
-    GenericTypePack(GenericTypePack),
+    GenericTypePack(Box<GenericTypePack>),
     /// A variadic type pack as return values.
     VariadicTypePack(VariadicTypePack),
 }
@@ -99,7 +99,7 @@ impl<T: Into<Type>> From<T> for FunctionReturnType {
     fn from(r#type: T) -> Self {
         match r#type.into() {
             Type::Parenthese(parenthese) => {
-                Self::TypePack(TypePack::default().with_type(parenthese.into_inner_type()))
+                Self::TypePack(Box::new(TypePack::default().with_type(parenthese.into_inner_type())))
             }
             other => Self::Type(Box::new(other)),
         }
@@ -108,13 +108,13 @@ impl<T: Into<Type>> From<T> for FunctionReturnType {
 
 impl From<TypePack> for FunctionReturnType {
     fn from(type_pack: TypePack) -> Self {
-        Self::TypePack(type_pack)
+        Self::TypePack(Box::new(type_pack))
     }
 }
 
 impl From<GenericTypePack> for FunctionReturnType {
     fn from(generic_type_pack: GenericTypePack) -> Self {
-        Self::GenericTypePack(generic_type_pack)
+        Self::GenericTypePack(Box::new(generic_type_pack))
     }
 }
 

--- a/src/nodes/types/function.rs
+++ b/src/nodes/types/function.rs
@@ -98,9 +98,9 @@ pub enum FunctionReturnType {
 impl<T: Into<Type>> From<T> for FunctionReturnType {
     fn from(r#type: T) -> Self {
         match r#type.into() {
-            Type::Parenthese(parenthese) => {
-                Self::TypePack(Box::new(TypePack::default().with_type(parenthese.into_inner_type())))
-            }
+            Type::Parenthese(parenthese) => Self::TypePack(Box::new(
+                TypePack::default().with_type(parenthese.into_inner_type()),
+            )),
             other => Self::Type(Box::new(other)),
         }
     }

--- a/src/nodes/types/function_variadic_type.rs
+++ b/src/nodes/types/function_variadic_type.rs
@@ -1,8 +1,11 @@
 use super::{GenericTypePack, Type};
 
+/// Represents a variadic type in a function signature.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FunctionVariadicType {
+    /// A specific type for variadic arguments.
     Type(Type),
+    /// A generic type pack for variadic arguments.
     GenericTypePack(GenericTypePack),
 }
 

--- a/src/nodes/types/function_variadic_type.rs
+++ b/src/nodes/types/function_variadic_type.rs
@@ -4,7 +4,7 @@ use super::{GenericTypePack, Type};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FunctionVariadicType {
     /// A specific type for variadic arguments.
-    Type(Type),
+    Type(Box<Type>),
     /// A generic type pack for variadic arguments.
     GenericTypePack(GenericTypePack),
 }
@@ -17,6 +17,6 @@ impl From<GenericTypePack> for FunctionVariadicType {
 
 impl<T: Into<Type>> From<T> for FunctionVariadicType {
     fn from(value: T) -> Self {
-        Self::Type(value.into())
+        Self::Type(Box::new(value.into()))
     }
 }

--- a/src/nodes/types/generics.rs
+++ b/src/nodes/types/generics.rs
@@ -196,7 +196,7 @@ impl GenericParametersTokens {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GenericTypePackDefault {
     /// A type pack default.
-    TypePack(TypePack),
+    TypePack(Box<TypePack>),
     /// A variadic type pack default.
     VariadicTypePack(VariadicTypePack),
     /// A generic type pack default.
@@ -205,7 +205,7 @@ pub enum GenericTypePackDefault {
 
 impl From<TypePack> for GenericTypePackDefault {
     fn from(type_pack: TypePack) -> Self {
-        Self::TypePack(type_pack)
+        Self::TypePack(Box::new(type_pack))
     }
 }
 
@@ -555,11 +555,11 @@ pub enum GenericParameter {
     /// A simple type variable like `T`.
     TypeVariable(Identifier),
     /// A type variable with a default value like `T = string`.
-    TypeVariableWithDefault(TypeVariableWithDefault),
+    TypeVariableWithDefault(Box<TypeVariableWithDefault>),
     /// A generic type pack like `T...`.
-    GenericTypePack(GenericTypePack),
+    GenericTypePack(Box<GenericTypePack>),
     /// A generic type pack with a default value like `T... = ...string`.
-    GenericTypePackWithDefault(GenericTypePackWithDefault),
+    GenericTypePackWithDefault(Box<GenericTypePackWithDefault>),
 }
 
 impl From<Identifier> for GenericParameter {
@@ -570,19 +570,19 @@ impl From<Identifier> for GenericParameter {
 
 impl From<TypeVariableWithDefault> for GenericParameter {
     fn from(value: TypeVariableWithDefault) -> Self {
-        Self::TypeVariableWithDefault(value)
+        Self::TypeVariableWithDefault(Box::new(value))
     }
 }
 
 impl From<GenericTypePack> for GenericParameter {
     fn from(value: GenericTypePack) -> Self {
-        Self::GenericTypePack(value)
+        Self::GenericTypePack(Box::new(value))
     }
 }
 
 impl From<GenericTypePackWithDefault> for GenericParameter {
     fn from(value: GenericTypePackWithDefault) -> Self {
-        Self::GenericTypePackWithDefault(value)
+        Self::GenericTypePackWithDefault(Box::new(value))
     }
 }
 

--- a/src/nodes/types/generics.rs
+++ b/src/nodes/types/generics.rs
@@ -4,6 +4,10 @@ use crate::nodes::{Identifier, Token, TypePack, VariadicTypePack};
 
 use super::Type;
 
+/// Represents a generic type pack.
+///
+/// Generic type packs represent a pack of types that can be specified later,
+/// written as `T...` where T is a type pack parameter name.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericTypePack {
     // name ...
@@ -12,6 +16,7 @@ pub struct GenericTypePack {
 }
 
 impl GenericTypePack {
+    /// Creates a new generic type pack with the specified name.
     pub fn new(name: impl Into<Identifier>) -> Self {
         Self {
             name: name.into(),
@@ -19,26 +24,31 @@ impl GenericTypePack {
         }
     }
 
+    /// Returns the name of this generic type pack.
     #[inline]
     pub fn get_name(&self) -> &Identifier {
         &self.name
     }
 
+    /// Returns a mutable reference to the name of this generic type pack.
     #[inline]
     pub fn mutate_name(&mut self) -> &mut Identifier {
         &mut self.name
     }
 
+    /// Associates a token with this generic type pack and returns the modified pack.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token associated with this generic type pack.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this generic type pack, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
@@ -50,6 +60,10 @@ impl GenericTypePack {
     );
 }
 
+/// Represents generic parameters in a function or type declaration.
+///
+/// Generic parameters allow type signatures to be parameterized,
+/// written as `<T, U...>` in Luau type annotations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericParameters {
     // generic type list
@@ -59,6 +73,7 @@ pub struct GenericParameters {
 }
 
 impl GenericParameters {
+    /// Creates new generic parameters with a single type variable.
     pub fn from_type_variable(name: impl Into<Identifier>) -> Self {
         Self {
             type_variables: vec![name.into()],
@@ -66,6 +81,8 @@ impl GenericParameters {
             tokens: None,
         }
     }
+
+    /// Creates new generic parameters with a single generic type pack.
     pub fn from_generic_type_pack(generic_type_pack: impl Into<GenericTypePack>) -> Self {
         Self {
             type_variables: Vec::new(),
@@ -74,65 +91,79 @@ impl GenericParameters {
         }
     }
 
+    /// Adds a type variable to these generic parameters.
     pub fn with_type_variable(mut self, type_variable: impl Into<Identifier>) -> Self {
         self.type_variables.push(type_variable.into());
         self
     }
 
+    /// Adds a type variable to these generic parameters.
     pub fn push_type_variable(&mut self, type_variable: impl Into<Identifier>) {
         self.type_variables.push(type_variable.into());
     }
 
+    /// Adds a generic type pack to these generic parameters.
     pub fn push_generic_type_pack(&mut self, generic_pack: GenericTypePack) {
         self.generic_type_packs.push(generic_pack);
     }
 
+    /// Returns the total number of generic parameters.
     #[inline]
     pub fn len(&self) -> usize {
         self.type_variables.len() + self.generic_type_packs.len()
     }
 
+    /// Returns whether there are no generic parameters.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.type_variables.is_empty() && self.generic_type_packs.is_empty()
     }
 
+    /// Returns the number of type variables in these generic parameters.
     #[inline]
     pub fn type_variables_len(&self) -> usize {
         self.type_variables.len()
     }
 
+    /// Returns the number of generic type packs in these generic parameters.
     #[inline]
     pub fn generic_type_packs_len(&self) -> usize {
         self.generic_type_packs.len()
     }
 
+    /// Returns an iterator over the type variables in these generic parameters.
     pub fn iter_type_variable(&self) -> impl Iterator<Item = &Identifier> {
         self.type_variables.iter()
     }
 
+    /// Returns a mutable iterator over the type variables in these generic parameters.
     pub fn iter_mut_type_variable(&mut self) -> impl Iterator<Item = &mut Identifier> {
         self.type_variables.iter_mut()
     }
 
+    /// Returns an iterator over the generic type packs in these generic parameters.
     pub fn iter_generic_type_pack(&self) -> impl Iterator<Item = &GenericTypePack> {
         self.generic_type_packs.iter()
     }
 
+    /// Returns a mutable iterator over the generic type packs in these generic parameters.
     pub fn iter_mut_generic_type_pack(&mut self) -> impl Iterator<Item = &mut GenericTypePack> {
         self.generic_type_packs.iter_mut()
     }
 
+    /// Associates tokens with these generic parameters.
     pub fn with_tokens(mut self, tokens: GenericParametersTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with these generic parameters.
     #[inline]
     pub fn set_tokens(&mut self, tokens: GenericParametersTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with these generic parameters, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&GenericParametersTokens> {
         self.tokens.as_ref()
@@ -141,10 +172,16 @@ impl GenericParameters {
     super::impl_token_fns!(iter = [type_variables, generic_type_packs, tokens]);
 }
 
+/// Contains the tokens that define the generic parameters syntax.
+///
+/// These tokens represent the angle brackets and commas in generic parameters.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericParametersTokens {
+    /// The opening angle bracket token.
     pub opening_list: Token,
+    /// The closing angle bracket token.
     pub closing_list: Token,
+    /// The comma tokens separating the parameters.
     pub commas: Vec<Token>,
 }
 
@@ -155,10 +192,14 @@ impl GenericParametersTokens {
     );
 }
 
+/// Represents the default value for a generic type pack.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GenericTypePackDefault {
+    /// A type pack default.
     TypePack(TypePack),
+    /// A variadic type pack default.
     VariadicTypePack(VariadicTypePack),
+    /// A generic type pack default.
     GenericTypePack(GenericTypePack),
 }
 
@@ -180,6 +221,7 @@ impl From<GenericTypePack> for GenericTypePackDefault {
     }
 }
 
+/// Represents a generic type pack with a default value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericTypePackWithDefault {
     generic_type_pack: GenericTypePack,
@@ -189,6 +231,7 @@ pub struct GenericTypePackWithDefault {
 }
 
 impl GenericTypePackWithDefault {
+    /// Creates a new generic type pack with the specified default value.
     pub fn new(
         generic_type_pack: impl Into<GenericTypePack>,
         default: impl Into<GenericTypePackDefault>,
@@ -200,36 +243,43 @@ impl GenericTypePackWithDefault {
         }
     }
 
+    /// Returns the generic type pack.
     #[inline]
     pub fn get_generic_type_pack(&self) -> &GenericTypePack {
         &self.generic_type_pack
     }
 
+    /// Returns a mutable reference to the generic type pack.
     #[inline]
     pub fn mutate_generic_type_pack(&mut self) -> &mut GenericTypePack {
         &mut self.generic_type_pack
     }
 
+    /// Returns the default type of this generic type pack.
     #[inline]
     pub fn get_default_type(&self) -> &GenericTypePackDefault {
         &self.default
     }
 
+    /// Returns a mutable reference to the default type of this generic type pack.
     #[inline]
     pub fn mutate_default_type(&mut self) -> &mut GenericTypePackDefault {
         &mut self.default
     }
 
+    /// Associates a token with this generic type pack and returns the modified pack.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token associated with this generic type pack.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this generic type pack, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
@@ -238,6 +288,7 @@ impl GenericTypePackWithDefault {
     super::impl_token_fns!(iter = [token]);
 }
 
+/// Represents a type variable with a default value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeVariableWithDefault {
     variable: Identifier,
@@ -247,6 +298,7 @@ pub struct TypeVariableWithDefault {
 }
 
 impl TypeVariableWithDefault {
+    /// Creates a new type variable with the specified default type.
     pub fn new(identifier: impl Into<Identifier>, r#type: impl Into<Type>) -> Self {
         Self {
             variable: identifier.into(),
@@ -255,36 +307,43 @@ impl TypeVariableWithDefault {
         }
     }
 
+    /// Returns the type variable identifier.
     #[inline]
     pub fn get_type_variable(&self) -> &Identifier {
         &self.variable
     }
 
+    /// Returns a mutable reference to the type variable identifier.
     #[inline]
     pub fn mutate_type_variable(&mut self) -> &mut Identifier {
         &mut self.variable
     }
 
+    /// Returns the default type of this type variable.
     #[inline]
     pub fn get_default_type(&self) -> &Type {
         &self.default
     }
 
+    /// Returns a mutable reference to the default type of this type variable.
     #[inline]
     pub fn mutate_default_type(&mut self) -> &mut Type {
         &mut self.default
     }
 
+    /// Associates a token for the `=` operator with this type variable and returns the modified variable.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for the `=` operator associated with this type variable.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token for the `=` operator associated with this type variable, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
@@ -296,6 +355,7 @@ impl TypeVariableWithDefault {
     );
 }
 
+/// Represents a collection of generic parameters that may include default values.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GenericParametersWithDefaults {
     type_variables: Vec<Identifier>,
@@ -305,6 +365,7 @@ pub struct GenericParametersWithDefaults {
 }
 
 impl GenericParametersWithDefaults {
+    /// Creates new generic parameters with a single type variable.
     pub fn from_type_variable(identifier: impl Into<Identifier>) -> Self {
         Self {
             type_variables: vec![identifier.into()],
@@ -314,6 +375,7 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Creates new generic parameters with a single type variable that has a default value.
     pub fn from_type_variable_with_default(
         type_variable_with_default: TypeVariableWithDefault,
     ) -> Self {
@@ -327,6 +389,7 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Creates new generic parameters with a single generic type pack.
     pub fn from_generic_type_pack(generic_type_pack: GenericTypePack) -> Self {
         Self {
             type_variables: Vec::new(),
@@ -336,6 +399,7 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Creates new generic parameters with a single generic type pack that has a default value.
     pub fn from_generic_type_pack_with_default(
         generic_type_pack_with_default: GenericTypePackWithDefault,
     ) -> Self {
@@ -347,15 +411,20 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Adds a type variable to these generic parameters.
     pub fn with_type_variable(mut self, identifier: impl Into<Identifier>) -> Self {
         self.type_variables.push(identifier.into());
         self
     }
 
+    /// Adds a type variable to these generic parameters.
     pub fn push_type_variable(&mut self, type_variable: impl Into<Identifier>) {
         self.type_variables.push(type_variable.into());
     }
 
+    /// Adds a type variable with a default value to these generic parameters.
+    ///
+    /// Returns `None` if the operation would mix type variables with default values and generic type packs.
     pub fn with_type_variable_with_default(
         mut self,
         type_variable_with_default: TypeVariableWithDefault,
@@ -367,6 +436,9 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Adds a type variable with a default value to these generic parameters.
+    ///
+    /// Returns `false` if the operation would mix type variables with default values and generic type packs.
     pub fn push_type_variable_with_default(
         &mut self,
         type_variable_with_default: TypeVariableWithDefault,
@@ -386,6 +458,9 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Adds a generic type pack to these generic parameters.
+    ///
+    /// Returns `None` if the operation would mix generic type packs and type variables with default values.
     pub fn with_generic_type_pack(mut self, generic_type_pack: GenericTypePack) -> Option<Self> {
         if self.push_generic_type_pack(generic_type_pack) {
             Some(self)
@@ -394,6 +469,9 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Adds a generic type pack to these generic parameters.
+    ///
+    /// Returns `false` if the operation would mix generic type packs and type variables with default values.
     pub fn push_generic_type_pack(&mut self, generic_type_pack: GenericTypePack) -> bool {
         match &mut self.middle {
             GenericParametersWithDefaultsMiddle::Empty => {
@@ -409,6 +487,7 @@ impl GenericParametersWithDefaults {
         }
     }
 
+    /// Adds a generic type pack with a default value to these generic parameters.
     pub fn with_generic_type_pack_with_default(
         mut self,
         generic_type_pack_with_default: GenericTypePackWithDefault,
@@ -418,6 +497,7 @@ impl GenericParametersWithDefaults {
         self
     }
 
+    /// Adds a generic type pack with a default value to these generic parameters.
     pub fn push_generic_type_pack_with_default(
         &mut self,
         generic_type_pack_with_default: GenericTypePackWithDefault,
@@ -426,33 +506,40 @@ impl GenericParametersWithDefaults {
             .push(generic_type_pack_with_default);
     }
 
+    /// Associates tokens with these generic parameters.
     pub fn with_tokens(mut self, tokens: GenericParametersTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with these generic parameters.
     #[inline]
     pub fn set_tokens(&mut self, tokens: GenericParametersTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with these generic parameters, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&GenericParametersTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns an iterator over references to the generic parameters.
     pub fn iter(&self) -> impl Iterator<Item = GenericParameterRef<'_>> {
         self.into_iter()
     }
 
+    /// Returns a mutable iterator over references to the generic parameters.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = GenericParameterMutRef<'_>> {
         self.into_iter()
     }
 
+    /// Returns the total number of generic parameters.
     pub fn len(&self) -> usize {
         self.type_variables.len() + self.middle.len() + self.generic_type_packs_with_default.len()
     }
 
+    /// Returns whether there are no generic parameters.
     pub fn is_empty(&self) -> bool {
         self.type_variables.is_empty()
             && self.middle.is_empty()
@@ -462,10 +549,16 @@ impl GenericParametersWithDefaults {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Represents a generic parameter in a type or function signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GenericParameter {
+    /// A simple type variable like `T`.
     TypeVariable(Identifier),
+    /// A type variable with a default value like `T = string`.
     TypeVariableWithDefault(TypeVariableWithDefault),
+    /// A generic type pack like `T...`.
     GenericTypePack(GenericTypePack),
+    /// A generic type pack with a default value like `T... = ...string`.
     GenericTypePackWithDefault(GenericTypePackWithDefault),
 }
 
@@ -493,10 +586,15 @@ impl From<GenericTypePackWithDefault> for GenericParameter {
     }
 }
 
+/// A reference to a generic parameter.
 pub enum GenericParameterRef<'a> {
+    /// A reference to a simple type variable.
     TypeVariable(&'a Identifier),
+    /// A reference to a type variable with a default value.
     TypeVariableWithDefault(&'a TypeVariableWithDefault),
+    /// A reference to a generic type pack.
     GenericTypePack(&'a GenericTypePack),
+    /// A reference to a generic type pack with a default value.
     GenericTypePackWithDefault(&'a GenericTypePackWithDefault),
 }
 
@@ -524,10 +622,15 @@ impl<'a> From<&'a GenericTypePackWithDefault> for GenericParameterRef<'a> {
     }
 }
 
+/// A mutable reference to a generic parameter.
 pub enum GenericParameterMutRef<'a> {
+    /// A mutable reference to a simple type variable.
     TypeVariable(&'a mut Identifier),
+    /// A mutable reference to a type variable with a default value.
     TypeVariableWithDefault(&'a mut TypeVariableWithDefault),
+    /// A mutable reference to a generic type pack.
     GenericTypePack(&'a mut GenericTypePack),
+    /// A mutable reference to a generic type pack with a default value.
     GenericTypePackWithDefault(&'a mut GenericTypePackWithDefault),
 }
 
@@ -555,6 +658,7 @@ impl<'a> From<&'a mut GenericTypePackWithDefault> for GenericParameterMutRef<'a>
     }
 }
 
+/// A utility struct to create iterators over generic parameters.
 pub struct GenericParameterIteratorGeneric<Item, A, B, C, D, IterA, IterB, IterC, IterD>
 where
     IterA: Iterator<Item = A>,

--- a/src/nodes/types/intersection.rs
+++ b/src/nodes/types/intersection.rs
@@ -4,6 +4,7 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents an intersection type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IntersectionType {
     types: Vec<Type>,
@@ -12,6 +13,7 @@ pub struct IntersectionType {
 }
 
 impl IntersectionType {
+    /// Creates a new intersection type with two component types.
     pub fn new(left_type: impl Into<Type>, right_type: impl Into<Type>) -> Self {
         Self {
             types: vec![left_type.into(), right_type.into()],
@@ -20,16 +22,19 @@ impl IntersectionType {
         }
     }
 
+    /// Adds another type to this intersection.
     pub fn with_type(mut self, r#type: impl Into<Type>) -> Self {
         self.types.push(r#type.into());
         self
     }
 
+    /// Associates tokens with this intersection type.
     pub fn with_tokens(mut self, tokens: IntersectionTypeTokens) -> Self {
         self.set_tokens(tokens);
         self
     }
 
+    /// Sets the tokens associated with this intersection type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: IntersectionTypeTokens) {
         if tokens.leading_token.is_some() {
@@ -38,36 +43,43 @@ impl IntersectionType {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this intersection type, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&IntersectionTypeTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the number of component types in this intersection.
     #[inline]
     pub(crate) fn len(&self) -> usize {
         self.types.len()
     }
 
+    /// Returns an iterator over the component types in this intersection.
     #[inline]
     pub fn iter_types(&self) -> impl Iterator<Item = &Type> {
         self.types.iter()
     }
 
+    /// Returns a mutable iterator over the component types in this intersection.
     #[inline]
     pub fn iter_mut_types(&mut self) -> impl Iterator<Item = &mut Type> {
         self.types.iter_mut()
     }
 
+    /// Returns the first component type in this intersection.
     #[inline]
     pub fn first_type(&self) -> &Type {
         self.types.first().unwrap()
     }
 
+    /// Returns the last component type in this intersection.
     #[inline]
     pub fn last_type(&self) -> &Type {
         self.types.last().unwrap()
     }
 
+    /// Returns whether this intersection type has a leading token.
     pub fn has_leading_token(&self) -> bool {
         self.leading_operator
             || self.types.len() < 2
@@ -78,15 +90,18 @@ impl IntersectionType {
                 .unwrap_or_default()
     }
 
+    /// Marks this intersection type as having a leading token and returns the modified type.
     pub fn with_leading_token(mut self) -> Self {
         self.put_leading_token();
         self
     }
 
+    /// Marks this intersection type as having a leading token.
     pub fn put_leading_token(&mut self) {
         self.leading_operator = true;
     }
 
+    /// Removes the leading token from this intersection type.
     pub fn remove_leading_token(&mut self) {
         self.leading_operator = false;
         if let Some(tokens) = &mut self.tokens {
@@ -94,6 +109,7 @@ impl IntersectionType {
         }
     }
 
+    /// Determines if a type needs parentheses when used within an intersection type.
     pub fn intermediate_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -101,6 +117,7 @@ impl IntersectionType {
         )
     }
 
+    /// Determines if the last type in an intersection needs parentheses.
     pub fn last_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -132,9 +149,14 @@ impl iter::FromIterator<Type> for IntersectionType {
     }
 }
 
+/// Contains the tokens that define the intersection type syntax.
+///
+/// These tokens represent the `&` operators that separate type components.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IntersectionTypeTokens {
+    /// Optional leading `&` token before the first type.
     pub leading_token: Option<Token>,
+    /// The `&` tokens separating the type components.
     pub separators: Vec<Token>,
 }
 

--- a/src/nodes/types/mod.rs
+++ b/src/nodes/types/mod.rs
@@ -34,29 +34,46 @@ use crate::nodes::Token;
 
 use super::impl_token_fns;
 
+/// Represents a type annotation in Luau.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Type {
+    /// A named type, such as `string` or a user-defined type.
     Name(TypeName),
+    /// A field access on a type, such as `Module.Type`.
     Field(TypeField),
+    /// The boolean literal type `true`.
     True(Option<Token>),
+    /// The boolean literal type `false`.
     False(Option<Token>),
+    /// The `nil` type.
     Nil(Option<Token>),
+    /// A string literal type, such as `"hello"`.
     String(StringType),
+    /// An array type, such as `{ string }`.
     Array(ArrayType),
+    /// A table type, such as `{ field: Type }`.
     Table(TableType),
+    /// A `typeof(expression)` type.
     TypeOf(ExpressionType),
+    /// A type in parentheses, such as `(string | number)`.
     Parenthese(ParentheseType),
+    /// A function type, such as `(number) -> string`.
     Function(FunctionType),
+    /// An optional type, such as `string?`.
     Optional(OptionalType),
+    /// An intersection type, such as `string & Serializable`.
     Intersection(IntersectionType),
+    /// A union type, such as `string | number`.
     Union(UnionType),
 }
 
 impl Type {
+    /// Creates a new `nil` type.
     pub fn nil() -> Self {
         Self::Nil(None)
     }
 
+    /// Wraps this type in parentheses.
     pub fn in_parentheses(self) -> Type {
         Self::Parenthese(ParentheseType::new(self))
     }

--- a/src/nodes/types/mod.rs
+++ b/src/nodes/types/mod.rs
@@ -40,7 +40,7 @@ pub enum Type {
     /// A named type, such as `string` or a user-defined type.
     Name(TypeName),
     /// A field access on a type, such as `Module.Type`.
-    Field(TypeField),
+    Field(Box<TypeField>),
     /// The boolean literal type `true`.
     True(Option<Token>),
     /// The boolean literal type `false`.
@@ -58,7 +58,7 @@ pub enum Type {
     /// A type in parentheses, such as `(string | number)`.
     Parenthese(ParentheseType),
     /// A function type, such as `(number) -> string`.
-    Function(FunctionType),
+    Function(Box<FunctionType>),
     /// An optional type, such as `string?`.
     Optional(OptionalType),
     /// An intersection type, such as `string & Serializable`.
@@ -105,13 +105,13 @@ impl From<TypeName> for Type {
 
 impl From<TypeField> for Type {
     fn from(type_field: TypeField) -> Self {
-        Self::Field(type_field)
+        Self::Field(Box::new(type_field))
     }
 }
 
 impl From<FunctionType> for Type {
     fn from(function: FunctionType) -> Self {
-        Self::Function(function)
+        Self::Function(Box::new(function))
     }
 }
 

--- a/src/nodes/types/optional.rs
+++ b/src/nodes/types/optional.rs
@@ -2,6 +2,7 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents an optional type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OptionalType {
     inner_type: Box<Type>,
@@ -9,6 +10,7 @@ pub struct OptionalType {
 }
 
 impl OptionalType {
+    /// Creates a new optional type with the specified base type.
     pub fn new(r#type: impl Into<Type>) -> Self {
         Self {
             inner_type: Box::new(r#type.into()),
@@ -16,31 +18,37 @@ impl OptionalType {
         }
     }
 
+    /// Returns the inner base type of this optional type.
     #[inline]
     pub fn get_inner_type(&self) -> &Type {
         &self.inner_type
     }
 
+    /// Returns a mutable reference to the inner base type of this optional type.
     #[inline]
     pub fn mutate_inner_type(&mut self) -> &mut Type {
         &mut self.inner_type
     }
 
+    /// Associates a token with this optional type.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token associated with this optional type.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this optional type, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Determines if a type needs parentheses when marked as optional.
     pub fn needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,

--- a/src/nodes/types/parenthese.rs
+++ b/src/nodes/types/parenthese.rs
@@ -2,6 +2,7 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents a parenthesized type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParentheseType {
     inner_type: Box<Type>,
@@ -9,6 +10,7 @@ pub struct ParentheseType {
 }
 
 impl ParentheseType {
+    /// Creates a new parenthesized type wrapping the specified type.
     pub fn new(r#type: impl Into<Type>) -> Self {
         Self {
             inner_type: Box::new(r#type.into()),
@@ -16,36 +18,43 @@ impl ParentheseType {
         }
     }
 
+    /// Returns the inner type wrapped by these parentheses.
     #[inline]
     pub fn get_inner_type(&self) -> &Type {
         &self.inner_type
     }
 
+    /// Consumes this parenthesized type and returns the inner type.
     #[inline]
     pub fn into_inner_type(self) -> Type {
         *self.inner_type
     }
 
+    /// Returns a mutable reference to the inner type wrapped by these parentheses.
     #[inline]
     pub fn mutate_inner_type(&mut self) -> &mut Type {
         &mut self.inner_type
     }
 
+    /// Associates tokens with this parenthesized type.
     pub fn with_tokens(mut self, tokens: ParentheseTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this parenthesized type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: ParentheseTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this parenthesized type, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&ParentheseTypeTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens of this parenthesized type, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut ParentheseTypeTokens> {
         self.tokens.as_mut()
@@ -54,9 +63,12 @@ impl ParentheseType {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains the tokens that define the parenthesized type syntax.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParentheseTypeTokens {
+    /// The left parenthesis token.
     pub left_parenthese: Token,
+    /// The right parenthesis token.
     pub right_parenthese: Token,
 }
 

--- a/src/nodes/types/string_type.rs
+++ b/src/nodes/types/string_type.rs
@@ -1,62 +1,74 @@
 use crate::nodes::{StringError, StringExpression, Token};
 
+/// Represents a string literal used in type annotations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringType {
     value: StringExpression,
 }
 
 impl StringType {
+    /// Creates a new string type from a raw Lua string literal.
     pub fn new(string: &str) -> Result<Self, StringError> {
         StringExpression::new(string).map(|value| Self { value })
     }
 
+    /// Creates an empty string type.
     pub fn empty() -> Self {
         Self {
             value: StringExpression::empty(),
         }
     }
 
+    /// Creates a string type from a value.
     pub fn from_value<T: Into<String>>(value: T) -> Self {
         Self {
             value: StringExpression::from_value(value.into()),
         }
     }
 
+    /// Associates a token with this string type.
     pub fn with_token(mut self, token: Token) -> Self {
         self.value.set_token(token);
         self
     }
 
+    /// Sets the token associated with this string type.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.value.set_token(token);
     }
 
+    /// Returns the token associated with this string type, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.value.get_token()
     }
 
+    /// Returns the string value of this type.
     #[inline]
     pub fn get_value(&self) -> &str {
         self.value.get_value()
     }
 
+    /// Consumes this string type and returns its string value.
     #[inline]
     pub fn into_value(self) -> String {
         self.value.into_value()
     }
 
+    /// Returns whether this string type is a multiline string.
     #[inline]
     pub fn is_multiline(&self) -> bool {
         self.value.is_multiline()
     }
 
+    /// Returns whether this string type uses single quotes.
     #[inline]
     pub fn has_single_quote(&self) -> bool {
         self.value.has_single_quote()
     }
 
+    /// Returns whether this string type uses double quotes.
     #[inline]
     pub fn has_double_quote(&self) -> bool {
         self.value.has_double_quote()

--- a/src/nodes/types/table.rs
+++ b/src/nodes/types/table.rs
@@ -2,6 +2,7 @@ use crate::nodes::{Identifier, Token, Trivia};
 
 use super::{StringType, Type};
 
+/// Represents an indexer in a table type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableIndexerType {
     key_type: Type,
@@ -10,6 +11,7 @@ pub struct TableIndexerType {
 }
 
 impl TableIndexerType {
+    /// Creates a new table indexer with the specified key and value types.
     pub fn new(key_type: impl Into<Type>, value_type: impl Into<Type>) -> Self {
         Self {
             key_type: key_type.into(),
@@ -18,36 +20,43 @@ impl TableIndexerType {
         }
     }
 
+    /// Returns the key type of this indexer.
     #[inline]
     pub fn get_key_type(&self) -> &Type {
         &self.key_type
     }
 
+    /// Returns a mutable reference to the key type of this indexer.
     #[inline]
     pub fn mutate_key_type(&mut self) -> &mut Type {
         &mut self.key_type
     }
 
+    /// Returns the value type of this indexer.
     #[inline]
     pub fn get_value_type(&self) -> &Type {
         &self.value_type
     }
 
+    /// Returns a mutable reference to the value type of this indexer.
     #[inline]
     pub fn mutate_value_type(&mut self) -> &mut Type {
         &mut self.value_type
     }
 
+    /// Associates tokens with this indexer and returns the modified indexer.
     pub fn with_tokens(mut self, token: TableIndexTypeTokens) -> Self {
         self.tokens = Some(token);
         self
     }
 
+    /// Sets the tokens associated with this indexer.
     #[inline]
     pub fn set_tokens(&mut self, token: TableIndexTypeTokens) {
         self.tokens = Some(token);
     }
 
+    /// Returns the tokens associated with this indexer, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TableIndexTypeTokens> {
         self.tokens.as_ref()
@@ -56,10 +65,14 @@ impl TableIndexerType {
     super::impl_token_fns!(iter = [tokens]);
 }
 
+/// Contains the tokens that define an indexer's syntax.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableIndexTypeTokens {
+    /// The opening bracket token.
     pub opening_bracket: Token,
+    /// The closing bracket token.
     pub closing_bracket: Token,
+    /// The colon token.
     pub colon: Token,
 }
 
@@ -67,6 +80,7 @@ impl TableIndexTypeTokens {
     super::impl_token_fns!(target = [opening_bracket, closing_bracket, colon]);
 }
 
+/// Represents a named property in a table type annotation (i.e. `name: Type`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TablePropertyType {
     property: Identifier,
@@ -75,6 +89,7 @@ pub struct TablePropertyType {
 }
 
 impl TablePropertyType {
+    /// Creates a new table property with the specified name and type.
     pub fn new(property: impl Into<Identifier>, r#type: impl Into<Type>) -> Self {
         Self {
             property: property.into(),
@@ -83,36 +98,43 @@ impl TablePropertyType {
         }
     }
 
+    /// Returns the identifier of this property.
     #[inline]
     pub fn get_identifier(&self) -> &Identifier {
         &self.property
     }
 
+    /// Returns a mutable reference to the identifier of this property.
     #[inline]
     pub fn mutate_identifier(&mut self) -> &mut Identifier {
         &mut self.property
     }
 
+    /// Returns the type of this property.
     #[inline]
     pub fn get_type(&self) -> &Type {
         &self.r#type
     }
 
+    /// Returns a mutable reference to the type of this property.
     #[inline]
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.r#type
     }
 
+    /// Associates a token for the colon with this property.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token for the colon associated with this property.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token for the colon associated with this property, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
@@ -121,6 +143,7 @@ impl TablePropertyType {
     super::impl_token_fns!(target = [property] iter = [token]);
 }
 
+/// Represents a string literal property in a table type annotation (i.e. `["key"]: Type`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableLiteralPropertyType {
     string: StringType,
@@ -129,6 +152,7 @@ pub struct TableLiteralPropertyType {
 }
 
 impl TableLiteralPropertyType {
+    /// Creates a new string literal property with the specified key and type.
     pub fn new(string: StringType, r#type: impl Into<Type>) -> Self {
         Self {
             string,
@@ -137,36 +161,43 @@ impl TableLiteralPropertyType {
         }
     }
 
+    /// Returns the string key of this property.
     #[inline]
     pub fn get_string(&self) -> &StringType {
         &self.string
     }
 
+    /// Returns a mutable reference to the string key of this property.
     #[inline]
     pub fn mutate_string(&mut self) -> &mut StringType {
         &mut self.string
     }
 
+    /// Returns the type of this property.
     #[inline]
     pub fn get_type(&self) -> &Type {
         &self.r#type
     }
 
+    /// Returns a mutable reference to the type of this property.
     #[inline]
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.r#type
     }
 
+    /// Associates tokens with this property.
     pub fn with_tokens(mut self, tokens: TableIndexTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this property.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TableIndexTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this property, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TableIndexTypeTokens> {
         self.tokens.as_ref()
@@ -175,14 +206,19 @@ impl TableLiteralPropertyType {
     super::impl_token_fns!(target = [string] iter = [tokens]);
 }
 
+/// Represents an entry in a table type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TableEntryType {
+    /// A named property entry.
     Property(TablePropertyType),
+    /// A string literal property entry.
     Literal(TableLiteralPropertyType),
+    /// An indexer entry.
     Indexer(TableIndexerType),
 }
 
 impl TableEntryType {
+    /// Removes all comments from this table entry.
     pub fn clear_comments(&mut self) {
         match self {
             TableEntryType::Property(property) => property.clear_comments(),
@@ -191,6 +227,7 @@ impl TableEntryType {
         }
     }
 
+    /// Removes all whitespace from this table entry.
     pub fn clear_whitespaces(&mut self) {
         match self {
             TableEntryType::Property(property) => property.clear_whitespaces(),
@@ -242,6 +279,7 @@ impl From<TableIndexerType> for TableEntryType {
     }
 }
 
+/// Represents a table type annotation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TableType {
     entries: Vec<TableEntryType>,
@@ -249,6 +287,7 @@ pub struct TableType {
 }
 
 impl TableType {
+    /// Creates a new table type with a property and returns the modified table type.
     pub fn with_new_property(
         mut self,
         property: impl Into<Identifier>,
@@ -259,11 +298,13 @@ impl TableType {
         self
     }
 
+    /// Adds a property to this table type and returns the modified table type.
     pub fn with_property(mut self, property: impl Into<TableEntryType>) -> Self {
         self.push_property(property.into());
         self
     }
 
+    /// Adds a property to this table type.
     #[inline]
     pub fn push_property(&mut self, property: impl Into<TableEntryType>) {
         let property = property.into();
@@ -277,11 +318,15 @@ impl TableType {
         }
     }
 
+    /// Sets the indexer type for this table type and returns the modified table type.
     pub fn with_indexer_type(mut self, indexer_type: TableIndexerType) -> Self {
         self.set_indexer_type(indexer_type);
         self
     }
 
+    /// Sets the indexer type for this table type.
+    /// If the key type is a string, converts it to a string literal property.
+    /// Returns the previous indexer type if one existed.
     #[inline]
     pub fn set_indexer_type(&mut self, indexer_type: TableIndexerType) -> Option<TableIndexerType> {
         match indexer_type.key_type {
@@ -314,6 +359,7 @@ impl TableType {
         }
     }
 
+    /// Returns whether this table type has an indexer.
     #[inline]
     pub fn has_indexer_type(&self) -> bool {
         self.entries
@@ -321,36 +367,43 @@ impl TableType {
             .any(|entry| matches!(entry, TableEntryType::Indexer(_)))
     }
 
+    /// Returns the number of entries in this table type.
     #[inline]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
+    /// Returns whether this table type has no entries.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
 
+    /// Returns an iterator over the entries in this table type.
     #[inline]
     pub fn iter_entries(&self) -> impl Iterator<Item = &TableEntryType> {
         self.entries.iter()
     }
 
+    /// Returns a mutable iterator over the entries in this table type.
     #[inline]
     pub fn iter_mut_entries(&mut self) -> impl Iterator<Item = &mut TableEntryType> {
         self.entries.iter_mut()
     }
 
+    /// Associates tokens with this table type and returns the modified table type.
     pub fn with_tokens(mut self, tokens: TableTypeTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this table type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TableTypeTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this table type, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TableTypeTokens> {
         self.tokens.as_ref()
@@ -359,10 +412,14 @@ impl TableType {
     super::impl_token_fns!(iter = [entries, tokens]);
 }
 
+/// Contains the tokens that define a table type's syntax.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableTypeTokens {
+    /// The opening brace token.
     pub opening_brace: Token,
+    /// The closing brace token.
     pub closing_brace: Token,
+    /// The comma tokens separating the entries.
     pub separators: Vec<Token>,
 }
 

--- a/src/nodes/types/table.rs
+++ b/src/nodes/types/table.rs
@@ -5,8 +5,8 @@ use super::{StringType, Type};
 /// Represents an indexer in a table type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableIndexerType {
-    key_type: Type,
-    value_type: Type,
+    key_type: Box<Type>,
+    value_type: Box<Type>,
     tokens: Option<TableIndexTypeTokens>,
 }
 
@@ -14,8 +14,8 @@ impl TableIndexerType {
     /// Creates a new table indexer with the specified key and value types.
     pub fn new(key_type: impl Into<Type>, value_type: impl Into<Type>) -> Self {
         Self {
-            key_type: key_type.into(),
-            value_type: value_type.into(),
+            key_type: Box::new(key_type.into()),
+            value_type: Box::new(value_type.into()),
             tokens: None,
         }
     }
@@ -84,7 +84,7 @@ impl TableIndexTypeTokens {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TablePropertyType {
     property: Identifier,
-    r#type: Type,
+    r#type: Box<Type>,
     token: Option<Token>,
 }
 
@@ -93,7 +93,7 @@ impl TablePropertyType {
     pub fn new(property: impl Into<Identifier>, r#type: impl Into<Type>) -> Self {
         Self {
             property: property.into(),
-            r#type: r#type.into(),
+            r#type: Box::new(r#type.into()),
             token: None,
         }
     }
@@ -147,7 +147,7 @@ impl TablePropertyType {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TableLiteralPropertyType {
     string: StringType,
-    r#type: Type,
+    r#type: Box<Type>,
     tokens: Option<TableIndexTypeTokens>,
 }
 
@@ -156,7 +156,7 @@ impl TableLiteralPropertyType {
     pub fn new(string: StringType, r#type: impl Into<Type>) -> Self {
         Self {
             string,
-            r#type: r#type.into(),
+            r#type: Box::new(r#type.into()),
             tokens: None,
         }
     }
@@ -329,7 +329,7 @@ impl TableType {
     /// Returns the previous indexer type if one existed.
     #[inline]
     pub fn set_indexer_type(&mut self, indexer_type: TableIndexerType) -> Option<TableIndexerType> {
-        match indexer_type.key_type {
+        match *indexer_type.key_type {
             Type::String(string_type) => {
                 self.entries
                     .push(TableEntryType::Literal(TableLiteralPropertyType {

--- a/src/nodes/types/type_field.rs
+++ b/src/nodes/types/type_field.rs
@@ -2,6 +2,7 @@ use crate::nodes::{Identifier, Token};
 
 use super::TypeName;
 
+/// Represents a field access on a type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeField {
     namespace: Identifier,
@@ -10,6 +11,7 @@ pub struct TypeField {
 }
 
 impl TypeField {
+    /// Creates a new type field with the specified namespace and type name.
     pub fn new(namespace: impl Into<Identifier>, type_name: TypeName) -> Self {
         Self {
             namespace: namespace.into(),
@@ -18,32 +20,39 @@ impl TypeField {
         }
     }
 
+    /// Returns the type name part of this field access.
     pub fn get_type_name(&self) -> &TypeName {
         &self.name
     }
 
+    /// Returns a mutable reference to the type name part of this field access.
     pub fn mutate_type_name(&mut self) -> &mut TypeName {
         &mut self.name
     }
 
+    /// Returns the namespace identifier of this field access.
     pub fn get_namespace(&self) -> &Identifier {
         &self.namespace
     }
 
+    /// Returns a mutable reference to the namespace identifier of this field access.
     pub fn mutate_namespace(&mut self) -> &mut Identifier {
         &mut self.namespace
     }
 
+    /// Associates a token with this type field and returns the modified field.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the token associated with this type field.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the token associated with this type field, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()

--- a/src/nodes/types/type_name.rs
+++ b/src/nodes/types/type_name.rs
@@ -4,6 +4,7 @@ use crate::nodes::{Identifier, Token};
 
 use super::{GenericTypePack, Type, TypePack, VariadicTypePack};
 
+/// Represents a named type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeName {
     type_name: Identifier,
@@ -11,6 +12,7 @@ pub struct TypeName {
 }
 
 impl TypeName {
+    /// Creates a new type name with the specified identifier.
     pub fn new(type_name: impl Into<Identifier>) -> Self {
         Self {
             type_name: type_name.into(),
@@ -18,16 +20,19 @@ impl TypeName {
         }
     }
 
+    /// Associates type parameters with this type name.
     pub fn with_type_parameters(mut self, type_parameters: TypeParameters) -> Self {
         self.type_parameters = Some(type_parameters);
         self
     }
 
+    /// Adds a type parameter to this type name.
     pub fn with_type_parameter(mut self, parameter: impl Into<TypeParameter>) -> Self {
         self.push_type_parameter(parameter.into());
         self
     }
 
+    /// Adds a type parameter to this type name.
     pub fn push_type_parameter(&mut self, parameter: impl Into<TypeParameter>) {
         if let Some(parameters) = &mut self.type_parameters {
             parameters.push_parameter(parameter.into());
@@ -39,26 +44,31 @@ impl TypeName {
         }
     }
 
+    /// Returns the identifier of this type name.
     #[inline]
     pub fn get_type_name(&self) -> &Identifier {
         &self.type_name
     }
 
+    /// Returns a mutable reference to the identifier of this type name.
     #[inline]
     pub fn mutate_type_name(&mut self) -> &mut Identifier {
         &mut self.type_name
     }
 
+    /// Returns the type parameters of this type name, if any.
     #[inline]
     pub fn get_type_parameters(&self) -> Option<&TypeParameters> {
         self.type_parameters.as_ref()
     }
 
+    /// Returns whether this type name has type parameters.
     #[inline]
     pub fn has_type_parameters(&self) -> bool {
         self.type_parameters.is_some()
     }
 
+    /// Returns a mutable reference to the type parameters of this type name, if any.
     #[inline]
     pub fn mutate_type_parameters(&mut self) -> Option<&mut TypeParameters> {
         self.type_parameters.as_mut()
@@ -67,6 +77,10 @@ impl TypeName {
     super::impl_token_fns!(target = [type_name] iter = [type_parameters]);
 }
 
+/// Represents a collection of type parameters in a generic type.
+///
+/// Type parameters are used in generic types, written as `Array<T>`
+/// or `Map<K, V>` in type annotations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeParameters {
     parameters: Vec<TypeParameter>,
@@ -74,6 +88,7 @@ pub struct TypeParameters {
 }
 
 impl TypeParameters {
+    /// Creates new type parameters with a single initial parameter.
     pub fn new(parameter: impl Into<TypeParameter>) -> Self {
         Self {
             parameters: vec![parameter.into()],
@@ -81,45 +96,54 @@ impl TypeParameters {
         }
     }
 
+    /// Adds a type parameter and returns the modified parameters.
     pub fn with_parameter(mut self, parameter: impl Into<TypeParameter>) -> Self {
         self.parameters.push(parameter.into());
         self
     }
 
+    /// Adds a type parameter.
     pub fn push_parameter(&mut self, parameter: impl Into<TypeParameter>) {
         self.parameters.push(parameter.into());
     }
 
+    /// Associates tokens with these type parameters.
     pub fn with_tokens(mut self, tokens: TypeParametersTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Returns an iterator over the type parameters.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &TypeParameter> {
         self.parameters.iter()
     }
 
+    /// Returns a mutable iterator over the type parameters.
     #[inline]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut TypeParameter> {
         self.parameters.iter_mut()
     }
 
+    /// Returns the number of type parameters.
     #[inline]
     pub fn len(&self) -> usize {
         self.parameters.len()
     }
 
+    /// Returns whether there are no type parameters.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.parameters.is_empty()
     }
 
+    /// Sets the tokens associated with these type parameters.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TypeParametersTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with these type parameters, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TypeParametersTokens> {
         self.tokens.as_ref()
@@ -164,11 +188,16 @@ impl<'a> IntoIterator for &'a TypeParameters {
     }
 }
 
+/// Represents a type parameter in a generic type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TypeParameter {
+    /// A single type parameter.
     Type(Type),
+    /// A type pack parameter.
     TypePack(TypePack),
+    /// A variadic type pack parameter.
     VariadicTypePack(VariadicTypePack),
+    /// A generic type pack parameter.
     GenericTypePack(GenericTypePack),
 }
 
@@ -201,10 +230,14 @@ impl From<GenericTypePack> for TypeParameter {
     }
 }
 
+/// Contains the tokens that define the type parameters syntax.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeParametersTokens {
+    /// The opening angle bracket token.
     pub opening_list: Token,
+    /// The closing angle bracket token.
     pub closing_list: Token,
+    /// The comma tokens separating the parameters.
     pub commas: Vec<Token>,
 }
 

--- a/src/nodes/types/type_name.rs
+++ b/src/nodes/types/type_name.rs
@@ -8,7 +8,7 @@ use super::{GenericTypePack, Type, TypePack, VariadicTypePack};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeName {
     type_name: Identifier,
-    type_parameters: Option<TypeParameters>,
+    type_parameters: Option<Box<TypeParameters>>,
 }
 
 impl TypeName {
@@ -22,7 +22,7 @@ impl TypeName {
 
     /// Associates type parameters with this type name.
     pub fn with_type_parameters(mut self, type_parameters: TypeParameters) -> Self {
-        self.type_parameters = Some(type_parameters);
+        self.type_parameters = Some(Box::new(type_parameters));
         self
     }
 
@@ -37,10 +37,10 @@ impl TypeName {
         if let Some(parameters) = &mut self.type_parameters {
             parameters.push_parameter(parameter.into());
         } else {
-            self.type_parameters = Some(TypeParameters {
+            self.type_parameters = Some(Box::new(TypeParameters {
                 parameters: vec![parameter.into()],
                 tokens: None,
-            })
+            }))
         }
     }
 
@@ -59,7 +59,7 @@ impl TypeName {
     /// Returns the type parameters of this type name, if any.
     #[inline]
     pub fn get_type_parameters(&self) -> Option<&TypeParameters> {
-        self.type_parameters.as_ref()
+        self.type_parameters.as_deref()
     }
 
     /// Returns whether this type name has type parameters.
@@ -71,7 +71,7 @@ impl TypeName {
     /// Returns a mutable reference to the type parameters of this type name, if any.
     #[inline]
     pub fn mutate_type_parameters(&mut self) -> Option<&mut TypeParameters> {
-        self.type_parameters.as_mut()
+        self.type_parameters.as_deref_mut()
     }
 
     super::impl_token_fns!(target = [type_name] iter = [type_parameters]);

--- a/src/nodes/types/type_pack.rs
+++ b/src/nodes/types/type_pack.rs
@@ -4,6 +4,7 @@ use crate::nodes::Token;
 
 use super::{Type, VariadicArgumentType};
 
+/// Represents a pack of types.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct TypePack {
     types: Vec<Type>,
@@ -12,74 +13,89 @@ pub struct TypePack {
 }
 
 impl TypePack {
+    /// Adds a type to this type pack and returns the modified pack.
     pub fn with_type(mut self, r#type: impl Into<Type>) -> Self {
         self.types.push(r#type.into());
         self
     }
 
+    /// Adds a type to this type pack.
     pub fn push_type(&mut self, r#type: impl Into<Type>) {
         self.types.push(r#type.into());
     }
 
+    /// Sets this type pack to include a variadic type and returns the modified pack.
     pub fn with_variadic_type(mut self, variadic_type: impl Into<VariadicArgumentType>) -> Self {
         self.variadic_type = Some(variadic_type.into());
         self
     }
 
+    /// Sets the variadic type of this type pack.
     pub fn set_variadic_type(&mut self, variadic_type: impl Into<VariadicArgumentType>) {
         self.variadic_type = Some(variadic_type.into());
     }
 
+    /// Returns the variadic type of this type pack, if any.
     #[inline]
     pub fn get_variadic_type(&self) -> Option<&VariadicArgumentType> {
         self.variadic_type.as_ref()
     }
 
+    /// Returns whether this type pack has a variadic type.
     #[inline]
     pub fn has_variadic_type(&self) -> bool {
         self.variadic_type.is_some()
     }
 
+    /// Returns a mutable reference to the variadic type of this type pack, if any.
     #[inline]
     pub fn mutate_variadic_type(&mut self) -> Option<&mut VariadicArgumentType> {
         self.variadic_type.as_mut()
     }
 
+    /// Returns the number of types in this type pack, excluding any variadic type.
     #[inline]
     pub fn len(&self) -> usize {
         self.types.len()
     }
 
+    /// Returns whether this type pack contains no types, excluding any variadic type.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.types.is_empty()
     }
 
+    /// Returns an iterator over the types in this type pack.
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &Type> {
         self.types.iter()
     }
 
+    /// Returns a mutable iterator over the types in this type pack.
     #[inline]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Type> {
         self.types.iter_mut()
     }
 
+    /// Associates tokens with this type pack and returns the modified pack.
     pub fn with_tokens(mut self, tokens: TypePackTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
+    /// Sets the tokens associated with this type pack.
     #[inline]
     pub fn set_tokens(&mut self, tokens: TypePackTokens) {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this type pack, if any.
     #[inline]
     pub fn get_tokens(&self) -> Option<&TypePackTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns a mutable reference to the tokens of this type pack, if any.
     #[inline]
     pub fn mutate_tokens(&mut self) -> Option<&mut TypePackTokens> {
         self.tokens.as_mut()
@@ -125,10 +141,16 @@ impl<'a> IntoIterator for &'a TypePack {
     }
 }
 
+/// Contains the tokens that define the type pack syntax.
+///
+/// These tokens represent the parentheses and commas in a type pack.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypePackTokens {
+    /// The left parenthesis token.
     pub left_parenthese: Token,
+    /// The right parenthesis token.
     pub right_parenthese: Token,
+    /// The comma tokens separating the types.
     pub commas: Vec<Token>,
 }
 

--- a/src/nodes/types/union.rs
+++ b/src/nodes/types/union.rs
@@ -4,6 +4,7 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents a union type annotation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnionType {
     types: Vec<Type>,
@@ -12,6 +13,7 @@ pub struct UnionType {
 }
 
 impl UnionType {
+    /// Creates a new union type with two alternative types.
     pub fn new(left_type: impl Into<Type>, right_type: impl Into<Type>) -> Self {
         Self {
             types: vec![left_type.into(), right_type.into()],
@@ -20,11 +22,13 @@ impl UnionType {
         }
     }
 
+    /// Associates tokens with this union type and returns the modified type.
     pub fn with_tokens(mut self, tokens: UnionTypeTokens) -> Self {
         self.set_tokens(tokens);
         self
     }
 
+    /// Sets the tokens associated with this union type.
     #[inline]
     pub fn set_tokens(&mut self, tokens: UnionTypeTokens) {
         if tokens.leading_token.is_some() {
@@ -33,36 +37,43 @@ impl UnionType {
         self.tokens = Some(tokens);
     }
 
+    /// Returns the tokens associated with this union type, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&UnionTypeTokens> {
         self.tokens.as_ref()
     }
 
+    /// Returns the number of type alternatives in this union.
     #[inline]
     pub(crate) fn len(&self) -> usize {
         self.types.len()
     }
 
+    /// Returns an iterator over the type alternatives in this union.
     #[inline]
     pub fn iter_types(&self) -> impl Iterator<Item = &Type> {
         self.types.iter()
     }
 
+    /// Returns the first type alternative in this union.
     #[inline]
     pub fn first_type(&self) -> &Type {
         self.types.first().unwrap()
     }
 
+    /// Returns the last type alternative in this union.
     #[inline]
     pub fn last_type(&self) -> &Type {
         self.types.last().unwrap()
     }
 
+    /// Returns a mutable iterator over the type alternatives in this union.
     #[inline]
     pub fn iter_mut_types(&mut self) -> impl Iterator<Item = &mut Type> {
         self.types.iter_mut()
     }
 
+    /// Returns whether this union type has a leading token.
     pub fn has_leading_token(&self) -> bool {
         self.leading_operator
             || self.types.len() < 2
@@ -73,15 +84,18 @@ impl UnionType {
                 .unwrap_or_default()
     }
 
+    /// Marks this union type as having a leading token and returns the modified type.
     pub fn with_leading_token(mut self) -> Self {
         self.put_leading_token();
         self
     }
 
+    /// Marks this union type as having a leading token.
     pub fn put_leading_token(&mut self) {
         self.leading_operator = true;
     }
 
+    /// Removes the leading token from this union type.
     pub fn remove_leading_token(&mut self) {
         self.leading_operator = false;
         if let Some(tokens) = &mut self.tokens {
@@ -89,6 +103,7 @@ impl UnionType {
         }
     }
 
+    /// Determines if a type needs parentheses when used within a union type.
     pub fn intermediate_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -96,6 +111,7 @@ impl UnionType {
         )
     }
 
+    /// Determines if the last type in a union needs parentheses.
     pub fn last_needs_parentheses(r#type: &Type) -> bool {
         matches!(
             r#type,
@@ -127,9 +143,12 @@ impl iter::FromIterator<Type> for UnionType {
     }
 }
 
+/// Contains the tokens that define the union type syntax.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UnionTypeTokens {
+    /// Optional leading `|` token before the first type.
     pub leading_token: Option<Token>,
+    /// The `|` tokens separating the type alternatives.
     pub separators: Vec<Token>,
 }
 

--- a/src/nodes/types/variadic_type_pack.rs
+++ b/src/nodes/types/variadic_type_pack.rs
@@ -2,6 +2,10 @@ use crate::nodes::Token;
 
 use super::Type;
 
+/// Represents a variadic type pack in Luau.
+///
+/// Variadic type packs represent an arbitrary number of values of the same type,
+/// written with a leading `...` and a type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VariadicTypePack {
     // ... type
@@ -10,6 +14,7 @@ pub struct VariadicTypePack {
 }
 
 impl VariadicTypePack {
+    /// Creates a new variadic type pack with the specified element type.
     pub fn new(r#type: impl Into<Type>) -> Self {
         Self {
             inner_type: Box::new(r#type.into()),
@@ -17,31 +22,37 @@ impl VariadicTypePack {
         }
     }
 
+    /// Returns the element type of this variadic type pack.
     #[inline]
     pub fn get_type(&self) -> &Type {
         &self.inner_type
     }
 
+    /// Returns a mutable reference to the element type of this variadic type pack.
     #[inline]
     pub fn mutate_type(&mut self) -> &mut Type {
         &mut self.inner_type
     }
 
+    /// Associates a token with this variadic type pack.
     pub fn with_token(mut self, token: Token) -> Self {
         self.token = Some(token);
         self
     }
 
+    /// Sets the `...` token preceding this variadic type pack.
     #[inline]
     pub fn set_token(&mut self, token: Token) {
         self.token = Some(token);
     }
 
+    /// Returns the `...` token preceding this variadic type pack, if any.
     #[inline]
     pub fn get_token(&self) -> Option<&Token> {
         self.token.as_ref()
     }
 
+    /// Returns a mutable reference to the `...` token preceding this variadic type pack, if any.
     #[inline]
     pub fn mutate_token(&mut self) -> Option<&mut Token> {
         self.token.as_mut()

--- a/src/nodes/variable.rs
+++ b/src/nodes/variable.rs
@@ -1,13 +1,18 @@
 use crate::nodes::{FieldExpression, Identifier, IndexExpression};
 
+/// Represents a variable reference.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Variable {
+    /// A simple named variable (e.g., `x`, `count`, `self`).
     Identifier(Identifier),
+    /// A field access on a table or object using dot notation (e.g., `table.field`, `self.name`).
     Field(Box<FieldExpression>),
+    /// An index access on a table using bracket notation (e.g., `array[1]`, `table[key]`).
     Index(Box<IndexExpression>),
 }
 
 impl Variable {
+    /// Creates a new variable from an identifier name.
     pub fn new<S: Into<String>>(name: S) -> Self {
         Self::Identifier(Identifier::new(name))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,12 +8,14 @@ use crate::{
     utils::Timer,
 };
 
+/// A parser for Luau code that converts it into an abstract syntax tree.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Parser {
     hold_token_data: bool,
 }
 
 impl Parser {
+    /// Parses Lua code into a [`Block`].
     pub fn parse(&self, code: &str) -> Result<Block, ParserError> {
         let full_moon_parse_timer = Timer::now();
         let parse_result = full_moon::parse(code);
@@ -33,6 +35,7 @@ impl Parser {
         })
     }
 
+    /// Configures the parser to preserve token data (line numbers, whitespace and comments).
     pub fn preserve_tokens(mut self) -> Self {
         self.hold_token_data = true;
         self
@@ -54,6 +57,7 @@ enum ParserErrorKind {
     Converting(ConvertError),
 }
 
+/// The error type that can occur when parsing code.
 #[derive(Clone, Debug)]
 pub struct ParserError {
     kind: Box<ParserErrorKind>,

--- a/src/process/expression_serializer.rs
+++ b/src/process/expression_serializer.rs
@@ -84,7 +84,7 @@ impl Serializer {
         if let Some(mut operation) = self.operation.pop() {
             let keep = match &mut operation {
                 SerializeOperation::Table(entries) => {
-                    entries.push(TableEntry::Value(expression));
+                    entries.push(TableEntry::from_value(expression));
                     true
                 }
                 SerializeOperation::TableEntryKey => {

--- a/src/rules/convert_require/mod.rs
+++ b/src/rules/convert_require/mod.rs
@@ -8,14 +8,14 @@ use serde::{Deserialize, Serialize};
 use crate::frontend::DarkluaResult;
 use crate::nodes::{Arguments, Block, FunctionCall};
 use crate::process::{DefaultVisitor, IdentifierTracker, NodeProcessor, NodeVisitor};
-use crate::rules::require::{is_require_call, PathRequireMode};
+use crate::rules::require::is_require_call;
 use crate::rules::{Context, RuleConfiguration, RuleConfigurationError, RuleProperties};
 
 use instance_path::InstancePath;
 pub use roblox_index_style::RobloxIndexStyle;
 pub use roblox_require_mode::RobloxRequireMode;
 
-use super::{verify_required_properties, Rule, RuleProcessResult};
+use super::{verify_required_properties, PathRequireMode, Rule, RuleProcessResult};
 
 use std::ffi::OsStr;
 use std::ops::{Deref, DerefMut};

--- a/src/rules/convert_require/mod.rs
+++ b/src/rules/convert_require/mod.rs
@@ -22,10 +22,13 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// A representation of how require calls are handled and transformed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", tag = "name")]
 pub enum RequireMode {
+    /// Handles requires using file system paths
     Path(PathRequireMode),
+    /// Handles requires using Roblox's instance-based require system
     Roblox(RobloxRequireMode),
 }
 

--- a/src/rules/convert_require/roblox_index_style.rs
+++ b/src/rules/convert_require/roblox_index_style.rs
@@ -5,11 +5,15 @@ use crate::process::utils::is_valid_identifier;
 
 use std::str::FromStr;
 
+/// Represents the different styles of indexing in Roblox.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "name")]
 pub enum RobloxIndexStyle {
+    /// Uses `:FindFirstChild(name)` calls to access child Instances.
     FindFirstChild,
+    /// Uses `:WaitForChild(name)` calls to access child Instances.
     WaitForChild,
+    /// Uses the property syntax (`parent.ObjectName`) to access child Instances.
     Property,
 }
 

--- a/src/rules/group_local.rs
+++ b/src/rules/group_local.rs
@@ -75,12 +75,12 @@ impl GroupLocalProcessor {
     fn merge(&self, first: &mut LocalAssignStatement, mut other: LocalAssignStatement) {
         if first.values_len() == 0 && other.values_len() != 0 {
             let variable_count = first.variables_len();
-            first.extend_values(iter::repeat(Expression::nil()).take(variable_count));
+            first.extend_values(iter::repeat_n(Expression::nil(), variable_count));
         }
 
         if other.values_len() == 0 && first.values_len() != 0 {
             let variable_count = other.variables_len();
-            other.extend_values(iter::repeat(Expression::nil()).take(variable_count));
+            other.extend_values(iter::repeat_n(Expression::nil(), variable_count));
         }
 
         let (mut variables, mut values) = other.into_assignments();

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,8 @@
-//! A module that contains the different rules that mutates a Lua block.
+//! A module that contains the different rules that mutates a Lua/Luau block.
+//!
+//! Rules are transformations that can be applied to Lua code blocks to modify their structure
+//! or behavior while preserving functionality. Each rule implements the [`Rule`] trait and can
+//! be configured through properties.
 
 mod append_text_comment;
 pub mod bundle;
@@ -76,6 +80,10 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+/// A builder for creating a [`Context`] with optional configuration.
+///
+/// This builder allows for incremental construction of a [`Context`] by adding
+/// blocks and project location information before building the final context.
 #[derive(Debug, Clone)]
 pub struct ContextBuilder<'a, 'resources, 'code> {
     path: PathBuf,
@@ -86,6 +94,7 @@ pub struct ContextBuilder<'a, 'resources, 'code> {
 }
 
 impl<'a, 'resources, 'code> ContextBuilder<'a, 'resources, 'code> {
+    /// Creates a new context builder with the specified path, resources, and original code.
     pub fn new(
         path: impl Into<PathBuf>,
         resources: &'resources Resources,
@@ -100,11 +109,13 @@ impl<'a, 'resources, 'code> ContextBuilder<'a, 'resources, 'code> {
         }
     }
 
+    /// Sets the project location for this context.
     pub fn with_project_location(mut self, path: impl Into<PathBuf>) -> Self {
         self.project_location = Some(path.into());
         self
     }
 
+    /// Builds the final context with all configured options.
     pub fn build(self) -> Context<'a, 'resources, 'code> {
         Context {
             path: self.path,
@@ -116,12 +127,16 @@ impl<'a, 'resources, 'code> ContextBuilder<'a, 'resources, 'code> {
         }
     }
 
+    /// Inserts a block into the context with the specified path.
     pub fn insert_block<'block: 'a>(&mut self, path: impl Into<PathBuf>, block: &'block Block) {
         self.blocks.insert(path.into(), block);
     }
 }
 
-/// The intent of this struct is to hold data shared across all rules applied to a file.
+/// A context that holds data shared across all rules applied to a file.
+///
+/// The context provides access to resources, file paths, and blocks that may be needed
+/// during rule processing.
 #[derive(Debug, Clone)]
 pub struct Context<'a, 'resources, 'code> {
     path: PathBuf,
@@ -133,14 +148,19 @@ pub struct Context<'a, 'resources, 'code> {
 }
 
 impl Context<'_, '_, '_> {
+    /// Returns the block associated with the given path, if any.
     pub fn block(&self, path: impl AsRef<Path>) -> Option<&Block> {
         self.blocks.get(path.as_ref()).copied()
     }
 
+    /// Returns the path of the current file being processed.
     pub fn current_path(&self) -> &Path {
         self.path.as_ref()
     }
 
+    /// Adds a file dependency to the context.
+    ///
+    /// This is used to track which files are required by the current file being processed.
     pub fn add_file_dependency(&self, path: PathBuf) {
         if let Ok(mut dependencies) = self.dependencies.try_borrow_mut() {
             log::trace!("add file dependency {}", path.display());
@@ -150,6 +170,7 @@ impl Context<'_, '_, '_> {
         }
     }
 
+    /// Consumes the context and returns an iterator over all file dependencies.
     pub fn into_dependencies(self) -> impl Iterator<Item = PathBuf> {
         self.dependencies.into_inner().into_iter()
     }
@@ -176,37 +197,57 @@ impl Context<'_, '_, '_> {
     }
 }
 
+/// The result type for rule processing operations.
 pub type RuleProcessResult = Result<(), String>;
 
-/// Defines an interface that will be used to mutate blocks and how to serialize and deserialize
-/// the rule configuration.
+/// Defines an interface for rules that can transform Lua blocks.
+///
+/// Rules implement this trait to define how they process blocks and how their configuration
+/// can be serialized and deserialized.
 pub trait Rule: RuleConfiguration + fmt::Debug {
-    /// This method should mutate the given block to apply the rule
+    /// Processes the given block to apply the rule's transformation.
+    ///
+    /// Returns `Ok(())` if the transformation was successful, or an error message if it failed.
     fn process(&self, block: &mut Block, context: &Context) -> RuleProcessResult;
 
-    /// Return the list of paths to Lua files that is necessary to apply this rule. This will load
-    /// each AST block from these files into the context object.
+    /// Returns a list of paths to Lua files that are required to apply this rule.
+    ///
+    /// These files will be loaded into the context for use during processing.
     fn require_content(&self, _current_source: &Path, _current_block: &Block) -> Vec<PathBuf> {
         Vec::new()
     }
 }
 
+/// Defines the configuration interface for rules.
+///
+/// This trait provides methods for configuring rules through properties and serializing
+/// their configuration state.
 pub trait RuleConfiguration {
-    /// The rule deserializer will construct the default rule and then send the properties through
-    /// this method to modify the behavior of the rule.
+    /// Configures the rule with the given properties.
+    ///
+    /// Returns an error if the configuration is invalid.
     fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError>;
-    /// This method should return the unique name of the rule.
+
+    /// Returns the unique name of the rule.
     fn get_name(&self) -> &'static str;
-    /// For implementing the serialize trait on the Rule trait, this method should return all
-    /// properties that differs from their default value.
+
+    /// Serializes the rule's configuration to properties.
+    ///
+    /// Only properties that differ from their default values are included.
     fn serialize_to_properties(&self) -> RuleProperties;
-    /// Returns `true` if the rule has at least one property.
+
+    /// Returns whether the rule has any non-default properties.
     fn has_properties(&self) -> bool {
         !self.serialize_to_properties().is_empty()
     }
 }
 
+/// A trait for rules that are guaranteed to succeed without errors.
+///
+/// Rules implementing this trait can be automatically converted to the `Rule` trait
+/// with error handling.
 pub trait FlawlessRule {
+    /// Processes the block without the possibility of failure.
     fn flawless_process(&self, block: &mut Block, context: &Context);
 }
 
@@ -217,9 +258,10 @@ impl<T: FlawlessRule + RuleConfiguration + fmt::Debug> Rule for T {
     }
 }
 
-/// A function to get the default rule stack for darklua. All the rules here must preserve all the
-/// functionalities of the original code after being applied. They must guarantee that the
-/// processed block will work as much as the original one.
+/// Returns the default set of rules that preserve code functionality.
+///
+/// These rules are guaranteed to maintain the original behavior of the code
+/// while performing their transformations.
 pub fn get_default_rules() -> Vec<Box<dyn Rule>> {
     vec![
         Box::<RemoveSpaces>::default(),
@@ -238,6 +280,9 @@ pub fn get_default_rules() -> Vec<Box<dyn Rule>> {
     ]
 }
 
+/// Returns a list of all available rule names.
+///
+/// This includes both default and optional rules that can be used for code transformation.
 pub fn get_all_rule_names() -> Vec<&'static str> {
     vec![
         APPEND_TEXT_COMMENT_RULE_NAME,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -64,6 +64,7 @@ pub use remove_types::*;
 pub use remove_unused_variable::*;
 pub use rename_variables::*;
 pub(crate) use replace_referenced_tokens::*;
+pub use require::PathRequireMode;
 pub use rule_property::*;
 pub(crate) use shift_token_line::*;
 pub use unused_if_branch::*;

--- a/src/rules/remove_call_match.rs
+++ b/src/rules/remove_call_match.rs
@@ -114,7 +114,7 @@ impl<Args, T: CallMatch<Args>> RemoveFunctionCallProcessor<Args, T> {
                         }
                         TableEntry::Value(value) => {
                             if self.evaluator.has_side_effects(value) {
-                                expressions.push(value.clone());
+                                expressions.push(*value.clone());
                             }
                         }
                     }

--- a/src/rules/remove_compound_assign.rs
+++ b/src/rules/remove_compound_assign.rs
@@ -170,7 +170,7 @@ impl Processor {
                         if let Expression::Identifier(identifier) = parenthese.inner_expression() {
                             Prefix::from(identifier.clone())
                         } else {
-                            parenthese.clone().into()
+                            (*parenthese.clone()).into()
                         };
                     let new_variable = FieldExpression::new(new_prefix, field.get_field().clone());
 

--- a/src/rules/remove_if_expression.rs
+++ b/src/rules/remove_if_expression.rs
@@ -16,7 +16,7 @@ struct Processor {
 
 impl Processor {
     fn wrap_in_table(&self, expression: Expression) -> Expression {
-        TableExpression::new(vec![TableEntry::Value({
+        TableExpression::new(vec![TableEntry::from_value({
             if self.evaluator.can_return_multiple_values(&expression) {
                 expression.in_parentheses()
             } else {

--- a/src/rules/require/mod.rs
+++ b/src/rules/require/mod.rs
@@ -5,4 +5,4 @@ mod path_require_mode;
 
 pub(crate) use match_require::{is_require_call, match_path_require_call};
 pub(crate) use path_locator::RequirePathLocator;
-pub(crate) use path_require_mode::PathRequireMode;
+pub use path_require_mode::PathRequireMode;

--- a/src/rules/require/path_require_mode.rs
+++ b/src/rules/require/path_require_mode.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 
 use super::RequirePathLocator;
 
+/// A require mode for handling content from file system paths.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct PathRequireMode {
@@ -56,6 +57,7 @@ fn is_default_module_folder_name(value: &String) -> bool {
 }
 
 impl PathRequireMode {
+    /// Creates a new path require mode with the specified module folder name.
     pub fn new(module_folder_name: impl Into<String>) -> Self {
         Self {
             module_folder_name: module_folder_name.into(),

--- a/src/rules/unused_if_branch.rs
+++ b/src/rules/unused_if_branch.rs
@@ -9,7 +9,7 @@ use super::verify_no_rule_properties;
 enum FilterResult {
     Keep,
     Remove,
-    Replace(Statement),
+    Replace(Box<Statement>),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -60,13 +60,13 @@ impl IfFilter {
                 if block_replacer.is_empty() {
                     FilterResult::Remove
                 } else {
-                    FilterResult::Replace(DoStatement::new(block_replacer).into())
+                    FilterResult::Replace(Box::new(DoStatement::new(block_replacer).into()))
                 }
             } else if let Some(else_block) = if_statement.take_else_block() {
                 if else_block.is_empty() {
                     FilterResult::Remove
                 } else {
-                    FilterResult::Replace(DoStatement::new(else_block).into())
+                    FilterResult::Replace(Box::new(DoStatement::new(else_block).into()))
                 }
             } else {
                 FilterResult::Remove
@@ -180,7 +180,7 @@ impl NodeProcessor for IfFilter {
                     FilterResult::Keep => true,
                     FilterResult::Remove => false,
                     FilterResult::Replace(new_statement) => {
-                        *statement = new_statement;
+                        *statement = *new_statement;
                         true
                     }
                 }

--- a/tests/ast_fuzzer/mod.rs
+++ b/tests/ast_fuzzer/mod.rs
@@ -1012,7 +1012,7 @@ impl AstFuzzer {
                         entries
                             .into_iter()
                             .map(|entry| match entry {
-                                TableEntryKind::Value => TableEntry::Value(self.pop_expression()),
+                                TableEntryKind::Value => TableEntry::from_value(self.pop_expression()),
                                 TableEntryKind::Field => TableFieldEntry::new(
                                     self.random.identifier(),
                                     self.pop_expression(),

--- a/tests/ast_fuzzer/mod.rs
+++ b/tests/ast_fuzzer/mod.rs
@@ -1012,7 +1012,9 @@ impl AstFuzzer {
                         entries
                             .into_iter()
                             .map(|entry| match entry {
-                                TableEntryKind::Value => TableEntry::from_value(self.pop_expression()),
+                                TableEntryKind::Value => {
+                                    TableEntry::from_value(self.pop_expression())
+                                }
                                 TableEntryKind::Field => TableFieldEntry::new(
                                     self.random.identifier(),
                                     self.pop_expression(),

--- a/tests/ast_fuzzer/random.rs
+++ b/tests/ast_fuzzer/random.rs
@@ -363,8 +363,7 @@ fn generate_string_content(poisson_lambda: f64) -> String {
                 0123456789\
                 ()[]{}=<>.!?,:;+-*/%^|&#";
 
-    iter::repeat(())
-        .take(length)
+    iter::repeat_n((), length)
         .map(|()| GEN_CHARSET[rng.gen_range(0..GEN_CHARSET.len())] as char)
         .collect()
 }

--- a/tests/snapshots/help_command.snap
+++ b/tests/snapshots/help_command.snap
@@ -6,7 +6,7 @@ Transform Lua scripts
 
 For specific help about each command, run `darklua <command> --help`
 
-Site: https://darklua.com
+Site: <https://darklua.com>
 
 Usage: darklua [OPTIONS] <COMMAND>
 
@@ -25,4 +25,3 @@ Options:
 
   -V, --version
           Print version
-


### PR DESCRIPTION
Related #150 

These changes add documentation for the [Rust docs site](https://docs.rs/darklua/latest/darklua_core/index.html).

This also fixes the new clippy lints that came up with Rust 1.87. It involved boxing a few structs in some AST node enums to reduce the size between variants.

The wasm build for the site was failing so that is fixed too!

- [x] add entry to the changelog
