### PR TITLE
Improve `inject_global_rule` to allow structured data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "log",
  "notify",
  "notify-debouncer-full",
+ "num-traits",
  "paste",
  "pathdiff",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ full_moon = { version = "1.0.0", features = ["roblox"] }
 indexmap = "2.7.0"
 json5 = "0.4.1"
 log = "0.4.22"
+num-traits = "0.2.19"
 pathdiff = "0.2.3"
 petgraph = "0.6.5"
 regex = "1.11.1"

--- a/site/content/rules/inject_global_value.md
+++ b/site/content/rules/inject_global_value.md
@@ -7,22 +7,45 @@ parameters:
     type: string
     description: The name of the global variable
   - name: value
-    type: boolean, number or string
+    type: any
     description: The value to inject
     default: nil
   - name: env
     added_in: "0.7.0"
     type: string
     description: An environment variable to read the value from
+  - name: env_json
+    added_in: "unreleased"
+    type: string
+    description: An environment variable to read the json-encoded value from
+  - name: default_value
+    added_in: "unreleased"
+    type: any
+    description: The default value when using an environment variable that is not defined
 examples:
   - rules: "[{ rule: 'inject_global_value', identifier: 'CONSTANT', value: 'Hello' }, { rule: 'inject_global_value', identifier: 'AMOUNT', value: 11 }]"
     content: |
       if _G.AMOUNT > 10 or _G.CONSTANT ~= nil then
         --[[ ... ]]
       end
+  - rules: "[{ rule: 'inject_global_value', identifier: 'DEBUG', value: true }]"
+    content: |
+      if _G.DEBUG then
+        print('Debug information')
+      end
 ---
 
 This rule will find a global variable and replace it with a given value. The value can be defined in the rule configuration or taken from an environment variable.
+
+To inject a static value, use the `value` property.
+
+```json5
+{
+  rule: "inject_global_value",
+  identifier: "GLOBAL",
+  value: true,
+}
+```
 
 If `value` is not specified, the `env` property can be defined to read an environment variable that will be read into a string.
 
@@ -31,6 +54,27 @@ If `value` is not specified, the `env` property can be defined to read an enviro
   rule: "inject_global_value",
   identifier: "GLOBAL",
   env: "SOME_VARIABLE",
+}
+```
+
+Alternatively, the `env_json` property allows you to read a JSON-encoded value (`json5` is supported) from an environment variable. This is useful for injecting any data like booleans or structured data like arrays or objects.
+
+```json5
+{
+  rule: "inject_global_value",
+  identifier: "SETTINGS",
+  env_json: "APP_SETTINGS",
+}
+```
+
+When using the `env` or `env_json` property, the `default_value` property can be used to provide a fallback value when the environment variable is not defined. This prevents the rule from using `nil` as the default value.
+
+```json5
+{
+  rule: "inject_global_value",
+  identifier: "FEATURE_FLAG",
+  env: "ENABLE_FEATURE",
+  default_value: false,
 }
 ```
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -493,15 +493,16 @@ fn verify_property_collisions(
     properties: &RuleProperties,
     names: &[&str],
 ) -> Result<(), RuleConfigurationError> {
-    let mut exists = false;
+    let mut exists: Option<&str> = None;
     for name in names.iter() {
         if properties.contains_key(*name) {
-            if exists {
-                return Err(RuleConfigurationError::PropertyCollision(
-                    names.iter().map(ToString::to_string).collect(),
-                ));
+            if let Some(existing_name) = &exists {
+                return Err(RuleConfigurationError::PropertyCollision(vec![
+                    existing_name.to_string(),
+                    name.to_string(),
+                ]));
             } else {
-                exists = true;
+                exists = Some(*name);
             }
         }
     }

--- a/src/rules/rule_property.rs
+++ b/src/rules/rule_property.rs
@@ -3,13 +3,18 @@ use std::collections::HashMap;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::{
+    nodes::{DecimalNumber, Expression, StringExpression, TableEntry, TableExpression},
+    process::to_expression,
+};
+
 use super::{require::PathRequireMode, RequireMode, RobloxRequireMode, RuleConfigurationError};
 
 pub type RuleProperties = HashMap<String, RulePropertyValue>;
 
 /// In order to be able to weakly-type the properties of any rule, this enum makes it possible to
 /// easily use serde to gather the value associated with a property.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum RulePropertyValue {
     Boolean(bool),
@@ -19,6 +24,10 @@ pub enum RulePropertyValue {
     StringList(Vec<String>),
     RequireMode(RequireMode),
     None,
+    #[doc(hidden)]
+    Map(serde_json::Map<String, serde_json::Value>),
+    #[doc(hidden)]
+    Array(Vec<serde_json::Value>),
 }
 
 impl RulePropertyValue {
@@ -80,6 +89,30 @@ impl RulePropertyValue {
                     })
             }
             _ => Err(RuleConfigurationError::RequireModeExpected(key.to_owned())),
+        }
+    }
+
+    pub(crate) fn into_expression(self) -> Option<Expression> {
+        match self {
+            Self::None => Some(Expression::nil()),
+            Self::String(value) => Some(StringExpression::from_value(value).into()),
+            Self::Boolean(value) => Some(Expression::from(value)),
+            Self::Usize(value) => Some(DecimalNumber::new(value as f64).into()),
+            Self::Float(value) => Some(Expression::from(value)),
+            Self::StringList(value) => Some(
+                TableExpression::new(
+                    value
+                        .into_iter()
+                        .map(|element| {
+                            TableEntry::from_value(StringExpression::from_value(element))
+                        })
+                        .collect(),
+                )
+                .into(),
+            ),
+            Self::RequireMode(require_mode) => to_expression(&require_mode).ok(),
+            Self::Map(value) => to_expression(&value).ok(),
+            Self::Array(value) => to_expression(&value).ok(),
         }
     }
 }
@@ -215,5 +248,167 @@ mod test {
     fn from_boolean_option_none() {
         let bool: Option<bool> = None;
         assert_eq!(RulePropertyValue::from(bool), RulePropertyValue::None);
+    }
+
+    mod parse {
+        use super::*;
+
+        fn parse_rule_property(json: &str, expect_property: RulePropertyValue) {
+            let parsed: RulePropertyValue = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, expect_property);
+        }
+
+        #[test]
+        fn parse_boolean_true() {
+            parse_rule_property("true", RulePropertyValue::Boolean(true));
+        }
+
+        #[test]
+        fn parse_boolean_false() {
+            parse_rule_property("false", RulePropertyValue::Boolean(false));
+        }
+
+        #[test]
+        fn parse_string() {
+            parse_rule_property(
+                r#""hello world""#,
+                RulePropertyValue::String("hello world".to_owned()),
+            );
+        }
+
+        #[test]
+        fn parse_empty_string() {
+            parse_rule_property(r#""""#, RulePropertyValue::String("".to_owned()));
+        }
+
+        #[test]
+        fn parse_string_with_escapes() {
+            parse_rule_property(
+                r#""hello\nworld\twith\"quotes\"""#,
+                RulePropertyValue::String("hello\nworld\twith\"quotes\"".to_owned()),
+            );
+        }
+
+        #[test]
+        fn parse_usize_zero() {
+            parse_rule_property("0", RulePropertyValue::Usize(0));
+        }
+
+        #[test]
+        fn parse_usize_positive() {
+            parse_rule_property("42", RulePropertyValue::Usize(42));
+        }
+
+        #[test]
+        fn parse_float_zero() {
+            parse_rule_property("0.0", RulePropertyValue::Float(0.0));
+        }
+
+        #[test]
+        fn parse_float_positive() {
+            parse_rule_property("3.14159", RulePropertyValue::Float(3.14159));
+        }
+
+        #[test]
+        fn parse_float_negative() {
+            parse_rule_property("-2.718", RulePropertyValue::Float(-2.718));
+        }
+
+        #[test]
+        fn parse_float_scientific_notation() {
+            parse_rule_property("1.23e-4", RulePropertyValue::Float(1.23e-4));
+        }
+
+        #[test]
+        fn parse_string_list_empty() {
+            parse_rule_property("[]", RulePropertyValue::StringList(vec![]));
+        }
+
+        #[test]
+        fn parse_string_list_single() {
+            parse_rule_property(
+                r#"["hello"]"#,
+                RulePropertyValue::StringList(vec!["hello".to_owned()]),
+            );
+        }
+
+        #[test]
+        fn parse_string_list_multiple() {
+            parse_rule_property(
+                r#"["hello", "world", "test"]"#,
+                RulePropertyValue::StringList(vec![
+                    "hello".to_owned(),
+                    "world".to_owned(),
+                    "test".to_owned(),
+                ]),
+            );
+        }
+
+        #[test]
+        fn parse_string_list_with_empty_strings() {
+            parse_rule_property(
+                r#"["", "hello", ""]"#,
+                RulePropertyValue::StringList(vec![
+                    "".to_owned(),
+                    "hello".to_owned(),
+                    "".to_owned(),
+                ]),
+            );
+        }
+
+        #[test]
+        fn parse_require_mode_path_string() {
+            parse_rule_property(r#""path""#, RulePropertyValue::String("path".to_owned()));
+        }
+
+        #[test]
+        fn parse_require_mode_roblox_string() {
+            parse_rule_property(
+                r#""roblox""#,
+                RulePropertyValue::String("roblox".to_owned()),
+            );
+        }
+
+        #[test]
+        fn parse_require_mode_path_object() {
+            parse_rule_property(
+                r#"{"name": "path"}"#,
+                RulePropertyValue::RequireMode(RequireMode::Path(PathRequireMode::default())),
+            );
+        }
+
+        #[test]
+        fn parse_require_mode_path_object_with_options() {
+            parse_rule_property(
+                r#"{"name": "path", "module_folder_name": "index"}"#,
+                RulePropertyValue::RequireMode(RequireMode::Path(PathRequireMode::new("index"))),
+            );
+        }
+
+        #[test]
+        fn parse_require_mode_roblox_object() {
+            parse_rule_property(
+                r#"{"name": "roblox"}"#,
+                RulePropertyValue::RequireMode(RequireMode::Roblox(RobloxRequireMode::default())),
+            );
+        }
+
+        #[test]
+        fn parse_require_mode_roblox_object_with_options() {
+            parse_rule_property(
+                r#"{"name": "roblox", "rojo_sourcemap": "./sourcemap.json"}"#,
+                RulePropertyValue::RequireMode(RequireMode::Roblox(
+                    serde_json::from_str::<RobloxRequireMode>(
+                        r#"{"rojo_sourcemap": "./sourcemap.json"}"#,
+                    )
+                    .unwrap(),
+                )),
+            );
+        }
+
+        #[test]
+        fn parse_null_as_none() {
+            parse_rule_property("null", RulePropertyValue::None);
+        }
     }
 }

--- a/tests/rule_tests/inject_value.rs
+++ b/tests/rule_tests/inject_value.rs
@@ -52,6 +52,48 @@ test_rule_without_effects!(
     does_not_inline_if_global_table_is_redefined("local _G return _G.foo"),
 );
 
+test_rule!(
+    inject_global_empty_array,
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'inject_global_value',
+        identifier: 'VALUE',
+        value: [],
+    }"#,
+    )
+    .unwrap(),
+    inject_value("return VALUE") => "return {}",
+    inject_value_from_global_table("return _G.VALUE") => "return {}",
+);
+
+test_rule!(
+    inject_global_mixed_array,
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'inject_global_value',
+        identifier: 'VALUE',
+        value: [1, "hello", true],
+    }"#,
+    )
+    .unwrap(),
+    inject_value("return VALUE") => "return {1, 'hello', true}",
+    inject_value_from_global_table("return _G.VALUE") => "return {1, 'hello', true}",
+);
+
+test_rule!(
+    inject_global_object,
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'inject_global_value',
+        identifier: 'VALUE',
+        value: {a: 1, b: "hello", c: true},
+    }"#,
+    )
+    .unwrap(),
+    inject_value("return VALUE") => "return { a = 1, b = 'hello', c = true }",
+    inject_value_from_global_table("return _G.VALUE") => "return { a = 1, b = 'hello', c = true }",
+);
+
 #[test]
 fn deserialize_from_object_notation_without_value() {
     json5::from_str::<Box<dyn Rule>>(
@@ -181,6 +223,19 @@ test_rule!(
     }"#,
     ).unwrap(),
     inject_negative_integer("return _G.num") => "return 1E49",
+);
+
+test_rule!(
+    inject_global_variable_default_value,
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'inject_global_value',
+        identifier: 'num',
+        env: 'NUM',
+        default_value: 10,
+    }"#,
+    ).unwrap(),
+    inject_negative_integer("return _G.num") => "return 10",
 );
 
 #[test]


### PR DESCRIPTION
Closes #126 

- Add support for composed data-structures like arrays or objects for the `value` property. That means that you can now inject tables into a global value
- Add a new property to read JSON data from an environment variable (using `env_json` instead of `env`)
- Add a new property to provide a default value when using a undefined environment variable (`default_value`)

- [x] add entry to the changelog
