### PR TITLE
Change internal representation of strings to support arbitrary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* change internal representation of Lua strings to avoid issues with non utf-8 encoded strings ([#282](https://github.com/seaofvoices/darklua/pull/282))
 * add support for path requires ending with an extension different than `.luau` or `.lua` ([#280](https://github.com/seaofvoices/darklua/pull/280))
 * add rule to convert `math.sqrt()` calls into an exponent form (using the `^` operator) (`convert_square_root_call`) ([#278](https://github.com/seaofvoices/darklua/pull/278))
 * improve `inject_global_value` to support structured data. Add the `env_json` property to inject JSON encoded data and the `default_value` property to inject data when the provided environment variable is not defined ([#277](https://github.com/seaofvoices/darklua/pull/277))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
  "anstyle",
- "bstr 1.11.1",
+ "bstr 1.12.0",
  "doc-comment",
  "libc",
  "predicates",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -407,6 +407,7 @@ version = "0.16.0"
 dependencies = [
  "anstyle",
  "assert_cmd",
+ "bstr 1.12.0",
  "clap",
  "criterion",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 anstyle = "1.0.10"
+bstr = "1.12.0"
 clap = { version = "4.5.23", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.10.0"

--- a/src/generator/token_based.rs
+++ b/src/generator/token_based.rs
@@ -26,7 +26,7 @@ impl<'a> TokenBasedLuaGenerator<'a> {
     }
 
     fn push_str(&mut self, string: &str) {
-        self.current_line += utils::count_new_lines(string);
+        self.current_line += utils::count_new_lines(string.as_bytes());
         self.output.push_str(string);
     }
 

--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -293,7 +293,7 @@ fn escape(character: u8) -> String {
 
 #[inline]
 pub fn count_new_lines(string: &[u8]) -> usize {
-    string.into_iter().filter(|c| **c == b'\n').count()
+    string.iter().filter(|c| **c == b'\n').count()
 }
 
 pub fn write_string(value: &[u8]) -> String {
@@ -303,7 +303,7 @@ pub fn write_string(value: &[u8]) -> String {
 
     if value.len() == 1 {
         let character = value
-            .into_iter()
+            .iter()
             .next()
             .expect("string should have at least one character");
         match *character {
@@ -319,7 +319,7 @@ pub fn write_string(value: &[u8]) -> String {
         }
     }
 
-    if !value.into_iter().any(needs_quoted_string)
+    if !value.iter().any(needs_quoted_string)
         && value.len() >= LONG_STRING_MIN_LENGTH
         && (value.len() >= QUOTED_STRING_MAX_LENGTH
             || count_new_lines(value) >= FORCE_LONG_STRING_NEW_LINE_THRESHOLD)
@@ -341,7 +341,7 @@ pub fn write_interpolated_string_segment(segment: &StringSegment) -> String {
 
     result.reserve(value.len());
 
-    for character in value.into_iter() {
+    for character in value.iter() {
         match character {
             b'`' | b'{' => {
                 result.push('\\');
@@ -392,7 +392,7 @@ fn write_quoted(value: &[u8]) -> String {
     let quote_symbol = get_quote_symbol(value);
     quoted.push(quote_symbol);
 
-    if let Some(stringified) = str::from_utf8(value).ok() {
+    if let Ok(stringified) = str::from_utf8(value) {
         for character in stringified.chars() {
             if character == quote_symbol {
                 quoted.push('\\');

--- a/src/nodes/expressions/interpolated_string.rs
+++ b/src/nodes/expressions/interpolated_string.rs
@@ -58,7 +58,7 @@ impl StringSegment {
     }
 
     fn append(&mut self, mut other: Self) {
-        self.value.extend(other.value.drain(..));
+        self.value.append(&mut other.value);
         self.token = None;
     }
 

--- a/src/nodes/expressions/string.rs
+++ b/src/nodes/expressions/string.rs
@@ -54,16 +54,13 @@ impl StringExpression {
         let mut chars = string.char_indices();
 
         match (chars.next(), chars.next_back()) {
-            (Some((_, '"')), Some((_, '"')))
-            |(Some((_, '\'')), Some((_, '\''))) =>
-                // if (first_char == '"' || first_char == '\'') && first_char == last_char =>
-            {
+            (Some((_, '"')), Some((_, '"'))) | (Some((_, '\'')), Some((_, '\''))) => {
                 string_utils::read_escaped_string(chars, Some(string.len())).map(Self::from_value)
             }
-            (None, None) | (None, Some(_)) | (Some(_), None) => {
-                Err(StringError::invalid("missing quotes"))
+            (Some((_, '"')), Some((_, '\''))) | (Some((_, '\'')), Some((_, '"'))) => {
+                Err(StringError::invalid("quotes do not match"))
             }
-            (Some(_), Some(_)) => Err(StringError::invalid("quotes do not match")),
+            _ => Err(StringError::invalid("missing quotes")),
         }
     }
 
@@ -360,12 +357,12 @@ mod test {
 
         #[test]
         fn missing_quotes() {
-            insta::assert_snapshot!(StringExpression::new("hello").unwrap_err().to_string(), @"invalid string: quotes do not match");
+            insta::assert_snapshot!(StringExpression::new("hello").unwrap_err().to_string(), @"invalid string: missing quotes");
         }
 
         #[test]
         fn delimiters_matching_but_not_quotes() {
-            insta::assert_snapshot!(StringExpression::new("aa").unwrap_err().to_string(), @"invalid string: quotes do not match");
+            insta::assert_snapshot!(StringExpression::new("aa").unwrap_err().to_string(), @"invalid string: missing quotes");
         }
 
         #[test]

--- a/src/nodes/expressions/string.rs
+++ b/src/nodes/expressions/string.rs
@@ -142,7 +142,7 @@ impl StringExpression {
     }
 
     fn find_not_escaped(&self, pattern: u8) -> Option<usize> {
-        self.find_not_escaped_from(pattern, &mut self.value.iter().map(|b| *b).enumerate())
+        self.find_not_escaped_from(pattern, &mut self.value.iter().copied().enumerate())
     }
 
     fn find_not_escaped_from(

--- a/src/nodes/types/string_type.rs
+++ b/src/nodes/types/string_type.rs
@@ -46,14 +46,26 @@ impl StringType {
 
     /// Returns the string value of this type.
     #[inline]
-    pub fn get_value(&self) -> &str {
+    pub fn get_value(&self) -> &[u8] {
         self.value.get_value()
+    }
+
+    /// Returns the string value if it is valid UTF-8.
+    #[inline]
+    pub fn get_string_value(&self) -> Option<&str> {
+        self.value.get_string_value()
     }
 
     /// Consumes this string type and returns its string value.
     #[inline]
-    pub fn into_value(self) -> String {
+    pub fn into_value(self) -> Vec<u8> {
         self.value.into_value()
+    }
+
+    /// Consumes the string expression and returns the inner string value if it is valid UTF-8.
+    #[inline]
+    pub fn into_string(self) -> Option<String> {
+        self.value.into_string()
     }
 
     /// Returns whether this string type is a multiline string.

--- a/src/process/expression_serializer.rs
+++ b/src/process/expression_serializer.rs
@@ -118,10 +118,12 @@ impl Serializer {
             match last_operation {
                 SerializeOperation::Table(entries) => {
                     if let Expression::String(string) = key {
-                        if is_valid_identifier(string.get_value()) {
-                            entries.push(
-                                TableFieldEntry::new(string.into_value(), entry_value).into(),
-                            );
+                        if let Some(value) = string
+                            .get_string_value()
+                            .filter(|value| is_valid_identifier(value))
+                        {
+                            entries
+                                .push(TableFieldEntry::new(value.to_owned(), entry_value).into());
                         } else {
                             entries.push(TableIndexEntry::new(string, entry_value).into());
                         }

--- a/src/rules/bundle/rename_type_declaration.rs
+++ b/src/rules/bundle/rename_type_declaration.rs
@@ -16,11 +16,11 @@ pub(crate) struct RenameTypeDeclarationProcessor {
     /// a map from the original type name to its newly generated name
     renamed_types: ScopedHashMap<String, String>,
     /// a map from identifiers to module names
-    type_namespace: ScopedHashMap<String, String>,
+    type_namespace: ScopedHashMap<String, Vec<u8>>,
     /// the exported types found
     exported_types: HashMap<String, String>,
     /// a map from module names to their exported types
-    all_types: HashMap<String, HashMap<String, String>>,
+    all_types: HashMap<Vec<u8>, HashMap<String, String>>,
     /// permutator to generate unique type identifier suffixes
     permutator: CharPermutator,
     modules_identifier: String,
@@ -63,7 +63,7 @@ impl RenameTypeDeclarationProcessor {
         module_name: String,
         types: HashMap<String, String>,
     ) {
-        self.all_types.insert(module_name, types);
+        self.all_types.insert(module_name.into_bytes(), types);
     }
 
     fn generate_unique_type(&mut self, original_name: &str) -> String {
@@ -73,7 +73,7 @@ impl RenameTypeDeclarationProcessor {
         new_name
     }
 
-    fn get_module_name(&self, value: &Expression) -> Option<String> {
+    fn get_module_name(&self, value: &Expression) -> Option<Vec<u8>> {
         if let Expression::Call(value) = value {
             if let Prefix::Field(field) = value.get_prefix() {
                 if field.get_field().get_name() == self.module_load_field {

--- a/src/rules/convert_index_to_field.rs
+++ b/src/rules/convert_index_to_field.rs
@@ -26,11 +26,12 @@ impl Converter {
 
     fn convert_to_field(&self, key_expression: &Expression) -> Option<String> {
         if let LuaValue::String(string) = self.evaluator.evaluate(key_expression) {
-            if is_valid_identifier(&string) {
-                return Some(string);
-            }
+            String::from_utf8(string)
+                .ok()
+                .filter(|string| is_valid_identifier(string))
+        } else {
+            None
         }
-        None
     }
 }
 

--- a/src/rules/inject_value.rs
+++ b/src/rules/inject_value.rs
@@ -56,7 +56,7 @@ impl NodeProcessor for ValueInjection {
             }
             Expression::Index(index) => {
                 !self.is_identifier_used("_G")
-                    && matches!(index.get_index(), Expression::String(string) if string.get_value() == self.identifier)
+                    && matches!(index.get_index(), Expression::String(string) if string.get_string_value() == Some(&self.identifier))
                     && matches!(index.get_prefix(), Prefix::Identifier(prefix) if prefix.get_name() == "_G")
             }
             _ => false,

--- a/src/rules/require/match_require.rs
+++ b/src/rules/require/match_require.rs
@@ -24,7 +24,7 @@ pub(crate) fn is_require_call(call: &FunctionCall, identifier_tracker: &Identifi
     }
 }
 
-fn convert_string_expression_to_path<'a>(string: &'a StringExpression) -> Option<&'a Path> {
+fn convert_string_expression_to_path(string: &StringExpression) -> Option<&Path> {
     string
         .get_string_value()
         .map(Path::new)


### PR DESCRIPTION
Closes #250 

The internal representation used to be a `String`, which implied that the value was a valid utf8 string. Instead, it's been changed to an arbitrary array of bytes to fix re-encoding issues that surfaced often with the dense or readable code generator.

- [x] add entry to the changelog
