### PR TITLE
Fix missing trailing commas when writing table types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* fix missing trailing commas when writing table types using the `retain_lines` generator ([#293](https://github.com/seaofvoices/darklua/pull/293))
 * fix string value generation to properly use decimal escape codes (e.g. `"\12"`) ([#292](https://github.com/seaofvoices/darklua/pull/292))
 * add a new require mode for the Luau require semantics (supporting the usage of `@self`) ([#290](https://github.com/seaofvoices/darklua/pull/290))
 * change internal representation of Lua strings to avoid issues with non utf-8 encoded strings ([#282](https://github.com/seaofvoices/darklua/pull/282))

--- a/src/generator/snapshots/darklua_core__generator__test__dense__snapshots__dense_table_type_with_final_comma.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__dense__snapshots__dense_table_type_with_final_comma.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generated_code
+---
+type A={field:number}

--- a/src/generator/snapshots/darklua_core__generator__test__readable__snapshots__readable_table_type_with_final_comma.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__readable__snapshots__readable_table_type_with_final_comma.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generated_code
+---
+type A = {field: number}

--- a/src/generator/snapshots/darklua_core__generator__test__token_based__snapshots__token_based_table_type_with_final_comma.snap
+++ b/src/generator/snapshots/darklua_core__generator__test__token_based__snapshots__token_based_table_type_with_final_comma.snap
@@ -1,0 +1,5 @@
+---
+source: src/generator/mod.rs
+expression: generated_code
+---
+type A = { field: number, }

--- a/src/generator/token_based.rs
+++ b/src/generator/token_based.rs
@@ -823,12 +823,10 @@ impl<'a> TokenBasedLuaGenerator<'a> {
                 }
             }
 
-            if i < last_index {
-                if let Some(comma) = tokens.separators.get(i) {
-                    self.write_token(comma);
-                } else {
-                    self.write_symbol(",");
-                }
+            if let Some(comma) = tokens.separators.get(i) {
+                self.write_token(comma);
+            } else if i < last_index {
+                self.write_symbol(",");
             }
         }
 


### PR DESCRIPTION
Closes #284 

This fixes a bug when using the default `retain-lines` generator. It will now preserve the trailing comma tokens when writing back the table type node.

- [x] add entry to the changelog
