### PR TITLE
Improve warning messages when a path can't be found in a Rojo sourcemap

### DIFF
--- a/src/rules/convert_require/roblox_require_mode.rs
+++ b/src/rules/convert_require/roblox_require_mode.rs
@@ -103,11 +103,31 @@ impl RobloxRequireMode {
                         instance_path.convert(&self.indexing_style),
                     )))
                 } else {
-                    log::warn!(
-                        "unable to find path `{}` in sourcemap (from `{}`)",
-                        require_relative_to_sourcemap.display(),
-                        source_path.display()
-                    );
+                    match (
+                        sourcemap.exists(&source_path),
+                        sourcemap.exists(&require_relative_to_sourcemap),
+                    ) {
+                        (true, true) => {
+                            log::warn!(
+                                "unable to get relative path to `{}` in sourcemap (from `{}`)",
+                                require_relative_to_sourcemap.display(),
+                                source_path.display()
+                            );
+                        }
+                        (false, _) => {
+                            log::warn!(
+                                "unable to find source path `{}` in sourcemap",
+                                source_path.display()
+                            );
+                        }
+                        (true, false) => {
+                            log::warn!(
+                                "unable to find path `{}` in sourcemap (from `{}`)",
+                                require_relative_to_sourcemap.display(),
+                                source_path.display()
+                            );
+                        }
+                    }
                     Ok(None)
                 }
             } else {

--- a/src/rules/convert_require/rojo_sourcemap.rs
+++ b/src/rules/convert_require/rojo_sourcemap.rs
@@ -116,6 +116,10 @@ impl RojoSourcemap {
         })
     }
 
+    pub(crate) fn exists(&self, path: &Path) -> bool {
+        self.find_node(path).is_some()
+    }
+
     pub(crate) fn get_instance_path(
         &self,
         from_file: impl AsRef<Path>,


### PR DESCRIPTION
Closes #171 

There can be multiple reasons why a new require path can't be generated from a Rojo sourcemap when using the roblox require mode.

This PR adds a few checks to specialize the error message and provide more information about why a require couldn't be converted.

- [ ] add entry to the changelog
