### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.17.0
+
 * improve statements filtering by transfering comments. This fixes the `remove_types` rule issues related to lost comments ([#297](https://github.com/seaofvoices/darklua/pull/297))
 * improve warning messages when a path can't be found in a Rojo sourcemap (when using the `roblox` require mode) ([#294](https://github.com/seaofvoices/darklua/pull/294))
 * fix missing trailing commas when writing table types using the `retain_lines` generator ([#293](https://github.com/seaofvoices/darklua/pull/293))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "darklua"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anstyle",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darklua"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["jeparlefrancais <jeparlefrancais21@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You can try darklua directly into your browser! Check out https://darklua.com/tr
 
 # [Installation](https://darklua.com/docs/installation/)
 
+## [GitHub Releases](https://github.com/seaofvoices/darklua/releases/latest)
+
+There are pre-built versions of darklua under the [releases page](https://github.com/seaofvoices/darklua/releases) available for direct downloads.
+
 ## [Rokit](https://github.com/rojo-rbx/rokit)
 
 When using [Rokit](https://github.com/rojo-rbx/rokit), install darklua with the command:
@@ -38,7 +42,7 @@ rokit add seaofvoices/darklua
 If you are already using Foreman, then installing darklua is as simple as adding this line in the `foreman.toml` file:
 
 ```toml
-darklua = { github = "seaofvoices/darklua", version = "=0.16.0" }
+darklua = { github = "seaofvoices/darklua", version = "=0.17.0" }
 ```
 
 # License

--- a/site/content/docs/bundle/index.md
+++ b/site/content/docs/bundle/index.md
@@ -225,7 +225,7 @@ jobs:
 <code>
 [package]
 name = "darklua"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2018"
 readme = "README.md"
 description = "Transform Lua scripts"
@@ -350,7 +350,7 @@ harness = false
 		name = "darklua",
 		readme = "README.md",
 		repository = "https://github.com/seaofvoices/darklua",
-		version = "0.16.0",
+		version = "0.17.0",
 	},
 	profile = {
 		dev = {

--- a/site/content/docs/installation/index.md
+++ b/site/content/docs/installation/index.md
@@ -18,7 +18,7 @@ rokit add seaofvoices/darklua
 If you are already using [Foreman](https://github.com/Roblox/foreman), then installing darklua is as simple as adding this line in the `foreman.toml` file:
 
 ```toml
-darklua = { github = "seaofvoices/darklua", version = "=0.16.0" }
+darklua = { github = "seaofvoices/darklua", version = "=0.17.0" }
 ```
 
 ## Download a Release

--- a/site/content/rules/convert_luau_number.md
+++ b/site/content/rules/convert_luau_number.md
@@ -1,6 +1,6 @@
 ---
 description: Convert Luau numbers into Lua compatible numbers
-added_in: "unreleased"
+added_in: "0.17.0"
 parameters: []
 examples:
   - content: "print(0b1000_0001)"

--- a/site/content/rules/convert_square_root_call.md
+++ b/site/content/rules/convert_square_root_call.md
@@ -1,6 +1,6 @@
 ---
 description: "Convert calls to `math.sqrt(value)` into an exponent form (`value ^ 0.5`)"
-added_in: "unreleased"
+added_in: "0.17.0"
 parameters: []
 examples:
   - content: "local result = math.sqrt(16)"

--- a/site/content/rules/inject_global_value.md
+++ b/site/content/rules/inject_global_value.md
@@ -15,11 +15,11 @@ parameters:
     type: string
     description: An environment variable to read the value from
   - name: env_json
-    added_in: "unreleased"
+    added_in: "0.17.0"
     type: string
     description: An environment variable to read the json-encoded value from
   - name: default_value
-    added_in: "unreleased"
+    added_in: "0.17.0"
     type: any
     description: The default value when using an environment variable that is not defined
 examples:

--- a/site/content/rules/remove_method_call.md
+++ b/site/content/rules/remove_method_call.md
@@ -1,6 +1,6 @@
 ---
 description: Removes usages of the method syntax (`:`) in function calls
-added_in: "unreleased"
+added_in: "0.17.0"
 parameters: []
 examples:
   - content: "obj:method()"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! darklua = "0.16.0"
+//! darklua = "0.17.0"
 //! ```
 //!
 //! This library is designed for developers who want to integrate Lua/Luau transformation capabilities


### PR DESCRIPTION
Many new things for this version:


* improve statements filtering by transfering comments. This fixes the `remove_types` rule issues related to lost comments ([#297](https://github.com/seaofvoices/darklua/pull/297))
* improve warning messages when a path can't be found in a Rojo sourcemap (when using the `roblox` require mode) ([#294](https://github.com/seaofvoices/darklua/pull/294))
* fix missing trailing commas when writing table types using the `retain_lines` generator ([#293](https://github.com/seaofvoices/darklua/pull/293))
* fix string value generation to properly use decimal escape codes (e.g. `"\12"`) ([#292](https://github.com/seaofvoices/darklua/pull/292))
* add a new require mode for the Luau require semantics (supporting the usage of `@self`) ([#290](https://github.com/seaofvoices/darklua/pull/290))
* change internal representation of Lua strings to avoid issues with non utf-8 encoded strings ([#282](https://github.com/seaofvoices/darklua/pull/282))
* add support for path requires ending with an extension different than `.luau` or `.lua` ([#280](https://github.com/seaofvoices/darklua/pull/280))
* add rule to convert `math.sqrt()` calls into an exponent form (using the `^` operator) (`convert_square_root_call`) ([#278](https://github.com/seaofvoices/darklua/pull/278))
* improve `inject_global_value` to support structured data. Add the `env_json` property to inject JSON encoded data and the `default_value` property to inject data when the provided environment variable is not defined ([#277](https://github.com/seaofvoices/darklua/pull/277))
* add rule to remove method call syntax (`remove_method_call`) ([#276](https://github.com/seaofvoices/darklua/pull/276))
* fix `remove_unused_variable` rule to correctly handle trailing unassigned (but used!) variables ([#275](https://github.com/seaofvoices/darklua/pull/275))
* add rule to convert Luau numbers (`convert_luau_number`) ([#274](https://github.com/seaofvoices/darklua/pull/274))
* export the `PathRequireMode` struct when using the darklua library and refactor AST node types to reduce size difference between variants ([#273](https://github.com/seaofvoices/darklua/pull/273))