### PR TITLE
Normalize `luaurc` alias paths

### DIFF
--- a/src/rules/require/luau_path_locator.rs
+++ b/src/rules/require/luau_path_locator.rs
@@ -64,6 +64,7 @@ impl super::PathLocator for LuauPathLocator<'_, '_, '_> {
                 let mut extra_module_location = self
                     .luau_require_mode
                     .get_source(source_name, self.extra_module_relative_location)
+                    .map(utils::normalize_path)
                     .ok_or_else(|| {
                         DarkluaError::invalid_resource_path(
                             path.display().to_string(),

--- a/src/rules/require/path_locator.rs
+++ b/src/rules/require/path_locator.rs
@@ -58,6 +58,7 @@ impl super::PathLocator for RequirePathLocator<'_, '_, '_> {
                 let mut extra_module_location = self
                     .path_require_mode
                     .get_source(source_name, self.extra_module_relative_location)
+                    .map(utils::normalize_path)
                     .ok_or_else(|| {
                         DarkluaError::invalid_resource_path(
                             path.display().to_string(),

--- a/tests/rule_tests/convert_require.rs
+++ b/tests/rule_tests/convert_require.rs
@@ -576,6 +576,21 @@ mod luau_to_roblox {
         }
 
         #[test]
+        fn convert_alias_module_from_init_module_with_current_dir() {
+            let resources = memory_resources!(
+                "src/init.lua" => "local value = require('@value')",
+                "src/value.lua" => "return nil",
+                ".luaurc" => r#"{ "aliases": { "value": "./src/value.lua" } }"#,
+                ".darklua.json" => CONVERT_LUAU_TO_ROBLOX_DEFAULT_CONFIG,
+            );
+            expect_file_process(
+                &resources,
+                "src/init.lua",
+                "local value = require(script:FindFirstChild('value'))",
+            );
+        }
+
+        #[test]
         fn convert_folder_alias_module_from_init_module() {
             let resources = memory_resources!(
                 "src/init.lua" => "local value = require('@value/default.lua')",
@@ -616,6 +631,21 @@ mod luaurc {
             "src/init.lua" => "local value = require('@value')",
             "src/value.lua" => "return nil",
             ".luaurc" => r#"{ "aliases": { "value": "src/value.lua" } }"#,
+            ".darklua.json" => CONVERT_PATH_TO_ROBLOX_DEFAULT_CONFIG,
+        );
+        expect_file_process(
+            &resources,
+            "src/init.lua",
+            "local value = require(script:FindFirstChild('value'))",
+        );
+    }
+
+    #[test]
+    fn convert_alias_module_from_init_module_with_current_dir() {
+        let resources = memory_resources!(
+            "src/init.lua" => "local value = require('@value')",
+            "src/value.lua" => "return nil",
+            ".luaurc" => r#"{ "aliases": { "value": "./src/value.lua" } }"#,
             ".darklua.json" => CONVERT_PATH_TO_ROBLOX_DEFAULT_CONFIG,
         );
         expect_file_process(


### PR DESCRIPTION
There is an issue with alias paths from `.luaurc` configuration files where paths starting with `.` are not properly normalized, which leads to inconsistencies when generating paths while converting require modes.

- [ ] add entry to the changelog
