### PR TITLE
Support command input paths starting with `./`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* fix issue with command line input paths starting with `./` ([#306](https://github.com/seaofvoices/darklua/pull/306))
 * fix issue with `.luaurc` configuration files containing aliases starting with `./` ([#305](https://github.com/seaofvoices/darklua/pull/305))
 
 ## 0.17.0

--- a/src/frontend/worker_tree.rs
+++ b/src/frontend/worker_tree.rs
@@ -66,7 +66,7 @@ impl WorkerTree {
                     self.add_source_if_missing(options.input(), Some(output.join(file_name)));
                 }
             } else {
-                let input = options.input().to_path_buf();
+                let input = normalize_path(options.input());
 
                 for source in resources.collect_work(&input) {
                     let source = normalize_path(source);
@@ -85,7 +85,7 @@ impl WorkerTree {
                 }
             }
         } else {
-            let input = options.input().to_path_buf();
+            let input = normalize_path(options.input());
 
             for source in resources.collect_work(input) {
                 self.add_source_if_missing(source, None);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -40,6 +40,12 @@ impl Context {
         self
     }
 
+    pub fn with_cwd(mut self, cwd: impl AsRef<Path>) -> Self {
+        let full_dir = self.working_directory.path().join(cwd.as_ref());
+        self.command.current_dir(full_dir);
+        self
+    }
+
     pub fn expect_file<P: AsRef<Path>>(&self, file_path: P) -> &Self {
         let file_path = file_path.as_ref();
         if !file_path.exists() || !file_path.is_file() {
@@ -274,6 +280,56 @@ fn run_process_command() {
         .replace_duration_labels()
         .snapshot_command("run_process_command")
         .snapshot_file("run_process_command_init_out", "out/init.lua");
+}
+
+#[test]
+fn run_process_command_with_input_path_starting_with_dot() {
+    Context::default()
+        .write_file("src/init.lua", "return 1 + 1\n")
+        .arg("process")
+        .arg("./src")
+        .arg("out")
+        .replace_duration_labels()
+        .snapshot_command("run_process_command")
+        .snapshot_file("run_process_command_init_out", "out/init.lua");
+}
+
+#[test]
+fn run_process_command_with_output_path_starting_with_dot() {
+    Context::default()
+        .write_file("src/init.lua", "return 1 + 1\n")
+        .arg("process")
+        .arg("src")
+        .arg("./out")
+        .replace_duration_labels()
+        .snapshot_command("run_process_command")
+        .snapshot_file("run_process_command_init_out", "out/init.lua");
+}
+
+#[test]
+fn run_process_command_with_input_and_output_path_starting_with_dot() {
+    Context::default()
+        .write_file("src/init.lua", "return 1 + 1\n")
+        .arg("process")
+        .arg("./src")
+        .arg("./out")
+        .replace_duration_labels()
+        .snapshot_command("run_process_command")
+        .snapshot_file("run_process_command_init_out", "out/init.lua");
+}
+
+#[test]
+fn run_process_command_with_input_path_starting_with_parent_dir() {
+    Context::default()
+        .write_file("src/init.lua", "return 1 + 1\n")
+        .write_file("lib/.darklua.json", "{}")
+        .arg("process")
+        .arg("../src")
+        .arg("out")
+        .with_cwd("lib")
+        .replace_duration_labels()
+        .snapshot_command("run_process_command")
+        .snapshot_file("run_process_command_init_out", "lib/out/init.lua");
 }
 
 #[test]


### PR DESCRIPTION
Closes #303 

These changes normalize the input paths when collecting work (files to process), which avoid the `unable to remove path prefix` error.

- [x] add entry to the changelog
