### PR TITLE
Fix bundling when using luaurc aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* fix ignored aliases from `.luaurc` configuration files when bundling ([#307](https://github.com/seaofvoices/darklua/pull/307))
 * fix issue with command line input paths starting with `./` ([#306](https://github.com/seaofvoices/darklua/pull/306))
 * fix issue with `.luaurc` configuration files containing aliases starting with `./` ([#305](https://github.com/seaofvoices/darklua/pull/305))
 

--- a/src/rules/bundle/require_mode.rs
+++ b/src/rules/bundle/require_mode.rs
@@ -56,7 +56,7 @@ impl BundleRequireMode {
                     .map_err(|err| err.to_string())?;
 
                 let locator = RequirePathLocator::new(
-                    path_require_mode,
+                    &require_mode,
                     context.project_location(),
                     context.resources(),
                 );
@@ -70,7 +70,7 @@ impl BundleRequireMode {
                     .map_err(|err| err.to_string())?;
 
                 let locator = LuauPathLocator::new(
-                    luau_require_mode,
+                    &require_mode,
                     context.project_location(),
                     context.resources(),
                 );

--- a/src/rules/require/luau_require_mode.rs
+++ b/src/rules/require/luau_require_mode.rs
@@ -227,7 +227,11 @@ impl LuauRequireMode {
     }
 
     pub(crate) fn get_source(&self, name: &str, rel: &Path) -> Option<PathBuf> {
-        log::trace!("lookup alias `{}` from `{}`", name, rel.display());
+        log::trace!(
+            "lookup alias `{}` from `{}` (luau mode)",
+            name,
+            rel.display()
+        );
 
         self.luau_rc_aliases
             .as_ref()

--- a/src/rules/require/path_require_mode.rs
+++ b/src/rules/require/path_require_mode.rs
@@ -90,6 +90,12 @@ impl PathRequireMode {
     }
 
     pub(crate) fn get_source(&self, name: &str, rel: &Path) -> Option<PathBuf> {
+        log::trace!(
+            "lookup alias `{}` from `{}` (path mode)",
+            name,
+            rel.display()
+        );
+
         self.sources
             .get(name)
             .map(|alias| rel.join(alias))

--- a/src/utils/luau_config.rs
+++ b/src/utils/luau_config.rs
@@ -47,6 +47,9 @@ fn find_luau_configuration_private(
                             key.insert(0, '@');
                             (key, normalize_path(ancestor.join(value)))
                         })
+                        .inspect(|(key, value)| {
+                            log::trace!(" ⨽ parsed alias `{}` (`{}`)", key, value.display())
+                        })
                         .collect();
 
                     Some(config)

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -243,6 +243,26 @@ mod without_rules {
         }
 
         #[test]
+        fn require_in_packages_directory_using_luau_rc_alias() {
+            process_main_require_value(memory_resources!(
+                "packages/value.lua" => "return true",
+                "src/main.lua" => "local value = require('@Packages/value.lua')",
+                ".luaurc" => "{ \"aliases\": { \"Packages\": \"packages\" } }",
+                ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG,
+            ));
+        }
+
+        #[test]
+        fn require_in_packages_directory_using_luau_rc_alias_starting_with_dot() {
+            process_main_require_value(memory_resources!(
+                "packages/value.lua" => "return true",
+                "src/main.lua" => "local value = require('@Packages/value.lua')",
+                ".luaurc" => "{ \"aliases\": { \"Packages\": \"./packages\" } }",
+                ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG,
+            ));
+        }
+
+        #[test]
         fn require_directory_with_custom_init_file() {
             process_main_require_value(memory_resources!(
                 "src/value/__init__.lua" => "return true",
@@ -376,6 +396,26 @@ mod without_rules {
                     "packages/value.lua" => "return true",
                     "src/main.lua" => "local value = require('@Packages/value.lua')",
                     ".darklua.json" => "{ \"rules\": [], \"generator\": \"readable\", \"bundle\": { \"require_mode\": { \"name\": \"luau\", \"sources\": { \"@Packages\": \"./packages\" } } } }",
+                ));
+            }
+
+            #[test]
+            fn require_in_packages_directory_using_luau_rc_alias() {
+                process_main_require_value(memory_resources!(
+                    "packages/value.lua" => "return true",
+                    "src/main.lua" => "local value = require('@Packages/value.lua')",
+                    ".luaurc" => "{ \"aliases\": { \"Packages\": \"packages\" } }",
+                    ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG_LUAU_MODE
+                ));
+            }
+
+            #[test]
+            fn require_in_packages_directory_using_luau_rc_alias_starting_with_dot() {
+                process_main_require_value(memory_resources!(
+                    "packages/value.lua" => "return true",
+                    "src/main.lua" => "local value = require('@Packages/value.lua')",
+                    ".luaurc" => "{ \"aliases\": { \"Packages\": \"./packages\" } }",
+                    ".darklua.json" => DARKLUA_BUNDLE_ONLY_READABLE_CONFIG_LUAU_MODE
                 ));
             }
         }


### PR DESCRIPTION
There was a typo that prevented the bundler from using the aliases from a `.luaurc` configuration file.

- [x] add entry to the changelog
