### PR TITLE
Upgrade to full_moon 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "full_moon"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7dafc2cbadd914f7019a08395a3a29c5d735cb6762751c5669e48c5ff2c775"
+checksum = "7e5544e0a9eb14156c6bdc12bfd3bdc35bef1a927e7376eb17626e5d8baec3a3"
 dependencies = [
  "bytecount",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.10.0"
 env_logger = "0.11.5"
-full_moon = { version = "1.0.0", features = ["roblox"] }
+full_moon = { version = "2.0.0", features = ["roblox"] }
 indexmap = "2.7.0"
 json5 = "0.4.1"
 log = "0.4.22"

--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -30,7 +30,7 @@ fn parse_code(c: &mut criterion::Criterion) {
     tracing::subscriber::set_global_default(
         tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt::with(
             tracing_subscriber::registry(),
-            tracing_tracy::TracyLayer::new(),
+            tracing_tracy::TracyLayer::default(),
         ),
     )
     .expect("set up the subscriber");

--- a/src/ast_converter.rs
+++ b/src/ast_converter.rs
@@ -1829,7 +1829,9 @@ impl<'a> AstConverter<'a> {
                 self.push_work(expression.as_ref());
             }
             ast::Expression::Function(function) => {
-                let (token, body) = function.as_ref();
+                let func = function.as_ref();
+                let body = func.body();
+                let token = func.function_token();
                 self.work_stack
                     .push(ConvertWork::MakeFunctionExpression { body, token });
 
@@ -2609,17 +2611,17 @@ impl<'a> AstConverter<'a> {
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
     fn convert_compound_op(
         &self,
-        operator: &ast::luau::CompoundOp,
+        operator: &ast::CompoundOp,
     ) -> Result<CompoundOperator, ConvertError> {
         Ok(match operator {
-            ast::luau::CompoundOp::PlusEqual(_) => CompoundOperator::Plus,
-            ast::luau::CompoundOp::MinusEqual(_) => CompoundOperator::Minus,
-            ast::luau::CompoundOp::StarEqual(_) => CompoundOperator::Asterisk,
-            ast::luau::CompoundOp::SlashEqual(_) => CompoundOperator::Slash,
-            ast::luau::CompoundOp::DoubleSlashEqual(_) => CompoundOperator::DoubleSlash,
-            ast::luau::CompoundOp::PercentEqual(_) => CompoundOperator::Percent,
-            ast::luau::CompoundOp::CaretEqual(_) => CompoundOperator::Caret,
-            ast::luau::CompoundOp::TwoDotsEqual(_) => CompoundOperator::Concat,
+            ast::CompoundOp::PlusEqual(_) => CompoundOperator::Plus,
+            ast::CompoundOp::MinusEqual(_) => CompoundOperator::Minus,
+            ast::CompoundOp::StarEqual(_) => CompoundOperator::Asterisk,
+            ast::CompoundOp::SlashEqual(_) => CompoundOperator::Slash,
+            ast::CompoundOp::DoubleSlashEqual(_) => CompoundOperator::DoubleSlash,
+            ast::CompoundOp::PercentEqual(_) => CompoundOperator::Percent,
+            ast::CompoundOp::CaretEqual(_) => CompoundOperator::Caret,
+            ast::CompoundOp::TwoDotsEqual(_) => CompoundOperator::Concat,
             _ => {
                 return Err(ConvertError::CompoundOperator {
                     operator: operator.to_string(),
@@ -2850,7 +2852,7 @@ enum ConvertWork<'a> {
         statement: &'a ast::Assignment,
     },
     MakeCompoundAssignStatement {
-        statement: &'a ast::luau::CompoundAssignment,
+        statement: &'a ast::CompoundAssignment,
     },
     MakeIfStatement {
         statement: &'a ast::If,
@@ -3152,9 +3154,9 @@ fn get_unary_operator_token(
 }
 
 fn get_compound_operator_token(
-    operator: &ast::luau::CompoundOp,
+    operator: &ast::CompoundOp,
 ) -> Result<&tokenizer::TokenReference, ConvertError> {
-    use ast::luau::CompoundOp;
+    use ast::CompoundOp;
 
     match operator {
         CompoundOp::PlusEqual(token)

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1163,5 +1163,5 @@ mod $mod_name {
 
     snapshot_generator!(dense, |_| DenseLuaGenerator::default(), false);
     snapshot_generator!(readable, |_| ReadableLuaGenerator::default(), false);
-    snapshot_generator!(token_based, |code| TokenBasedLuaGenerator::new(code), true);
+    snapshot_generator!(token_based, TokenBasedLuaGenerator::new, true);
 }

--- a/src/nodes/arguments.rs
+++ b/src/nodes/arguments.rs
@@ -329,10 +329,8 @@ mod tests {
         let code = format!("f {}", lua);
 
         let block = parser.parse(&code).expect("code should parse");
-        if let Some(statement) = block.first_statement() {
-            if let Statement::Call(call) = statement {
-                return call.get_arguments().clone();
-            }
+        if let Some(Statement::Call(call)) = block.first_statement() {
+            return call.get_arguments().clone();
         }
         panic!("failed to parse call arguments from: {}", lua);
     }

--- a/src/nodes/function_call.rs
+++ b/src/nodes/function_call.rs
@@ -167,10 +167,8 @@ mod tests {
     fn parse_call(code: &str) -> FunctionCall {
         let parser = Parser::default().preserve_tokens();
         let block = parser.parse(code).expect("code should parse");
-        if let Some(statement) = block.first_statement() {
-            if let Statement::Call(call) = statement {
-                return call.clone();
-            }
+        if let Some(Statement::Call(call)) = block.first_statement() {
+            return call.clone();
         }
         panic!("failed to parse call from: {}", code);
     }

--- a/src/rules/rule_property.rs
+++ b/src/rules/rule_property.rs
@@ -191,6 +191,7 @@ impl<T: Into<RulePropertyValue>> From<Option<T>> for RulePropertyValue {
 
 #[cfg(test)]
 mod test {
+    #![allow(clippy::approx_constant)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
Closes #265

Upgrade to `full_moon` 2.0.0

**Changes**
- switch to `ast::CompoundOp` and `ast::CompoundAssignment`
- handle `ast::Expression::Function(function)`
- update bench init for `tracing-tracy` 0.11
- clippy cleanups

**Effect**
- Luau function attributes (`@native`, `@inline`, etc...) now parse
- not emitting attributes yet; they'll be dropped
- no public API changes are required

**Validation**
- `cargo fmt`
- `cargo test -q`
- `cargo clippy --all-targets --all-features -D warnings`