### PR TITLE
Implement length operator computation in Lua evaluatior

### DIFF
--- a/src/process/evaluator/lua_value.rs
+++ b/src/process/evaluator/lua_value.rs
@@ -116,6 +116,14 @@ impl LuaValue {
         }
         .unwrap_or(self)
     }
+
+    /// Returns the length of a Lua value (equivalent to the `#` operator).
+    pub fn length(&self) -> LuaValue {
+        match self {
+            Self::String(value) => LuaValue::Number(value.len() as f64),
+            _ => LuaValue::Unknown,
+        }
+    }
 }
 
 impl Default for LuaValue {

--- a/src/process/evaluator/mod.rs
+++ b/src/process/evaluator/mod.rs
@@ -427,7 +427,7 @@ impl Evaluator {
                     _ => LuaValue::Unknown,
                 }
             }
-            _ => LuaValue::Unknown,
+            UnaryOperator::Length => self.evaluate(expression.get_expression()).length(),
         }
     }
 
@@ -525,6 +525,18 @@ mod test {
             => LuaValue::from(2.0),
         if_expression_elseif_always_false(IfExpression::new(false, 1.0, 0.0).with_branch(false, 2.0))
             => LuaValue::from(0.0),
+        length_empty_string(UnaryExpression::new(UnaryOperator::Length, StringExpression::empty()))
+            => LuaValue::Number(0.0),
+        length_single_char_string(UnaryExpression::new(UnaryOperator::Length, StringExpression::from_value("a")))
+            => LuaValue::Number(1.0),
+        length_short_string(UnaryExpression::new(UnaryOperator::Length, StringExpression::from_value("hello")))
+            => LuaValue::Number(5.0),
+        length_unknown_expression(UnaryExpression::new(UnaryOperator::Length, Expression::identifier("var")))
+            => LuaValue::Unknown,
+        length_number_expression(UnaryExpression::new(UnaryOperator::Length, Expression::from(42.0)))
+            => LuaValue::Unknown,
+        length_nil_expression(UnaryExpression::new(UnaryOperator::Length, Expression::nil()))
+            => LuaValue::Unknown,
     );
 
     mod binary_expressions {


### PR DESCRIPTION
Related to #5 

Implements the length operator (`#`) for string values in the Lua evaluator. This impacts the `compute_expression` rule and other rules that attempts to statically compute Lua values.

- [ ] add entry to the changelog
