### PR TITLE
Add `convert_function_to_assignment` rule

### DIFF
--- a/site/content/rules/convert_function_to_assignment.md
+++ b/site/content/rules/convert_function_to_assignment.md
@@ -1,0 +1,20 @@
+---
+description: Convert global function definitions to assignment statements
+added_in: "unreleased"
+parameters: []
+examples:
+  - content: |
+      function foo(a, b)
+          return a + b
+      end
+  - content: |
+      function obj:method(value)
+          return self.field + value
+      end
+---
+
+Global function declarations will be transformed into assignment statements. This rule handles simple global functions, functions with field access (`module.function`), and method definitions (`object:method`).
+
+When converting method syntax (`:method`), the rule automatically adds `self` as the first parameter to maintain the same behavior.
+
+Note that, depending on your Lua runtime implementation, you may no longer be able to use reflection-like APIs (eg `debug.info`) to acquire the name of the function, or the function name may be missing from stack traces of `error` invocations.

--- a/src/rules/global_function_to_assign.rs
+++ b/src/rules/global_function_to_assign.rs
@@ -1,0 +1,129 @@
+use crate::nodes::{
+    AssignStatement, Block, FieldExpression, FunctionExpression, FunctionStatement, Identifier,
+    Statement, Variable,
+};
+use crate::process::{DefaultVisitor, NodeProcessor, NodeVisitor};
+use crate::rules::{
+    Context, FlawlessRule, RuleConfiguration, RuleConfigurationError, RuleProperties,
+};
+
+use serde::ser::{Serialize, Serializer};
+use std::mem;
+
+use super::verify_no_rule_properties;
+
+struct Processor;
+
+impl Processor {
+    fn convert(&self, function: &mut FunctionStatement) -> Statement {
+        let mut function_expression = FunctionExpression::default();
+        function_expression.set_variadic(function.is_variadic());
+        mem::swap(function_expression.mutate_block(), function.mutate_block());
+        mem::swap(
+            function_expression.mutate_parameters(),
+            function.mutate_parameters(),
+        );
+
+        let name = function.get_name();
+
+        let base = name.get_name().clone();
+
+        let fields = name.get_field_names();
+
+        let variable = if fields.is_empty() {
+            if let Some(method) = name.get_method() {
+                Variable::from(FieldExpression::new(base, method.clone()))
+            } else {
+                Variable::from(base)
+            }
+        } else {
+            let mut fields_iter = fields.iter().chain(name.get_method()).map(Clone::clone);
+            let mut current = FieldExpression::new(base, fields_iter.next().unwrap());
+            while let Some(field) = fields_iter.next() {
+                current = FieldExpression::new(current, field.clone());
+            }
+            Variable::from(current)
+        };
+
+        if name.has_method() {
+            function_expression
+                .mutate_parameters()
+                .insert(0, Identifier::new("self").into());
+        }
+
+        AssignStatement::from_variable(variable, function_expression).into()
+    }
+}
+
+impl NodeProcessor for Processor {
+    fn process_statement(&mut self, statement: &mut Statement) {
+        if let Statement::Function(function) = statement {
+            let mut assign = self.convert(function);
+            mem::swap(statement, &mut assign)
+        };
+    }
+}
+
+pub const CONVERT_FUNCTION_TO_ASSIGNMENT_RULE_NAME: &str = "convert_function_to_assignment";
+
+/// Convert function statements into regular assignments.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ConvertFunctionToAssign {}
+
+impl FlawlessRule for ConvertFunctionToAssign {
+    fn flawless_process(&self, block: &mut Block, _: &Context) {
+        let mut processor = Processor;
+        DefaultVisitor::visit_block(block, &mut processor);
+    }
+}
+
+impl RuleConfiguration for ConvertFunctionToAssign {
+    fn configure(&mut self, properties: RuleProperties) -> Result<(), RuleConfigurationError> {
+        verify_no_rule_properties(&properties)?;
+
+        Ok(())
+    }
+
+    fn get_name(&self) -> &'static str {
+        CONVERT_FUNCTION_TO_ASSIGNMENT_RULE_NAME
+    }
+
+    fn serialize_to_properties(&self) -> RuleProperties {
+        RuleProperties::new()
+    }
+}
+
+impl Serialize for ConvertFunctionToAssign {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(CONVERT_FUNCTION_TO_ASSIGNMENT_RULE_NAME)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::rules::Rule;
+
+    use insta::assert_json_snapshot;
+
+    fn new_rule() -> ConvertFunctionToAssign {
+        ConvertFunctionToAssign::default()
+    }
+
+    #[test]
+    fn serialize_default_rule() {
+        assert_json_snapshot!(new_rule(), @r###""convert_function_to_assignment""###);
+    }
+
+    #[test]
+    fn configure_with_extra_field_error() {
+        let result = json5::from_str::<Box<dyn Rule>>(
+            r#"{
+            rule: 'convert_function_to_assignment',
+            prop: "something",
+        }"#,
+        );
+        pretty_assertions::assert_eq!(result.unwrap_err().to_string(), "unexpected field 'prop'");
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -15,6 +15,7 @@ mod convert_require;
 mod convert_square_root_call;
 mod empty_do;
 mod filter_early_return;
+mod global_function_to_assign;
 mod group_local;
 mod inject_value;
 mod method_def;
@@ -51,6 +52,7 @@ pub use convert_require::*;
 pub use convert_square_root_call::*;
 pub use empty_do::*;
 pub use filter_early_return::*;
+pub use global_function_to_assign::*;
 pub use group_local::*;
 pub use inject_value::*;
 pub use method_def::*;
@@ -294,6 +296,7 @@ pub fn get_all_rule_names() -> Vec<&'static str> {
     vec![
         APPEND_TEXT_COMMENT_RULE_NAME,
         COMPUTE_EXPRESSIONS_RULE_NAME,
+        CONVERT_FUNCTION_TO_ASSIGNMENT_RULE_NAME,
         CONVERT_INDEX_TO_FIELD_RULE_NAME,
         CONVERT_LOCAL_FUNCTION_TO_ASSIGN_RULE_NAME,
         CONVERT_LUAU_NUMBER_RULE_NAME,
@@ -331,6 +334,7 @@ impl FromStr for Box<dyn Rule> {
         let rule: Box<dyn Rule> = match string {
             APPEND_TEXT_COMMENT_RULE_NAME => Box::<AppendTextComment>::default(),
             COMPUTE_EXPRESSIONS_RULE_NAME => Box::<ComputeExpression>::default(),
+            CONVERT_FUNCTION_TO_ASSIGNMENT_RULE_NAME => Box::<ConvertFunctionToAssign>::default(),
             CONVERT_INDEX_TO_FIELD_RULE_NAME => Box::<ConvertIndexToField>::default(),
             CONVERT_LOCAL_FUNCTION_TO_ASSIGN_RULE_NAME => {
                 Box::<ConvertLocalFunctionToAssign>::default()

--- a/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
+++ b/src/rules/snapshots/darklua_core__rules__test__all_rule_names.snap
@@ -5,6 +5,7 @@ expression: rule_names
 [
   "append_text_comment",
   "compute_expression",
+  "convert_function_to_assignment",
   "convert_index_to_field",
   "convert_local_function_to_assign",
   "convert_luau_number",

--- a/tests/rule_tests/global_function_to_assign.rs
+++ b/tests/rule_tests/global_function_to_assign.rs
@@ -1,0 +1,35 @@
+use darklua_core::rules::{ConvertFunctionToAssign, Rule};
+
+test_rule!(
+    convert_function_to_assignment,
+    ConvertFunctionToAssign::default(),
+    empty_function("function foo() end") => "foo = function() end",
+    empty_function_with_arguments("function foo(a, b) end") => "foo = function(a, b) end",
+    empty_variadic_function("function foo(...) end") => "foo = function(...) end",
+    empty_variadic_function_with_arguments("function foo(a, b, c, ...) end") => "foo = function(a, b, c, ...) end",
+    function_with_block("function foo() return true end") => "foo = function() return true end",
+    function_with_field("function foo.bar() end") => "foo.bar = function() end",
+    function_with_field_and_arguments("function foo.bar(a, b) end") => "foo.bar = function(a, b) end",
+    function_with_nested_fields("function foo.bar.baz() end") => "foo.bar.baz = function() end",
+    function_with_method("function foo:bar() end") => "foo.bar = function(self) end",
+    function_with_method_and_arguments("function foo:bar(a, b) end") => "foo.bar = function(self, a, b) end",
+    function_with_method_and_variadic("function foo:bar(...) end") => "foo.bar = function(self, ...) end",
+    function_with_nested_fields_and_method("function foo.bar:baz() end") => "foo.bar.baz = function(self) end",
+    function_with_body("function foo() local x = 1 return x end") => "foo = function() local x = 1 return x end",
+    recursive_function("function foo() foo() end") => "foo = function() foo() end"
+);
+
+#[test]
+fn deserialize_from_object_notation() {
+    json5::from_str::<Box<dyn Rule>>(
+        r#"{
+        rule: 'convert_function_to_assignment',
+    }"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn deserialize_from_string() {
+    json5::from_str::<Box<dyn Rule>>("'convert_function_to_assignment'").unwrap();
+}

--- a/tests/rule_tests/mod.rs
+++ b/tests/rule_tests/mod.rs
@@ -539,6 +539,7 @@ mod convert_luau_number;
 mod convert_require;
 mod convert_square_root_call;
 mod filter_early_return;
+mod global_function_to_assign;
 mod group_local_assignment;
 mod inject_value;
 mod no_local_function;


### PR DESCRIPTION
Closes #11 

Add a new rule to convert function declaration statements into regular assignments.

```lua
local var = {}

function var.func() end
-- turns into:
var.func = function() end
```

- [ ] add entry to the changelog
