### PR TITLE
Support type instantiation prefixes and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* add support for type instantiation prefixes and methods (e.g. `func<<string>>()`) ([#345](https://github.com/seaofvoices/darklua/pull/345))
+
 ## 0.18.0
 
 * add `apply_to_files` and `skip_files` parameters to control for which files rules are applied ([#341](https://github.com/seaofvoices/darklua/pull/341))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -77,10 +77,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.1.2"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -99,15 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
@@ -120,10 +120,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
+ "bytes",
  "cfg_aliases",
 ]
 
@@ -140,15 +141,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -158,9 +165,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -177,6 +184,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "ciborium"
@@ -207,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -217,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -229,47 +247,47 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -284,10 +302,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.1"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
  "alloca",
  "anes",
@@ -310,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -351,9 +378,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
@@ -375,7 +402,7 @@ dependencies = [
  "env_logger",
  "full_moon",
  "include_dir",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "insta",
  "json5",
  "log",
@@ -419,7 +446,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -437,11 +464,11 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -476,9 +503,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -486,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -515,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file-id"
@@ -557,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "full_moon"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40373a6bf84c41c6124c01cbedf5ab53d0d468adf1c0d7efd4c3273531fbb609"
+checksum = "a083d6f598bbe9d70e694f2a5cf78f0354678a8c13528da2df6467b089586404"
 dependencies = [
  "bytecount",
  "cfg-if",
@@ -583,15 +610,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -622,15 +675,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "include_dir"
@@ -663,21 +722,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -693,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.2"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c91d64f9ad425e80200a50a0e8b8a641680b44e33ce832efe5b8bc65161b07"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -713,15 +774,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -730,16 +782,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -750,34 +811,51 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "json5"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c86c72f9e1d3fe29baa32cab8896548eef9aae271fce4e796d16b583fdf6d5"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
 dependencies = [
  "serde",
  "ucd-trie",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -791,11 +869,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -806,10 +884,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -819,9 +903,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -831,9 +915,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -843,9 +927,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -855,11 +939,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -881,7 +965,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -895,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "notify-debouncer-full"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375bd3a138be7bfeff3480e4a623df4cbfb55b79df617c055cd810ba466fa078"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
 dependencies = [
  "file-id",
  "log",
@@ -912,7 +996,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -936,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -951,9 +1035,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -997,15 +1081,15 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1052,27 +1136,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1081,15 +1156,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1106,6 +1181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,53 +1201,41 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand",
@@ -1170,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1190,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1202,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1213,17 +1286,17 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1238,9 +1311,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1250,6 +1323,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1288,7 +1367,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1306,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1319,7 +1398,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1348,6 +1427,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,9 +1440,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
  "borsh",
  "serde_core",
@@ -1388,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1399,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1418,22 +1503,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1457,11 +1542,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -1472,27 +1557,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1513,7 +1598,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1539,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -1559,9 +1644,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -1614,18 +1699,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1636,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1646,34 +1740,68 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wax"
-version = "0.6.0"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cbf8125142b9b30321ac8721f54c52fbcd6659f76cf863d5e2e38c07a3d7b"
 dependencies = [
  "const_format",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "nom",
  "pori",
  "regex",
@@ -1683,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1740,20 +1868,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1767,42 +1886,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1812,21 +1909,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1836,21 +1921,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1860,21 +1933,9 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1884,27 +1945,109 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xxhash-rust"
@@ -1920,26 +2063,26 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,48 +26,48 @@ path = "src/bin.rs"
 tracing = ["dep:tracing"]
 
 [dependencies]
-anstyle = "1.0.13"
+anstyle = "1.0.14"
 bstr = "1.12.1"
-clap = { version = "4.5.56", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 durationfmt = "0.1.1"
 elsa = "1.11.2"
-env_logger = "0.11.8"
-full_moon = { version = "2.1.1", features = ["roblox"] }
-indexmap = "2.13.0"
-json5 = "1.3.0"
+env_logger = "0.11.10"
+full_moon = { version = "2.2.0", features = ["roblox"] }
+indexmap = "2.14.0"
+json5 = "1.3.1"
 log = "0.4.29"
 num-traits = "0.2.19"
 pathdiff = "0.2.3"
 petgraph = "0.8.3"
-regex = "1.12.2"
+regex = "1.12.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.33"
-toml = "0.9.8"
+toml = "1.1.2"
 tracing = { version = "0.1", optional = true }
-wax = "0.6.0"
+wax = "0.7.0"
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 
 [dev-dependencies]
-assert_cmd = "2.1.2"
-criterion = { version = "0.8.1", features = ["html_reports"] }
+assert_cmd = "2.2.1"
+criterion = { version = "0.8.2", features = ["html_reports"] }
 include_dir = "0.7.4"
-insta = { version = "1.46.2", features = ["json", "filters"] }
+insta = { version = "1.47.2", features = ["json", "filters"] }
 paste = "1.0.15"
 pretty_assertions = "1.4.1"
-rand = "0.9.2"
-rand_distr = "0.5.1"
+rand = "0.10.1"
+rand_distr = "0.6.0"
 serde_bytes = "0.11.19"
-tempfile = "3.24.0"
-tracing-subscriber = "0.3.22"
+tempfile = "3.27.0"
+tracing-subscriber = "0.3.23"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ctrlc = { version = "3.5.1", features = ["termination"] }
+ctrlc = { version = "3.5.2", features = ["termination"] }
 notify = "8.2.0"
-notify-debouncer-full = "0.6.0"
+notify-debouncer-full = "0.7.0"
 
 # This is needed because when runnin `cargo test`, the library and its
 # dependencies are build with the `dev` profile. To make sure full_moon

--- a/src/ast_converter.rs
+++ b/src/ast_converter.rs
@@ -965,7 +965,7 @@ impl<'a> AstConverter<'a> {
                         Prefix::Identifier(name) => Variable::Identifier(name),
                         Prefix::Field(field) => Variable::Field(field),
                         Prefix::Index(index) => Variable::Index(index),
-                        Prefix::Call(_) | Prefix::Parenthese(_) => {
+                        Prefix::Call(_) | Prefix::Parenthese(_) | Prefix::TypeInstantiation(_) => {
                             return Err(ConvertError::Variable {
                                 variable: variable.to_string(),
                             })
@@ -1812,19 +1812,38 @@ impl<'a> AstConverter<'a> {
                     ast::Call::AnonymousCall(_) => {
                         let mut call = FunctionCall::new(prefix, self.pop_arguments()?, None);
                         if self.hold_token_data {
-                            call.set_tokens(FunctionCallTokens { colon: None })
+                            call.set_tokens(FunctionCallTokens {
+                                colon: None,
+                                type_instantiation_tokens: None,
+                            })
                         }
                         prefix = call.into();
                     }
                     ast::Call::MethodCall(method_call) => {
-                        let mut call = FunctionCall::new(
-                            prefix,
-                            self.pop_arguments()?,
-                            Some(self.convert_token_to_identifier(method_call.name())?),
-                        );
+                        let mut call = FunctionCall::new(prefix, self.pop_arguments()?, None);
+
+                        let method_name = self.convert_token_to_identifier(method_call.name())?;
+
+                        if let Some(type_instantiation) = method_call.type_instantiation() {
+                            call.set_type_instantiation_method(
+                                method_name,
+                                self.pop_types(type_instantiation.types().len())?,
+                            );
+                        } else {
+                            call.set_method(method_name);
+                        }
+
                         if self.hold_token_data {
+                            let type_instantiation_tokens = method_call
+                                .type_instantiation()
+                                .map(|type_instantiation| {
+                                    self.convert_type_instantiation_tokens(type_instantiation)
+                                })
+                                .transpose()?;
+
                             call.set_tokens(FunctionCallTokens {
                                 colon: Some(self.convert_token(method_call.colon_token())?),
+                                type_instantiation_tokens,
                             });
                         }
                         prefix = call.into();
@@ -1865,6 +1884,18 @@ impl<'a> AstConverter<'a> {
                         });
                     }
                 },
+                ast::Suffix::TypeInstantiation(type_instantiation) => {
+                    let mut type_expression = TypeInstantiationExpression::new(
+                        prefix,
+                        self.pop_types(type_instantiation.types().len())?,
+                    );
+                    if self.hold_token_data {
+                        type_expression.set_tokens(
+                            self.convert_type_instantiation_tokens(&type_instantiation)?,
+                        );
+                    }
+                    prefix = type_expression.into();
+                }
                 _ => {
                     return Err(ConvertError::Suffix {
                         suffix: suffix.to_string(),
@@ -1874,6 +1905,23 @@ impl<'a> AstConverter<'a> {
         }
 
         Ok(prefix)
+    }
+
+    fn convert_type_instantiation_tokens(
+        &mut self,
+        type_instantiation: &ast::luau::TypeInstantiation,
+    ) -> Result<TypeInstantiationTokens, ConvertError> {
+        let (first_opening_list, second_closing_list) =
+            self.extract_contained_span_tokens(type_instantiation.outer_arrows())?;
+        let (second_opening_list, first_closing_list) =
+            self.extract_contained_span_tokens(type_instantiation.inner_arrows())?;
+        Ok(TypeInstantiationTokens {
+            first_opening_list,
+            second_opening_list,
+            first_closing_list,
+            second_closing_list,
+            commas: self.extract_tokens_from_punctuation(type_instantiation.types())?,
+        })
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
@@ -2363,6 +2411,11 @@ impl<'a> AstConverter<'a> {
                     }
                     ast::Call::MethodCall(method_call) => {
                         self.push_work(method_call.args());
+                        if let Some(type_instantiation) = method_call.type_instantiation() {
+                            for type_info in type_instantiation.types() {
+                                self.push_work(type_info);
+                            }
+                        }
                     }
                     _ => {
                         return Err(ConvertError::Call {
@@ -2384,6 +2437,11 @@ impl<'a> AstConverter<'a> {
                         });
                     }
                 },
+                ast::Suffix::TypeInstantiation(type_instantiation) => {
+                    for type_info in type_instantiation.types() {
+                        self.push_work(type_info);
+                    }
+                }
                 _ => {
                     return Err(ConvertError::Suffix {
                         suffix: suffix.to_string(),

--- a/src/ast_converter.rs
+++ b/src/ast_converter.rs
@@ -1891,7 +1891,7 @@ impl<'a> AstConverter<'a> {
                     );
                     if self.hold_token_data {
                         type_expression.set_tokens(
-                            self.convert_type_instantiation_tokens(&type_instantiation)?,
+                            self.convert_type_instantiation_tokens(type_instantiation)?,
                         );
                     }
                     prefix = type_expression.into();
@@ -2325,8 +2325,7 @@ impl<'a> AstConverter<'a> {
 
                 self.push_work(inner.as_ref());
             }
-            TypeInfo::Tuple { types, parentheses } => {
-                if types.len() == 1 {
+            TypeInfo::Tuple { types, parentheses } if types.len() == 1  => {
                     self.work_stack
                         .push(ConvertWork::MakeParentheseType { parentheses });
                     self.push_work(
@@ -2335,11 +2334,12 @@ impl<'a> AstConverter<'a> {
                             .next()
                             .expect("types should contain exactly one type at this point"),
                     );
-                } else {
-                    return Err(ConvertError::TypeInfo {
-                        type_info: type_info.to_string(),
-                    });
-                }
+            }
+            TypeInfo::Tuple { .. } => {
+                return Err(ConvertError::TypeInfo {
+                    type_info: type_info.to_string(),
+                });
+
             }
             TypeInfo::Variadic { type_info, .. } => {
                 self.push_work(type_info.as_ref());

--- a/src/ast_converter.rs
+++ b/src/ast_converter.rs
@@ -2325,21 +2325,20 @@ impl<'a> AstConverter<'a> {
 
                 self.push_work(inner.as_ref());
             }
-            TypeInfo::Tuple { types, parentheses } if types.len() == 1  => {
-                    self.work_stack
-                        .push(ConvertWork::MakeParentheseType { parentheses });
-                    self.push_work(
-                        types
-                            .iter()
-                            .next()
-                            .expect("types should contain exactly one type at this point"),
-                    );
+            TypeInfo::Tuple { types, parentheses } if types.len() == 1 => {
+                self.work_stack
+                    .push(ConvertWork::MakeParentheseType { parentheses });
+                self.push_work(
+                    types
+                        .iter()
+                        .next()
+                        .expect("types should contain exactly one type at this point"),
+                );
             }
             TypeInfo::Tuple { .. } => {
                 return Err(ConvertError::TypeInfo {
                     type_info: type_info.to_string(),
                 });
-
             }
             TypeInfo::Variadic { type_info, .. } => {
                 self.push_work(type_info.as_ref());

--- a/src/generator/dense.rs
+++ b/src/generator/dense.rs
@@ -1054,6 +1054,29 @@ impl LuaGenerator for DenseLuaGenerator {
         self.write_type(type_cast.get_type());
     }
 
+    fn write_type_instantiation(
+        &mut self,
+        type_instantiation: &nodes::TypeInstantiationExpression,
+    ) {
+        self.write_prefix(type_instantiation.get_prefix());
+
+        self.push_new_line_if_needed(2);
+        self.raw_push_char('<');
+        self.raw_push_char('<');
+
+        let last_index = type_instantiation.types_len().saturating_sub(1);
+        for (index, r#type) in type_instantiation.iter_types().enumerate() {
+            self.write_type(r#type);
+            if index != last_index {
+                self.push_char(',');
+            }
+        }
+
+        self.push_new_line_if_needed(2);
+        self.raw_push_char('>');
+        self.raw_push_char('>');
+    }
+
     fn write_type_name(&mut self, type_name: &nodes::TypeName) {
         self.write_identifier(type_name.get_type_name());
         if let Some(parameters) = type_name.get_type_parameters() {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -86,6 +86,9 @@ pub trait LuaGenerator {
             Unary(unary) => self.write_unary_expression(unary),
             VariableArguments(token) => self.write_variable_arguments_expression(token),
             TypeCast(type_cast) => self.write_type_cast(type_cast),
+            TypeInstantiation(type_instantiation) => {
+                self.write_type_instantiation(type_instantiation)
+            }
         }
     }
 
@@ -127,6 +130,7 @@ pub trait LuaGenerator {
     fn write_index(&mut self, index: &nodes::IndexExpression);
     fn write_parenthese(&mut self, parenthese: &nodes::ParentheseExpression);
     fn write_type_cast(&mut self, type_cast: &nodes::TypeCastExpression);
+    fn write_type_instantiation(&mut self, type_instantiation: &nodes::TypeInstantiationExpression);
 
     fn write_false_expression(&mut self, token: &Option<nodes::Token>);
     fn write_true_expression(&mut self, token: &Option<nodes::Token>);
@@ -141,6 +145,9 @@ pub trait LuaGenerator {
             Identifier(identifier) => self.write_identifier(identifier),
             Index(index) => self.write_index(index),
             Parenthese(parenthese) => self.write_parenthese(parenthese),
+            TypeInstantiation(type_instantiation) => {
+                self.write_type_instantiation(type_instantiation)
+            }
         }
     }
 

--- a/src/generator/readable.rs
+++ b/src/generator/readable.rs
@@ -1319,6 +1319,28 @@ impl LuaGenerator for ReadableLuaGenerator {
         self.pop_can_add_new_line();
     }
 
+    fn write_type_instantiation(
+        &mut self,
+        type_instantiation: &nodes::TypeInstantiationExpression,
+    ) {
+        self.write_prefix(type_instantiation.get_prefix());
+        self.push_can_add_new_line(false);
+
+        self.push_str("<<");
+
+        let last_index = type_instantiation.types_len().saturating_sub(1);
+        for (index, r#type) in type_instantiation.iter_types().enumerate() {
+            self.write_type(r#type);
+            if index != last_index {
+                self.push_char(',');
+            }
+        }
+
+        self.push_str(">>");
+
+        self.pop_can_add_new_line();
+    }
+
     fn write_type_name(&mut self, type_name: &nodes::TypeName) {
         self.write_identifier(type_name.get_type_name());
         if let Some(parameters) = type_name.get_type_parameters() {

--- a/src/generator/token_based.rs
+++ b/src/generator/token_based.rs
@@ -220,6 +220,32 @@ impl<'a> TokenBasedLuaGenerator<'a> {
         self.write_type(type_cast.get_type());
     }
 
+    fn write_type_instantiation_with_tokens(
+        &mut self,
+        type_instantiation: &TypeInstantiationExpression,
+        tokens: &TypeInstantiationTokens,
+    ) {
+        self.write_prefix(type_instantiation.get_prefix());
+        self.write_token(&tokens.first_opening_list);
+        self.write_token(&tokens.second_opening_list);
+
+        let last_index = type_instantiation.types_len().saturating_sub(1);
+
+        for (i, r#type) in type_instantiation.iter_types().enumerate() {
+            self.write_type(r#type);
+            if i < last_index {
+                if let Some(comma) = tokens.commas.get(i) {
+                    self.write_token(comma);
+                } else {
+                    self.write_symbol(",");
+                }
+            }
+        }
+
+        self.write_token(&tokens.first_closing_list);
+        self.write_token(&tokens.second_closing_list);
+    }
+
     fn write_tuple_arguments_with_tokens(
         &mut self,
         arguments: &TupleArguments,
@@ -1603,6 +1629,18 @@ impl<'a> TokenBasedLuaGenerator<'a> {
     fn generate_function_call_tokens(&self, call: &FunctionCall) -> FunctionCallTokens {
         FunctionCallTokens {
             colon: call.get_method().map(|_| Token::from_content(":")),
+            type_instantiation_tokens: call.has_method_type_instantiation().then(|| {
+                TypeInstantiationTokens {
+                    first_opening_list: Token::from_content("<"),
+                    second_opening_list: Token::from_content("<"),
+                    first_closing_list: Token::from_content(">"),
+                    second_closing_list: Token::from_content(">"),
+                    commas: call
+                        .get_method_type_instantiation()
+                        .map(|_| Token::from_content(","))
+                        .collect(),
+                }
+            }),
         }
     }
 
@@ -1672,6 +1710,19 @@ impl<'a> TokenBasedLuaGenerator<'a> {
 
     fn generate_type_cast_token(&self, _type_cast: &TypeCastExpression) -> Token {
         Token::from_content("::")
+    }
+
+    fn generate_type_instantiation_tokens(
+        &self,
+        type_instantiation: &TypeInstantiationExpression,
+    ) -> TypeInstantiationTokens {
+        TypeInstantiationTokens {
+            first_opening_list: Token::from_content("<"),
+            second_opening_list: Token::from_content("<"),
+            first_closing_list: Token::from_content(">"),
+            second_closing_list: Token::from_content(">"),
+            commas: intersect_with_token(comma_token(), type_instantiation.types_len()),
+        }
     }
 
     fn generate_type_parameters_tokens(&self, parameters: &TypeParameters) -> TypeParametersTokens {
@@ -2372,6 +2423,17 @@ impl LuaGenerator for TokenBasedLuaGenerator<'_> {
             self.write_type_cast_with_tokens(type_cast, token);
         } else {
             self.write_type_cast_with_tokens(type_cast, &self.generate_type_cast_token(type_cast));
+        }
+    }
+
+    fn write_type_instantiation(&mut self, type_instantiation: &TypeInstantiationExpression) {
+        if let Some(tokens) = type_instantiation.get_tokens() {
+            self.write_type_instantiation_with_tokens(type_instantiation, tokens);
+        } else {
+            self.write_type_instantiation_with_tokens(
+                type_instantiation,
+                &self.generate_type_instantiation_tokens(type_instantiation),
+            );
         }
     }
 

--- a/src/generator/utils.rs
+++ b/src/generator/utils.rs
@@ -118,7 +118,8 @@ pub fn starts_with_table(mut expression: &Expression) -> Option<&TableExpression
             | Expression::InterpolatedString(_)
             | Expression::True(_)
             | Expression::Unary(_)
-            | Expression::VariableArguments(_) => break None,
+            | Expression::VariableArguments(_)
+            | Expression::TypeInstantiation(_) => break None,
             Expression::TypeCast(type_cast) => {
                 expression = type_cast.get_expression();
             }
@@ -156,7 +157,8 @@ fn expression_ends_with_prefix(expression: &Expression) -> bool {
         | Expression::Parenthese(_)
         | Expression::Identifier(_)
         | Expression::Field(_)
-        | Expression::Index(_) => true,
+        | Expression::Index(_)
+        | Expression::TypeInstantiation(_) => true,
         Expression::Unary(unary) => expression_ends_with_prefix(unary.get_expression()),
         Expression::If(if_expression) => {
             expression_ends_with_prefix(if_expression.get_else_result())
@@ -175,12 +177,24 @@ fn expression_ends_with_prefix(expression: &Expression) -> bool {
 }
 
 fn prefix_starts_with_parenthese(prefix: &Prefix) -> bool {
-    match prefix {
-        Prefix::Parenthese(_) => true,
-        Prefix::Call(call) => call_starts_with_parenthese(call),
-        Prefix::Field(field) => field_starts_with_parenthese(field),
-        Prefix::Index(index) => index_starts_with_parenthese(index),
-        Prefix::Identifier(_) => false,
+    let mut current = prefix;
+    loop {
+        match current {
+            Prefix::Parenthese(_) => break true,
+            Prefix::Identifier(_) => break false,
+            Prefix::Call(call) => {
+                current = call.get_prefix();
+            }
+            Prefix::Field(field) => {
+                current = field.get_prefix();
+            }
+            Prefix::Index(index) => {
+                current = index.get_prefix();
+            }
+            Prefix::TypeInstantiation(type_instantiation) => {
+                current = type_instantiation.get_prefix();
+            }
+        }
     }
 }
 

--- a/src/nodes/expressions/binary.rs
+++ b/src/nodes/expressions/binary.rs
@@ -60,7 +60,8 @@ fn ends_with_if_expression(expression: &Expression) -> bool {
             | Expression::Table(_)
             | Expression::True(_)
             | Expression::VariableArguments(_)
-            | Expression::TypeCast(_) => break false,
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => break false,
         }
     }
 }
@@ -122,6 +123,7 @@ fn ends_with_type_cast_to_type_name_without_type_parameters(expression: &Express
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::True(_)
+            | Expression::TypeInstantiation(_)
             | Expression::VariableArguments(_) => break false,
         }
     }

--- a/src/nodes/expressions/mod.rs
+++ b/src/nodes/expressions/mod.rs
@@ -11,6 +11,7 @@ mod string;
 pub(crate) mod string_utils;
 mod table;
 mod type_cast;
+mod type_instantiation;
 mod unary;
 
 pub use binary::*;
@@ -26,6 +27,7 @@ pub use string::*;
 pub use string_utils::StringError;
 pub use table::*;
 pub use type_cast::*;
+pub use type_instantiation::*;
 pub use unary::*;
 
 use crate::nodes::{FunctionCall, Identifier, Token, Variable};
@@ -73,6 +75,8 @@ pub enum Expression {
     VariableArguments(Option<Token>),
     /// A type cast expression (e.g., `value :: Type`)
     TypeCast(TypeCastExpression),
+    /// A type instantiation expression (e.g., `var<<Type1, Type2>>`)
+    TypeInstantiation(Box<TypeInstantiationExpression>),
 }
 
 impl Expression {
@@ -121,6 +125,9 @@ impl Expression {
                 Self::Table(table) => break table.mutate_last_token(),
                 Self::Parenthese(parenthese) => break parenthese.mutate_last_token(),
                 Self::TypeCast(type_cast) => break type_cast.mutate_last_token(),
+                Self::TypeInstantiation(type_instantiation) => {
+                    break type_instantiation.mutate_last_token()
+                }
                 Self::Unary(unary) => {
                     current = unary.mutate_expression();
                 }
@@ -344,6 +351,9 @@ impl From<Prefix> for Expression {
             Prefix::Identifier(name) => Self::Identifier(name),
             Prefix::Index(index) => Self::Index(index),
             Prefix::Parenthese(expression) => (*expression).into(),
+            Prefix::TypeInstantiation(type_instantiation) => {
+                Self::TypeInstantiation(type_instantiation)
+            }
         }
     }
 }
@@ -381,6 +391,12 @@ impl From<UnaryExpression> for Expression {
 impl From<TypeCastExpression> for Expression {
     fn from(type_cast: TypeCastExpression) -> Self {
         Self::TypeCast(type_cast)
+    }
+}
+
+impl From<TypeInstantiationExpression> for Expression {
+    fn from(type_instantiation: TypeInstantiationExpression) -> Self {
+        Self::TypeInstantiation(Box::new(type_instantiation))
     }
 }
 

--- a/src/nodes/expressions/prefix.rs
+++ b/src/nodes/expressions/prefix.rs
@@ -1,6 +1,6 @@
 use crate::nodes::{
     Expression, FieldExpression, FunctionCall, Identifier, IndexExpression, ParentheseExpression,
-    Token,
+    Token, TypeInstantiationExpression,
 };
 
 /// Represents a prefix expression.
@@ -19,6 +19,8 @@ pub enum Prefix {
     Index(Box<IndexExpression>),
     /// A parenthesized expression (e.g., `(expression)`)
     Parenthese(Box<ParentheseExpression>),
+    /// A type instantiation expression (e.g., `var<<Type1, Type2>>`)
+    TypeInstantiation(Box<TypeInstantiationExpression>),
 }
 
 impl Prefix {
@@ -48,6 +50,9 @@ impl Prefix {
                 Prefix::Parenthese(parenthese_expression) => {
                     break parenthese_expression.mutate_first_token();
                 }
+                Prefix::TypeInstantiation(type_instantiation_expression) => {
+                    current = type_instantiation_expression.mutate_prefix();
+                }
             }
         }
     }
@@ -61,6 +66,9 @@ impl Prefix {
             Prefix::Identifier(identifier) => identifier.mutate_or_insert_token(),
             Prefix::Index(index_expression) => index_expression.mutate_last_token(),
             Prefix::Parenthese(parenthese_expression) => parenthese_expression.mutate_last_token(),
+            Prefix::TypeInstantiation(type_instantiation_expression) => {
+                type_instantiation_expression.mutate_last_token()
+            }
         }
     }
 }
@@ -73,6 +81,9 @@ impl From<Expression> for Prefix {
             Expression::Identifier(identifier) => Prefix::Identifier(identifier),
             Expression::Index(index) => Prefix::Index(index),
             Expression::Parenthese(parenthese) => Prefix::Parenthese(parenthese),
+            Expression::TypeInstantiation(type_instantiation) => {
+                Prefix::TypeInstantiation(type_instantiation)
+            }
             Expression::Binary(_)
             | Expression::False(_)
             | Expression::Function(_)
@@ -131,5 +142,17 @@ impl From<Box<IndexExpression>> for Prefix {
 impl From<ParentheseExpression> for Prefix {
     fn from(expression: ParentheseExpression) -> Self {
         Self::Parenthese(Box::new(expression))
+    }
+}
+
+impl From<TypeInstantiationExpression> for Prefix {
+    fn from(type_instantiation: TypeInstantiationExpression) -> Self {
+        Self::TypeInstantiation(Box::new(type_instantiation))
+    }
+}
+
+impl From<Box<TypeInstantiationExpression>> for Prefix {
+    fn from(type_instantiation: Box<TypeInstantiationExpression>) -> Self {
+        Self::TypeInstantiation(type_instantiation)
     }
 }

--- a/src/nodes/expressions/type_instantiation.rs
+++ b/src/nodes/expressions/type_instantiation.rs
@@ -1,6 +1,6 @@
 use crate::nodes::{Prefix, Token, Type};
 
-/// Contains token information for an index expression.
+/// Contains token information for a type instantiation expression.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeInstantiationTokens {
     /// The first opening angle bracket token in the double `<<`.
@@ -22,11 +22,11 @@ impl TypeInstantiationTokens {
     );
 }
 
-/// Represents a table index access expression.
+/// Represents a Luau type instantiation expression.
 ///
-/// An index expression accesses a value in a table using square bracket notation,
-/// such as `table[key]`. It consists of a prefix (the table being accessed)
-/// and an index expression that evaluates to the key.
+/// A type instantiation applies generic type arguments to a prefix using double
+/// angle bracket notation, such as `Foo<<Bar, Baz>>`. It consists of a prefix
+/// (the type or expression being instantiated) and a list of type arguments.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TypeInstantiationExpression {
     prefix: Prefix,
@@ -35,7 +35,7 @@ pub struct TypeInstantiationExpression {
 }
 
 impl TypeInstantiationExpression {
-    /// Creates a new index expression with the given prefix and index expression.
+    /// Creates a new type instantiation expression with the given prefix and type arguments.
     pub fn new(prefix: impl Into<Prefix>, types: Vec<Type>) -> Self {
         Self {
             prefix: prefix.into(),
@@ -44,53 +44,54 @@ impl TypeInstantiationExpression {
         }
     }
 
-    /// Attaches tokens to this index expression.
+    /// Attaches tokens to this type instantiation expression.
     pub fn with_tokens(mut self, tokens: TypeInstantiationTokens) -> Self {
         self.tokens = Some(tokens);
         self
     }
 
-    /// Attaches tokens to this index expression.
+    /// Attaches tokens to this type instantiation expression.
     pub fn set_tokens(&mut self, tokens: TypeInstantiationTokens) {
         self.tokens = Some(tokens);
     }
 
-    /// Returns a reference to the tokens attached to this index expression, if any.
+    /// Returns a reference to the tokens attached to this type instantiation expression, if any.
     pub fn get_tokens(&self) -> Option<&TypeInstantiationTokens> {
         self.tokens.as_ref()
     }
 
-    /// Returns a reference to the prefix of this index expression.
+    /// Returns a reference to the prefix of this type instantiation expression.
     pub fn get_prefix(&self) -> &Prefix {
         &self.prefix
     }
 
-    /// Returns a reference to the index expression of this index expression.
+    /// Returns an iterator over the type arguments of this type instantiation expression.
     pub fn iter_types(&self) -> impl Iterator<Item = &Type> {
         self.types.iter()
     }
 
+    /// Returns the number of type arguments in this type instantiation expression.
     pub fn types_len(&self) -> usize {
         self.types.len()
     }
 
-    /// Returns a mutable reference to the prefix of this index expression.
+    /// Returns a mutable reference to the prefix of this type instantiation expression.
     pub fn mutate_prefix(&mut self) -> &mut Prefix {
         &mut self.prefix
     }
 
-    /// Returns a mutable reference to the index expression of this index expression.
+    /// Returns an iterator over the mutable type arguments of this type instantiation expression.
     pub fn iter_mut_types(&mut self) -> impl Iterator<Item = &mut Type> {
         self.types.iter_mut()
     }
 
-    /// Returns a mutable reference to the first token of this index expression,
+    /// Returns a mutable reference to the first token of this type instantiation expression,
     /// creating it if missing.
     pub fn mutate_first_token(&mut self) -> &mut crate::nodes::Token {
         self.prefix.mutate_first_token()
     }
 
-    /// Returns a mutable reference to the last token of this index expression,
+    /// Returns a mutable reference to the last token of this type instantiation expression,
     /// creating it if missing.
     pub fn mutate_last_token(&mut self) -> &mut Token {
         if self.tokens.is_none() {

--- a/src/nodes/expressions/type_instantiation.rs
+++ b/src/nodes/expressions/type_instantiation.rs
@@ -1,0 +1,111 @@
+use crate::nodes::{Prefix, Token, Type};
+
+/// Contains token information for an index expression.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeInstantiationTokens {
+    /// The first opening angle bracket token in the double `<<`.
+    pub first_opening_list: Token,
+    /// The second opening angle bracket token in the double `<<`.
+    pub second_opening_list: Token,
+    /// The first closing angle bracket token in the double `>>`.
+    pub first_closing_list: Token,
+    /// The second closing angle bracket token in the double `>>`.
+    pub second_closing_list: Token,
+    /// The comma tokens.
+    pub commas: Vec<Token>,
+}
+
+impl TypeInstantiationTokens {
+    super::impl_token_fns!(
+        target = [first_opening_list, second_opening_list, first_closing_list, second_closing_list]
+        iter = [commas]
+    );
+}
+
+/// Represents a table index access expression.
+///
+/// An index expression accesses a value in a table using square bracket notation,
+/// such as `table[key]`. It consists of a prefix (the table being accessed)
+/// and an index expression that evaluates to the key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TypeInstantiationExpression {
+    prefix: Prefix,
+    types: Vec<Type>,
+    tokens: Option<TypeInstantiationTokens>,
+}
+
+impl TypeInstantiationExpression {
+    /// Creates a new index expression with the given prefix and index expression.
+    pub fn new(prefix: impl Into<Prefix>, types: Vec<Type>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            types,
+            tokens: None,
+        }
+    }
+
+    /// Attaches tokens to this index expression.
+    pub fn with_tokens(mut self, tokens: TypeInstantiationTokens) -> Self {
+        self.tokens = Some(tokens);
+        self
+    }
+
+    /// Attaches tokens to this index expression.
+    pub fn set_tokens(&mut self, tokens: TypeInstantiationTokens) {
+        self.tokens = Some(tokens);
+    }
+
+    /// Returns a reference to the tokens attached to this index expression, if any.
+    pub fn get_tokens(&self) -> Option<&TypeInstantiationTokens> {
+        self.tokens.as_ref()
+    }
+
+    /// Returns a reference to the prefix of this index expression.
+    pub fn get_prefix(&self) -> &Prefix {
+        &self.prefix
+    }
+
+    /// Returns a reference to the index expression of this index expression.
+    pub fn iter_types(&self) -> impl Iterator<Item = &Type> {
+        self.types.iter()
+    }
+
+    pub fn types_len(&self) -> usize {
+        self.types.len()
+    }
+
+    /// Returns a mutable reference to the prefix of this index expression.
+    pub fn mutate_prefix(&mut self) -> &mut Prefix {
+        &mut self.prefix
+    }
+
+    /// Returns a mutable reference to the index expression of this index expression.
+    pub fn iter_mut_types(&mut self) -> impl Iterator<Item = &mut Type> {
+        self.types.iter_mut()
+    }
+
+    /// Returns a mutable reference to the first token of this index expression,
+    /// creating it if missing.
+    pub fn mutate_first_token(&mut self) -> &mut crate::nodes::Token {
+        self.prefix.mutate_first_token()
+    }
+
+    /// Returns a mutable reference to the last token of this index expression,
+    /// creating it if missing.
+    pub fn mutate_last_token(&mut self) -> &mut Token {
+        if self.tokens.is_none() {
+            self.tokens = Some(TypeInstantiationTokens {
+                first_opening_list: Token::from_content("<"),
+                second_opening_list: Token::from_content("<"),
+                first_closing_list: Token::from_content(">"),
+                second_closing_list: Token::from_content(">"),
+                commas: (0..self.types.len().saturating_sub(1))
+                    .map(|_| Token::from_content(","))
+                    .collect(),
+            });
+        }
+        &mut self.tokens.as_mut().unwrap().second_closing_list
+    }
+
+    super::impl_token_fns!(iter = [tokens]);
+}

--- a/src/nodes/function_call.rs
+++ b/src/nodes/function_call.rs
@@ -1,13 +1,16 @@
-use crate::nodes::{Arguments, Expression, Identifier, Prefix, Token};
+use crate::nodes::{
+    Arguments, Expression, Identifier, Prefix, Token, Type, TypeInstantiationTokens,
+};
 
 /// Tokens associated with a function call.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FunctionCallTokens {
     pub colon: Option<Token>,
+    pub type_instantiation_tokens: Option<TypeInstantiationTokens>,
 }
 
 impl FunctionCallTokens {
-    super::impl_token_fns!(iter = [colon]);
+    super::impl_token_fns!(iter = [colon, type_instantiation_tokens]);
 }
 
 /// Represents a function call expression (e.g., `func()`, `obj:method()`, `a.b.c()`).
@@ -15,8 +18,18 @@ impl FunctionCallTokens {
 pub struct FunctionCall {
     prefix: Box<Prefix>,
     arguments: Arguments,
-    method: Option<Identifier>,
+    method: Option<Method>,
     tokens: Option<FunctionCallTokens>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Method {
+    name: Identifier,
+    types: Option<Vec<Type>>,
+}
+
+impl Method {
+    super::impl_token_fns!(target = [name]);
 }
 
 impl FunctionCall {
@@ -25,7 +38,7 @@ impl FunctionCall {
         Self {
             prefix: Box::new(prefix),
             arguments,
-            method,
+            method: method.map(|name| Method { name, types: None }),
             tokens: None,
         }
     }
@@ -81,9 +94,39 @@ impl FunctionCall {
     }
 
     /// Sets the method name for this function call (for method calls like `obj:method()`).
-    pub fn with_method<IntoString: Into<Identifier>>(mut self, method: IntoString) -> Self {
-        self.method.replace(method.into());
+    pub fn with_method(mut self, method: impl Into<Identifier>) -> Self {
+        self.set_method(method.into());
         self
+    }
+
+    /// Sets the method with a specific type instantiation.
+    pub fn with_type_instantiation_method(
+        mut self,
+        method: impl Into<Identifier>,
+        types: Vec<Type>,
+    ) -> Self {
+        self.set_type_instantiation_method(method.into(), types);
+        self
+    }
+
+    /// Sets the method with a specific type instantiation.
+    pub fn set_type_instantiation_method(
+        &mut self,
+        method: impl Into<Identifier>,
+        types: Vec<Type>,
+    ) {
+        self.method = Some(Method {
+            name: method.into(),
+            types: Some(types),
+        });
+    }
+
+    /// Removes the type instantiation from the method, if any, and returns true if it was present.
+    pub fn remove_type_instantiation_from_method(&mut self) -> bool {
+        self.method
+            .as_mut()
+            .and_then(|method| method.types.take())
+            .is_some()
     }
 
     /// Returns the arguments of this function call.
@@ -95,7 +138,22 @@ impl FunctionCall {
     /// Returns the method name, if this is a method call.
     #[inline]
     pub fn get_method(&self) -> Option<&Identifier> {
-        self.method.as_ref()
+        self.method.as_ref().map(|method| &method.name)
+    }
+
+    /// Returns an iterator over the type instantiations of the method.
+    pub fn get_method_type_instantiation(&self) -> impl Iterator<Item = &Type> {
+        self.method
+            .iter()
+            .flat_map(|method| method.types.iter().flatten())
+    }
+
+    /// Returns whether this call has a method with a type instantiation.
+    pub fn has_method_type_instantiation(&self) -> bool {
+        self.method
+            .as_ref()
+            .map(|method| method.types.is_some())
+            .unwrap_or_default()
     }
 
     /// Returns if this call uses a method.
@@ -117,7 +175,7 @@ impl FunctionCall {
         if let Some(tokens) = self.tokens.as_mut() {
             tokens.colon = None;
         }
-        method
+        method.map(|method| method.name)
     }
 
     /// Sets the arguments for this function call.
@@ -129,7 +187,14 @@ impl FunctionCall {
     /// Sets the method name for this function call.
     #[inline]
     pub fn set_method(&mut self, method: Identifier) {
-        self.method.replace(method);
+        if let Some(current_method) = &mut self.method {
+            current_method.name = method;
+        } else {
+            self.method = Some(Method {
+                name: method,
+                types: None,
+            });
+        }
     }
 
     /// Returns a mutable reference to the arguments.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -246,6 +246,30 @@ mod test {
         call_indexed_table("foo.bar()") => FunctionCall::from_prefix(
             FieldExpression::new(Prefix::from_name("foo"), "bar")
         ),
+        call_indexed_with_empty_type_instantiation("foo.bar<<>>()") => FunctionCall::from_prefix(
+            TypeInstantiationExpression::new(
+                FieldExpression::new(Prefix::from_name("foo"), "bar"),
+                Vec::new()
+            )
+        ),
+        call_indexed_with_empty_type_instantiation_with_spaces("foo.bar < <   >  >  ()") => FunctionCall::from_prefix(
+            TypeInstantiationExpression::new(
+                FieldExpression::new(Prefix::from_name("foo"), "bar"),
+                Vec::new()
+            )
+        ),
+        call_indexed_with_type_instantiation_of_one_type("foo.bar<<string>>()") => FunctionCall::from_prefix(
+            TypeInstantiationExpression::new(
+                FieldExpression::new(Prefix::from_name("foo"), "bar"),
+                vec![TypeName::new("string").into()]
+            )
+        ),
+        call_indexed_with_type_instantiation_of_two_types("foo.bar< <string, number> >()") => FunctionCall::from_prefix(
+            TypeInstantiationExpression::new(
+                FieldExpression::new(Prefix::from_name("foo"), "bar"),
+                vec![TypeName::new("string").into(), TypeName::new("number").into()]
+            )
+        ),
         call_method("foo:bar()") => FunctionCall::from_name("foo").with_method("bar"),
         call_method_with_one_argument("foo:bar(true)") => FunctionCall::from_name("foo")
             .with_method("bar")
@@ -332,6 +356,15 @@ mod test {
         ),
         return_field_expression("return math.huge") => ReturnStatement::one(
             FieldExpression::new(Prefix::from_name("math"), "huge")
+        ),
+        return_type_instantiation("return foo << string >>") => ReturnStatement::one(
+            TypeInstantiationExpression::new(Prefix::from_name("foo"), vec![TypeName::new("string").into()])
+        ),
+        return_type_instantiation_indexed("return foo << string >>.bar") => ReturnStatement::one(
+            FieldExpression::new(
+                TypeInstantiationExpression::new(Prefix::from_name("foo"), vec![TypeName::new("string").into()]),
+                "bar"
+            )
         ),
         index_field_function_call("return call().result") => ReturnStatement::one(
             FieldExpression::new(FunctionCall::from_name("call"), "result"),
@@ -1646,6 +1679,7 @@ mod test {
                 commas: Vec::new(),
             })).with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_indexed_table("foo.bar()") => FunctionCall::from_prefix(
                 FieldExpression::new(
@@ -1658,6 +1692,7 @@ mod test {
                 commas: Vec::new(),
             })).with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_method("foo: bar()") => FunctionCall::from_name(create_identifier("foo", 0, 0))
                 .with_method(create_identifier("bar", 5, 0))
@@ -1668,6 +1703,29 @@ mod test {
                 }))
                 .with_tokens(FunctionCallTokens {
                     colon: Some(spaced_token(3, 4)),
+                    type_instantiation_tokens: None,
+                }),
+            call_method_with_type_instantiation_of_one_type("foo: bar< <T>--[[]]>  ()") => FunctionCall::from_name(create_identifier("foo", 0, 0))
+                .with_type_instantiation_method(
+                    create_identifier("bar", 5, 0),
+                    vec![TypeName::new(create_identifier("T", 11, 0)).into()]
+                )
+                .with_arguments(TupleArguments::default().with_tokens(TupleArgumentsTokens {
+                    opening_parenthese: token_at_first_line(22, 23),
+                    closing_parenthese: token_at_first_line(23, 24),
+                    commas: Vec::new(),
+                }))
+                .with_tokens(FunctionCallTokens {
+                    colon: Some(spaced_token(3, 4)),
+                    type_instantiation_tokens: Some(TypeInstantiationTokens {
+                        first_opening_list: spaced_token(8, 9),
+                        second_opening_list: token_at_first_line(10, 11),
+                        first_closing_list: token_at_first_line(12, 13)
+                            .with_trailing_trivia(TriviaKind::Comment.at(13, 19, 1)),
+                        second_closing_list: token_at_first_line(19, 20)
+                            .with_trailing_trivia(TriviaKind::Whitespace.at(20, 22, 1)),
+                        commas: Vec::new(),
+                    }),
                 }),
             call_method_with_one_argument("foo:bar( true )") => FunctionCall::from_name(
                 create_identifier("foo", 0, 0)
@@ -1684,6 +1742,7 @@ mod test {
                 )
             .with_tokens(FunctionCallTokens {
                 colon: Some(token_at_first_line(3, 4)),
+                type_instantiation_tokens: None,
             }),
             call_function_with_one_argument("call ( true ) ") =>  FunctionCall::from_name(
                 create_identifier("call", 0, 1)
@@ -1699,6 +1758,7 @@ mod test {
                 )
             .with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_function_with_two_arguments("call(true, true)") =>  FunctionCall::from_name(
                 create_identifier("call", 0, 0)
@@ -1715,6 +1775,7 @@ mod test {
                 )
             .with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_chain_with_args("call(true)( )") => FunctionCall::from_prefix(
                 FunctionCall::from_name(create_identifier("call", 0, 0))
@@ -1729,6 +1790,7 @@ mod test {
                         )
                     .with_tokens(FunctionCallTokens {
                         colon: None,
+                        type_instantiation_tokens: None,
                     }),
             )
             .with_arguments(TupleArguments::default().with_tokens(TupleArgumentsTokens {
@@ -1738,6 +1800,7 @@ mod test {
             }))
             .with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_with_empty_table_argument("call{ }") => FunctionCall::from_name(
                 create_identifier("call", 0, 0)
@@ -1747,6 +1810,7 @@ mod test {
                 separators: Vec::new(),
             })).with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             call_with_empty_string_argument("call ''") => FunctionCall::from_name(
                 create_identifier("call", 0, 1)
@@ -1754,6 +1818,7 @@ mod test {
                 StringExpression::empty().with_token(token_at_first_line(5, 7))
             ).with_tokens(FunctionCallTokens {
                 colon: None,
+                type_instantiation_tokens: None,
             }),
             empty_do("do end") => DoStatement::new(default_block())
                 .with_tokens(DoTokens {

--- a/src/process/evaluator/mod.rs
+++ b/src/process/evaluator/mod.rs
@@ -31,11 +31,7 @@ impl Evaluator {
             Expression::True(_) => LuaValue::True,
             Expression::Binary(binary) => self.evaluate_binary(binary),
             Expression::Unary(unary) => self.evaluate_unary(unary),
-            Expression::Parenthese(parenthese) => {
-                // when the evaluator will be able to manage tuples, keep only the first element
-                // of the tuple here (or coerce the tuple to `nil` if it is empty)
-                self.evaluate(parenthese.inner_expression())
-            }
+            Expression::Parenthese(parenthese) => self.evaluate_parenthese_expression(parenthese),
             Expression::If(if_expression) => self.evaluate_if(if_expression),
             Expression::InterpolatedString(interpolated_string) => {
                 let mut result = Vec::new();
@@ -69,6 +65,9 @@ impl Evaluator {
                 LuaValue::String(result)
             }
             Expression::TypeCast(type_cast) => self.evaluate(type_cast.get_expression()),
+            Expression::TypeInstantiation(type_instantiation) => {
+                self.evaluate_type_instantiation(type_instantiation)
+            }
             Expression::Call(_)
             | Expression::Field(_)
             | Expression::Identifier(_)
@@ -77,18 +76,42 @@ impl Evaluator {
         }
     }
 
-    #[allow(clippy::only_used_in_recursion)]
+    fn evaluate_type_instantiation(
+        &self,
+        type_instantiation: &Box<TypeInstantiationExpression>,
+    ) -> LuaValue {
+        // when the evaluator will be able to manage tuples, keep only the first element
+        // of the tuple here (or coerce the tuple to `nil` if it is empty)
+        self.evaluate_prefix(type_instantiation.get_prefix())
+    }
+
+    fn evaluate_parenthese_expression(&self, parenthese: &Box<ParentheseExpression>) -> LuaValue {
+        // when the evaluator will be able to manage tuples, keep only the first element
+        // of the tuple here (or coerce the tuple to `nil` if it is empty)
+        self.evaluate(parenthese.inner_expression())
+    }
+
+    fn evaluate_prefix(&self, prefix: &Prefix) -> LuaValue {
+        match prefix {
+            Prefix::Call(_) | Prefix::Field(_) | Prefix::Identifier(_) | Prefix::Index(_) => {
+                LuaValue::Unknown
+            }
+            Prefix::Parenthese(parenthese) => self.evaluate_parenthese_expression(parenthese),
+            Prefix::TypeInstantiation(type_instantiation) => {
+                self.evaluate_type_instantiation(type_instantiation)
+            }
+        }
+    }
+
     pub fn can_return_multiple_values(&self, expression: &Expression) -> bool {
         match expression {
-            Expression::Call(_)
-            | Expression::Field(_)
-            | Expression::Index(_)
-            | Expression::Unary(_)
-            | Expression::VariableArguments(_) => true,
+            Expression::Call(_) | Expression::Unary(_) | Expression::VariableArguments(_) => true,
             Expression::Binary(binary) => {
                 !matches!(binary.operator(), BinaryOperator::And | BinaryOperator::Or)
             }
             Expression::False(_)
+            | Expression::Field(_)
+            | Expression::Index(_)
             | Expression::Function(_)
             | Expression::Identifier(_)
             | Expression::If(_)
@@ -98,10 +121,9 @@ impl Evaluator {
             | Expression::String(_)
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
-            | Expression::True(_) => false,
-            Expression::TypeCast(type_cast) => {
-                self.can_return_multiple_values(type_cast.get_expression())
-            }
+            | Expression::True(_)
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => false,
         }
     }
 
@@ -179,6 +201,9 @@ impl Evaluator {
                     }
                 }),
             Expression::TypeCast(type_cast) => self.has_side_effects(type_cast.get_expression()),
+            Expression::TypeInstantiation(type_instantiation) => {
+                self.type_instantiation_has_side_effects(type_instantiation)
+            }
         }
     }
 
@@ -265,7 +290,17 @@ impl Evaluator {
             Prefix::Parenthese(sub_expression) => {
                 self.has_side_effects(sub_expression.inner_expression())
             }
+            Prefix::TypeInstantiation(type_instantiation) => {
+                self.type_instantiation_has_side_effects(type_instantiation)
+            }
         }
+    }
+
+    fn type_instantiation_has_side_effects(
+        &self,
+        type_instantiation: &TypeInstantiationExpression,
+    ) -> bool {
+        self.prefix_has_side_effects(type_instantiation.get_prefix())
     }
 
     #[inline]

--- a/src/process/evaluator/mod.rs
+++ b/src/process/evaluator/mod.rs
@@ -78,14 +78,14 @@ impl Evaluator {
 
     fn evaluate_type_instantiation(
         &self,
-        type_instantiation: &Box<TypeInstantiationExpression>,
+        type_instantiation: &TypeInstantiationExpression,
     ) -> LuaValue {
         // when the evaluator will be able to manage tuples, keep only the first element
         // of the tuple here (or coerce the tuple to `nil` if it is empty)
         self.evaluate_prefix(type_instantiation.get_prefix())
     }
 
-    fn evaluate_parenthese_expression(&self, parenthese: &Box<ParentheseExpression>) -> LuaValue {
+    fn evaluate_parenthese_expression(&self, parenthese: &ParentheseExpression) -> LuaValue {
         // when the evaluator will be able to manage tuples, keep only the first element
         // of the tuple here (or coerce the tuple to `nil` if it is empty)
         self.evaluate(parenthese.inner_expression())

--- a/src/process/node_processor.rs
+++ b/src/process/node_processor.rs
@@ -46,6 +46,7 @@ pub trait NodeProcessor {
     fn process_table_expression(&mut self, _: &mut TableExpression) {}
     fn process_unary_expression(&mut self, _: &mut UnaryExpression) {}
     fn process_type_cast_expression(&mut self, _: &mut TypeCastExpression) {}
+    fn process_type_instantiation(&mut self, _: &mut TypeInstantiationExpression) {}
 
     fn process_type(&mut self, _: &mut Type) {}
 
@@ -114,6 +115,7 @@ pub trait NodePostProcessor {
     fn process_after_table_expression(&mut self, _: &mut TableExpression) {}
     fn process_after_unary_expression(&mut self, _: &mut UnaryExpression) {}
     fn process_after_type_cast_expression(&mut self, _: &mut TypeCastExpression) {}
+    fn process_after_type_instantiation(&mut self, _: &mut TypeInstantiationExpression) {}
 
     fn process_after_type(&mut self, _: &mut Type) {}
 

--- a/src/process/post_visitor.rs
+++ b/src/process/post_visitor.rs
@@ -89,6 +89,9 @@ pub trait NodePostVisitor<T: NodeProcessor + NodePostProcessor> {
             Expression::TypeCast(type_cast) => {
                 Self::visit_type_cast_expression(type_cast, processor);
             }
+            Expression::TypeInstantiation(type_instantiation) => {
+                Self::visit_type_instantiation(type_instantiation, processor);
+            }
             Expression::False(_)
             | Expression::Nil(_)
             | Expression::True(_)
@@ -149,6 +152,18 @@ pub trait NodePostVisitor<T: NodeProcessor + NodePostProcessor> {
         Self::visit_expression(type_cast.mutate_expression(), processor);
         Self::visit_type(type_cast.mutate_type(), processor);
         processor.process_after_type_cast_expression(type_cast);
+    }
+
+    fn visit_type_instantiation(
+        type_instantiation: &mut TypeInstantiationExpression,
+        processor: &mut T,
+    ) {
+        processor.process_type_instantiation(type_instantiation);
+        Self::visit_prefix_expression(type_instantiation.mutate_prefix(), processor);
+        for r#type in type_instantiation.iter_mut_types() {
+            Self::visit_type(r#type, processor);
+        }
+        processor.process_after_type_instantiation(type_instantiation);
     }
 
     fn visit_function_expression(function: &mut FunctionExpression, processor: &mut T) {
@@ -515,6 +530,9 @@ pub trait NodePostVisitor<T: NodeProcessor + NodePostProcessor> {
             Prefix::Index(index) => Self::visit_index_expression(index, processor),
             Prefix::Parenthese(expression) => {
                 Self::visit_parenthese_expression(expression, processor)
+            }
+            Prefix::TypeInstantiation(type_instantiation) => {
+                Self::visit_type_instantiation(type_instantiation, processor)
             }
         };
         processor.process_after_prefix_expression(prefix);

--- a/src/process/visitors.rs
+++ b/src/process/visitors.rs
@@ -82,6 +82,9 @@ pub trait NodeVisitor<T: NodeProcessor> {
             Expression::TypeCast(type_cast) => {
                 Self::visit_type_cast_expression(type_cast, processor);
             }
+            Expression::TypeInstantiation(type_instantiation) => {
+                Self::visit_type_instantiation(type_instantiation, processor);
+            }
             Expression::False(_)
             | Expression::Nil(_)
             | Expression::True(_)
@@ -134,6 +137,18 @@ pub trait NodeVisitor<T: NodeProcessor> {
 
         Self::visit_expression(type_cast.mutate_expression(), processor);
         Self::visit_type(type_cast.mutate_type(), processor);
+    }
+
+    fn visit_type_instantiation(
+        type_instantiation: &mut TypeInstantiationExpression,
+        processor: &mut T,
+    ) {
+        processor.process_type_instantiation(type_instantiation);
+
+        Self::visit_prefix_expression(type_instantiation.mutate_prefix(), processor);
+        for r#type in type_instantiation.iter_mut_types() {
+            Self::visit_type(r#type, processor);
+        }
     }
 
     fn visit_function_expression(function: &mut FunctionExpression, processor: &mut T) {
@@ -478,6 +493,9 @@ pub trait NodeVisitor<T: NodeProcessor> {
             Prefix::Index(index) => Self::visit_index_expression(index, processor),
             Prefix::Parenthese(expression) => {
                 Self::visit_parenthese_expression(expression, processor)
+            }
+            Prefix::TypeInstantiation(type_instantiation) => {
+                Self::visit_type_instantiation(type_instantiation, processor);
             }
         };
     }

--- a/src/rules/bundle/mod.rs
+++ b/src/rules/bundle/mod.rs
@@ -4,6 +4,8 @@ mod require_mode;
 
 use std::path::Path;
 
+use wax::Program;
+
 use crate::nodes::Block;
 use crate::rules::{
     Context, Rule, RuleConfiguration, RuleConfigurationError, RuleMetadata, RuleProcessResult,
@@ -13,7 +15,6 @@ use crate::Parser;
 
 pub(crate) use rename_type_declaration::RenameTypeDeclarationProcessor;
 pub use require_mode::BundleRequireMode;
-use wax::Pattern;
 
 pub const BUNDLER_RULE_NAME: &str = "bundler";
 

--- a/src/rules/remove_comments.rs
+++ b/src/rules/remove_comments.rs
@@ -128,7 +128,8 @@ impl NodeProcessor for RemoveCommentProcessor {
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::Unary(_)
-            | Expression::TypeCast(_) => {}
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => {}
         }
     }
 
@@ -185,6 +186,10 @@ impl NodeProcessor for RemoveCommentProcessor {
 
     fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
         type_cast.clear_comments();
+    }
+
+    fn process_type_instantiation(&mut self, type_instantiation: &mut TypeInstantiationExpression) {
+        type_instantiation.clear_comments();
     }
 
     fn process_prefix_expression(&mut self, _: &mut Prefix) {}
@@ -399,7 +404,8 @@ impl NodeProcessor for FilterCommentProcessor<'_> {
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::Unary(_)
-            | Expression::TypeCast(_) => {}
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => {}
         }
     }
 
@@ -456,6 +462,10 @@ impl NodeProcessor for FilterCommentProcessor<'_> {
 
     fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
         type_cast.filter_comments(|trivia| self.ignore_trivia(trivia));
+    }
+
+    fn process_type_instantiation(&mut self, type_instantiation: &mut TypeInstantiationExpression) {
+        type_instantiation.filter_comments(|trivia| self.ignore_trivia(trivia));
     }
 
     fn process_prefix_expression(&mut self, _: &mut Prefix) {}

--- a/src/rules/remove_compound_assign.rs
+++ b/src/rules/remove_compound_assign.rs
@@ -33,7 +33,11 @@ impl Processor {
                     None
                 }
             }
-            Prefix::Identifier(_) | Prefix::Call(_) | Prefix::Field(_) | Prefix::Index(_) => None,
+            Prefix::Identifier(_)
+            | Prefix::Call(_)
+            | Prefix::Field(_)
+            | Prefix::Index(_)
+            | Prefix::TypeInstantiation(_) => None,
         }
     }
 
@@ -68,7 +72,8 @@ impl Processor {
                     Prefix::Call(_)
                     | Prefix::Field(_)
                     | Prefix::Index(_)
-                    | Prefix::Parenthese(_) => Some(self.generate_variable()),
+                    | Prefix::Parenthese(_)
+                    | Prefix::TypeInstantiation(_) => Some(self.generate_variable()),
                 };
                 let index_assignment = match index.get_index() {
                     Expression::False(_)
@@ -102,6 +107,7 @@ impl Processor {
                     | Expression::Parenthese(_)
                     | Expression::Table(_)
                     | Expression::TypeCast(_)
+                    | Expression::TypeInstantiation(_)
                     | Expression::Unary(_) => Some(self.generate_variable()),
                 };
 
@@ -180,7 +186,11 @@ impl Processor {
                         Some(new_variable.into()),
                     ))
                 }
-                Prefix::Call(_) | Prefix::Field(_) | Prefix::Index(_) | Prefix::Parenthese(_) => {
+                Prefix::Call(_)
+                | Prefix::Field(_)
+                | Prefix::Index(_)
+                | Prefix::Parenthese(_)
+                | Prefix::TypeInstantiation(_) => {
                     let identifier = self.generate_variable();
                     let new_variable = FieldExpression::new(
                         Prefix::from_name(&identifier),

--- a/src/rules/remove_method_call.rs
+++ b/src/rules/remove_method_call.rs
@@ -33,6 +33,7 @@ impl NodeProcessor for Processor {
                 | Expression::Unary(_)
                 | Expression::VariableArguments(_)
                 | Expression::TypeCast(_)
+                | Expression::TypeInstantiation(_)
                 | Expression::InterpolatedString(_)
                 | Expression::Parenthese(_)
                 | Expression::Call(_) => None,

--- a/src/rules/remove_spaces.rs
+++ b/src/rules/remove_spaces.rs
@@ -128,7 +128,8 @@ impl NodeProcessor for RemoveWhitespacesProcessor {
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::Unary(_)
-            | Expression::TypeCast(_) => {}
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => {}
         }
     }
 
@@ -185,6 +186,10 @@ impl NodeProcessor for RemoveWhitespacesProcessor {
 
     fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
         type_cast.clear_whitespaces();
+    }
+
+    fn process_type_instantiation(&mut self, type_instantiation: &mut TypeInstantiationExpression) {
+        type_instantiation.clear_whitespaces();
     }
 
     fn process_prefix_expression(&mut self, _: &mut Prefix) {}

--- a/src/rules/remove_types.rs
+++ b/src/rules/remove_types.rs
@@ -76,13 +76,8 @@ impl NodeProcessor for RemoveTypesProcessor {
     }
 
     fn process_prefix_expression(&mut self, prefix: &mut Prefix) {
-        loop {
-            match prefix {
-                Prefix::TypeInstantiation(type_instantiation) => {
-                    *prefix = type_instantiation.get_prefix().clone();
-                }
-                _ => break,
-            }
+        while let Prefix::TypeInstantiation(type_instantiation) = prefix {
+            *prefix = type_instantiation.get_prefix().clone();
         }
     }
 }

--- a/src/rules/remove_types.rs
+++ b/src/rules/remove_types.rs
@@ -45,20 +45,44 @@ impl NodeProcessor for RemoveTypesProcessor {
         function.clear_types();
     }
 
+    fn process_function_call(&mut self, call: &mut FunctionCall) {
+        call.remove_type_instantiation_from_method();
+    }
+
     fn process_expression(&mut self, expression: &mut Expression) {
-        match expression {
-            Expression::TypeCast(type_cast) => {
-                let value = type_cast.get_expression();
-                if self.evaluator.can_return_multiple_values(value) {
-                    *expression = value.clone().in_parentheses();
-                } else {
-                    *expression = value.clone();
+        loop {
+            match expression {
+                Expression::TypeCast(type_cast) => {
+                    let value = type_cast.get_expression();
+                    if self.evaluator.can_return_multiple_values(value) {
+                        *expression = value.clone().in_parentheses();
+                    } else {
+                        *expression = value.clone();
+                    }
+                }
+                Expression::TypeInstantiation(type_instantiation) => {
+                    let prefix: Expression = type_instantiation.get_prefix().clone().into();
+                    if self.evaluator.can_return_multiple_values(&prefix) {
+                        *expression = prefix.in_parentheses();
+                    } else {
+                        *expression = prefix;
+                    }
+                }
+                _ => {
+                    break;
                 }
             }
-            Expression::Function(function) => {
-                function.clear_types();
+        }
+    }
+
+    fn process_prefix_expression(&mut self, prefix: &mut Prefix) {
+        loop {
+            match prefix {
+                Prefix::TypeInstantiation(type_instantiation) => {
+                    *prefix = type_instantiation.get_prefix().clone();
+                }
+                _ => break,
             }
-            _ => {}
         }
     }
 }

--- a/src/rules/replace_referenced_tokens.rs
+++ b/src/rules/replace_referenced_tokens.rs
@@ -136,7 +136,8 @@ impl NodeProcessor for Processor<'_> {
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::Unary(_)
-            | Expression::TypeCast(_) => {}
+            | Expression::TypeCast(_)
+            | Expression::TypeInstantiation(_) => {}
         }
     }
 
@@ -193,6 +194,10 @@ impl NodeProcessor for Processor<'_> {
 
     fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
         type_cast.replace_referenced_tokens(self.code);
+    }
+
+    fn process_type_instantiation(&mut self, type_instantiation: &mut TypeInstantiationExpression) {
+        type_instantiation.replace_referenced_tokens(self.code);
     }
 
     fn process_prefix_expression(&mut self, _: &mut Prefix) {}

--- a/src/rules/shift_token_line.rs
+++ b/src/rules/shift_token_line.rs
@@ -136,6 +136,7 @@ impl NodeProcessor for ShiftTokenLineProcessor {
             | Expression::InterpolatedString(_)
             | Expression::Table(_)
             | Expression::Unary(_)
+            | Expression::TypeInstantiation(_)
             | Expression::TypeCast(_) => {}
         }
     }
@@ -193,6 +194,10 @@ impl NodeProcessor for ShiftTokenLineProcessor {
 
     fn process_type_cast_expression(&mut self, type_cast: &mut TypeCastExpression) {
         type_cast.shift_token_line(self.shift_amount);
+    }
+
+    fn process_type_instantiation(&mut self, type_instantiation: &mut TypeInstantiationExpression) {
+        type_instantiation.shift_token_line(self.shift_amount);
     }
 
     fn process_prefix_expression(&mut self, _: &mut Prefix) {}

--- a/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_in_code.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_in_code.snap
@@ -91,3 +91,9 @@ end
 type   function   example_complex_type_function <  T , U, R...>(first: T & U, opts: { [number  ]: string }? , ...: R...) :  ()
     return first
 end
+
+format << Obj >> ()
+format <   < Obj >   > ()
+Formatter.format <   <  Obj , Item<Obj> >   > ()
+
+local f = format <  < Obj >>.containerFormat["test-fn"] < < string >>

--- a/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_in_code_with_exception.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_comments__test__remove_comments_in_code_with_exception.snap
@@ -91,3 +91,9 @@ end
 type   function   example_complex_type_function <  T , U, R...>(first: T & U, opts: { [number  ]: string }? , ...: R...) :  ()
     return first
 end
+
+format << Obj >> ()
+format <   < Obj >   > ()
+Formatter.format <   <  Obj , Item<Obj> >   > ()
+
+local f = format <  < Obj >>.containerFormat["test-fn"] < < string >>

--- a/src/rules/snapshots/darklua_core__rules__remove_spaces__test__remove_spaces_in_code.snap
+++ b/src/rules/snapshots/darklua_core__rules__remove_spaces__test__remove_spaces_in_code.snap
@@ -91,3 +91,9 @@ end
 type function example_complex_type_function<T--[[]],U,R...>(first:T&U,opts:{[number--[[index type]] ]:string}?--[[opts]],...:R...):()
 return first
 end
+
+format<<Obj>>()
+format<<Obj>--[[]]>()
+Formatter.format<<--[[c]]Obj,Item<Obj>>--[[c]]>()
+
+local f=format<--[[c]]<Obj>>.containerFormat["test-fn"]<--[[c]]<string>>

--- a/src/utils/filter_pattern.rs
+++ b/src/utils/filter_pattern.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use serde::{de, Deserialize, Deserializer, Serialize};
-use wax::{Glob, Pattern};
+use wax::{Glob, Program};
 
 use crate::DarkluaError;
 

--- a/src/utils/lines.rs
+++ b/src/utils/lines.rs
@@ -124,6 +124,9 @@ fn last_expression_token(expression: &Expression) -> Option<&Token> {
         | Expression::VariableArguments(token) => token.as_ref(),
         Expression::Unary(unary) => last_expression_token(unary.get_expression()),
         Expression::TypeCast(type_cast) => last_type_token(type_cast.get_type()),
+        Expression::TypeInstantiation(type_instantiation) => type_instantiation
+            .get_tokens()
+            .map(|tokens| &tokens.second_closing_list),
     }
 }
 
@@ -228,14 +231,28 @@ fn first_variable_token(variable: &Variable) -> Option<&Token> {
 }
 
 fn first_prefix_token(prefix: &Prefix) -> Option<&Token> {
-    match prefix {
-        Prefix::Call(function_call) => first_prefix_token(function_call.get_prefix()),
-        Prefix::Field(field_expression) => first_prefix_token(field_expression.get_prefix()),
-        Prefix::Identifier(identifier) => identifier.get_token(),
-        Prefix::Index(index_expression) => first_prefix_token(index_expression.get_prefix()),
-        Prefix::Parenthese(parenthese_expression) => parenthese_expression
-            .get_tokens()
-            .map(|tokens| &tokens.left_parenthese),
+    let mut current = prefix;
+    loop {
+        match current {
+            Prefix::Call(function_call) => {
+                current = function_call.get_prefix();
+            }
+            Prefix::Field(field_expression) => {
+                current = field_expression.get_prefix();
+            }
+            Prefix::Identifier(identifier) => break identifier.get_token(),
+            Prefix::Index(index_expression) => {
+                current = index_expression.get_prefix();
+            }
+            Prefix::Parenthese(parenthese_expression) => {
+                break parenthese_expression
+                    .get_tokens()
+                    .map(|tokens| &tokens.left_parenthese)
+            }
+            Prefix::TypeInstantiation(type_instantiation) => {
+                current = type_instantiation.get_prefix();
+            }
+        }
     }
 }
 

--- a/tests/ast_fuzzer/fuzzer_work.rs
+++ b/tests/ast_fuzzer/fuzzer_work.rs
@@ -62,6 +62,9 @@ pub enum AstFuzzerWork {
     MakeParentheseExpression,
     MakeUnaryExpression,
     MakeTypeCastExpression,
+    MakeTypeInstantiationExpression {
+        types: usize,
+    },
     MakeInterpolatedString {
         segment_is_expression: Vec<bool>,
     },
@@ -91,6 +94,9 @@ pub enum AstFuzzerWork {
     MakeParenthesePrefix,
     MakeIndexPrefix,
     MakeCallPrefix,
+    MakeTypeInstantiationPrefix {
+        types: usize,
+    },
     MakeIntersectionType {
         has_leading_token: bool,
         length: usize,

--- a/tests/ast_fuzzer/mod.rs
+++ b/tests/ast_fuzzer/mod.rs
@@ -472,7 +472,7 @@ impl AstFuzzer {
                         6
                     };
                     let bound = if self.budget.has_types() && self.budget.has_expressions() {
-                        16
+                        18
                     } else {
                         15
                     };
@@ -592,20 +592,30 @@ impl AstFuzzer {
                             });
                             self.fuzz_multiple_nested_expression(depth, expression_count);
                         }
-                        _ => {
+                        17 => {
                             self.budget.try_take_expressions(1);
 
                             self.push_work(AstFuzzerWork::MakeTypeCastExpression);
                             self.fuzz_nested_expression(depth);
                             self.fuzz_type();
                         }
+                        _ => {
+                            let types_count = self
+                                .budget
+                                .try_take_types(self.random.type_instantiation_types());
+                            self.push_work(AstFuzzerWork::MakeTypeInstantiationExpression {
+                                types: types_count,
+                            });
+                            self.push_work(AstFuzzerWork::FuzzPrefix);
+                            self.fuzz_multiple_type(types_count);
+                        }
                     }
                 }
                 AstFuzzerWork::FuzzPrefix => {
                     let bound = if self.budget.can_have_expression(2) {
-                        4
+                        5
                     } else if self.budget.has_expressions() {
-                        3
+                        4
                     } else {
                         0
                     };
@@ -629,6 +639,17 @@ impl AstFuzzer {
                             self.push_work(AstFuzzerWork::MakeFunctionCall);
                             self.push_work(AstFuzzerWork::FuzzPrefix);
                             self.push_work(AstFuzzerWork::FuzzArguments);
+                        }
+                        4 => {
+                            self.budget.take_expression();
+                            let type_count = self
+                                .budget
+                                .try_take_types(self.random.type_instantiation_types());
+                            self.push_work(AstFuzzerWork::MakeTypeInstantiationPrefix {
+                                types: type_count,
+                            });
+                            self.push_work(AstFuzzerWork::FuzzPrefix);
+                            self.fuzz_multiple_type(type_count);
                         }
                         _ => {
                             self.budget.try_take_expressions(2);
@@ -1390,6 +1411,12 @@ impl AstFuzzer {
                     self.expressions
                         .push(TypeCastExpression::new(expression, r#type).into());
                 }
+                AstFuzzerWork::MakeTypeInstantiationExpression { types } => {
+                    let prefix = self.pop_prefix();
+                    let types = self.pop_types(types);
+                    self.expressions
+                        .push(TypeInstantiationExpression::new(prefix, types).into());
+                }
                 AstFuzzerWork::MakeFieldPrefix => {
                     let prefix = self.pop_prefix();
                     self.prefixes
@@ -1409,6 +1436,12 @@ impl AstFuzzer {
                 AstFuzzerWork::MakeCallPrefix => {
                     let call = self.pop_call();
                     self.prefixes.push(call.into());
+                }
+                AstFuzzerWork::MakeTypeInstantiationPrefix { types } => {
+                    let prefix = self.pop_prefix();
+                    let types = self.pop_types(types);
+                    self.prefixes
+                        .push(TypeInstantiationExpression::new(prefix, types).into());
                 }
                 AstFuzzerWork::MakeIntersectionType {
                     has_leading_token,

--- a/tests/ast_fuzzer/random.rs
+++ b/tests/ast_fuzzer/random.rs
@@ -3,7 +3,7 @@ use std::iter;
 use darklua_core::nodes::{
     BinaryOperator, CompoundOperator, Identifier, TablePropertyModifier, UnaryOperator,
 };
-use rand::{rng, Rng};
+use rand::{rng, RngExt};
 
 pub struct RandomAst {
     block_mean: f64,
@@ -163,6 +163,10 @@ impl RandomAst {
 
     pub fn return_length(&self) -> usize {
         normal_sample(self.return_length_mean, self.return_length_std_dev)
+    }
+
+    pub fn type_instantiation_types(&self) -> usize {
+        normal_sample(1.0, 1.0)
     }
 
     pub fn intersection_type_length(&self) -> usize {

--- a/tests/rule_tests/remove_if_expression.rs
+++ b/tests/rule_tests/remove_if_expression.rs
@@ -20,7 +20,7 @@ test_rule!(
     if_expression_with_varargs("local function f(...: string) return if condition(...) then ... else transform(...) end")
         => "local function f(...: string) return (condition(...) and {(...)} or {(transform(...))})[1] end",
     if_expression_with_varargs_elseif("local function f(...: string) return if condition(...) then ... elseif condition2(...) then ... else transform(...) end")
-        => "local function f(...: string) return (condition(...) and {(...)} or { ((condition2(...) and {(...)} or { (transform(...)) })[1]) }) [1] end"
+        => "local function f(...: string) return (condition(...) and {(...)} or { (condition2(...) and {(...)} or { (transform(...)) })[1] }) [1] end"
 );
 
 #[test]

--- a/tests/rule_tests/remove_nil_declaration.rs
+++ b/tests/rule_tests/remove_nil_declaration.rs
@@ -10,8 +10,8 @@ test_rule!(
     assign_to_nil_and_nil("local a, b = nil, nil") => "local a, b",
     assign_call_and_nil("local a, b = call(), nil") => "local a, b = (call())",
     assign_variadic_args_and_nil("local a, b = ..., nil") => "local a, b = (...)",
-    assign_field_expression_and_nil("local a, b = object.prop, nil") => "local a, b = (object.prop)",
-    assign_index_expression_and_nil("local a, b = object[key], nil") => "local a, b = (object[key])",
+    assign_field_expression_and_nil("local a, b = object.prop, nil") => "local a, b = object.prop",
+    assign_index_expression_and_nil("local a, b = object[key], nil") => "local a, b = object[key]",
     assign_call_and_nil_and_nil("local a, b, c = call(), nil, nil") => "local a, b, c = (call())",
     // we can re-order variables that gets assigned to `nil`
     assign_to_nil_and_true("local a, b = nil, true") => "local b, a = true",

--- a/tests/rule_tests/remove_types.rs
+++ b/tests/rule_tests/remove_types.rs
@@ -53,6 +53,12 @@ test_rule!(
         => "return value",
     remove_types_in_type_cast_of_table("return {} :: any")
         => "return {}",
+    remove_type_instantiation_in_method("obj:method<<string>>()")
+        => "obj:method()",
+    remove_type_instantiation_in_field_in_method_call("obj.field<<string>>:method()")
+        => "obj.field:method()",
+    remove_type_instantiation_in_field_call("obj.field<< string >>()")
+        => "obj.field()",
 );
 
 #[test]
@@ -110,6 +116,10 @@ fn fuzz_bundle() {
         let mut processor = HasTypeProcessor::new();
         DefaultVisitor::visit_block(&mut result_block, &mut processor);
 
-        assert!(!processor.found_type);
+        assert!(
+            !processor.found_type,
+            "found type remaining in:\n{}",
+            block_content
+        );
     })
 }

--- a/tests/rule_tests/remove_unused_if_branch.rs
+++ b/tests/rule_tests/remove_unused_if_branch.rs
@@ -18,10 +18,10 @@ test_rule!(
     expression_one_inline_result_branch("return if 1 then 'first' else 'second'") => "return 'first'",
     expression_true_inline_result_branch_with_field_expression(
         "return if true then value.prop else 'second'"
-    ) => "return (value.prop)",
+    ) => "return value.prop",
     expression_true_inline_result_branch_with_index_expression(
         "return if true then value['prop'] else 'second'"
-    ) => "return (value['prop'])",
+    ) => "return value['prop']",
     expression_true_inline_result_branch_with_variadic_expression(
         "return if true then ... else 'second'"
     ) => "return (...)",

--- a/tests/test_cases/spaces_and_comments.lua
+++ b/tests/test_cases/spaces_and_comments.lua
@@ -87,3 +87,9 @@ end
 type   function   example_complex_type_function <  T --[[]], U, R... --[[for variadic ]]>(first: T & U, opts: { [number --[[index type]] ]: string }? --[[opts]], ...: R... ) :  ()
     return first
 end
+
+format << Obj >> ()
+format <   < Obj >  --[[]] > ()
+Formatter.format <   < --[[c]] Obj , Item<Obj> >  --[[c]] > ()
+
+local f = format < --[[c]] < Obj >>.containerFormat["test-fn"] <--[[c]] < string >>


### PR DESCRIPTION
This PR add support for [type instantiation](https://rfcs.luau.org/explicit-type-parameter-instantiation.html).

The `remove_types` rule was also updated to clear this new syntax out.

- [x] add entry to the changelog
