### PR TITLE
Add `detect_globals` parameter to `rename_variables` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* add a new parameter for the `rename_variables` rule so that globals can be detected automatically and then avoided in the renaming pass ([#348](https://github.com/seaofvoices/darklua/pull/348))
 * add support for `const` declaration of variables and functions (e.g. `const var = true` or `const function test() end`) and add rule (`make_assignment_local`) to convert those assignments to `local` assignments ([#346](https://github.com/seaofvoices/darklua/pull/346))
 * add support for type instantiation prefixes and methods (e.g. `func<<string>>()`) ([#345](https://github.com/seaofvoices/darklua/pull/345))
 

--- a/site/content/rules/rename_variables.md
+++ b/site/content/rules/rename_variables.md
@@ -11,6 +11,11 @@ parameters:
     type: boolean
     default: "false"
     description: Controls if function names get renamed
+  - name: detect_globals
+    added_in: "unreleased"
+    type: boolean
+    default: "true"
+    description: Runs a pre-processor to collect globals used in per file
 ---
 
 To configure this rule to avoid using Roblox globals, add `$roblox` to the

--- a/src/process/processors/collect_globals.rs
+++ b/src/process/processors/collect_globals.rs
@@ -5,20 +5,13 @@ use crate::{
     process::{NodeProcessor, Scope},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CollectGlobalsProcessor {
     scopes: Vec<HashSet<String>>,
     globals: HashSet<String>,
 }
 
 impl CollectGlobalsProcessor {
-    pub fn new() -> Self {
-        Self {
-            scopes: Default::default(),
-            globals: Default::default(),
-        }
-    }
-
     pub(crate) fn add(&mut self, identifier: &str) {
         if self.scopes.is_empty() {
             self.scopes.push(HashSet::new());
@@ -97,7 +90,7 @@ mod test {
     use super::*;
 
     fn extract_globals(code: &str) -> Vec<String> {
-        let mut processor = CollectGlobalsProcessor::new();
+        let mut processor = CollectGlobalsProcessor::default();
 
         let mut block = Parser::default()
             .parse(code)

--- a/src/process/processors/collect_globals.rs
+++ b/src/process/processors/collect_globals.rs
@@ -1,0 +1,140 @@
+use std::collections::HashSet;
+
+use crate::{
+    nodes::{Expression, FunctionAssignment, Identifier, TypeField},
+    process::{NodeProcessor, Scope},
+};
+
+#[derive(Debug)]
+pub struct CollectGlobalsProcessor {
+    scopes: Vec<HashSet<String>>,
+    globals: HashSet<String>,
+}
+
+impl CollectGlobalsProcessor {
+    pub fn new() -> Self {
+        Self {
+            scopes: Default::default(),
+            globals: Default::default(),
+        }
+    }
+
+    pub(crate) fn add(&mut self, identifier: &str) {
+        if self.scopes.is_empty() {
+            self.scopes.push(HashSet::new());
+        }
+
+        let current = self.scopes.last_mut().unwrap();
+        if !current.contains(identifier) {
+            current.insert(identifier.to_owned());
+        }
+    }
+
+    pub fn is_declared(&self, identifier: &str) -> bool {
+        self.scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(identifier))
+    }
+
+    pub fn iter_globals(&self) -> impl Iterator<Item = &str> {
+        self.globals.iter().map(String::as_str)
+    }
+
+    pub fn into_globals(self) -> impl Iterator<Item = String> {
+        self.globals.into_iter()
+    }
+}
+
+impl Scope for CollectGlobalsProcessor {
+    fn push(&mut self) {
+        self.scopes.push(HashSet::new())
+    }
+
+    fn pop(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn insert(&mut self, identifier: &mut String) {
+        self.add(identifier);
+    }
+
+    fn insert_self(&mut self) {
+        self.add("self");
+    }
+
+    fn insert_local(&mut self, identifier: &mut String, _value: Option<&mut Expression>) {
+        self.add(identifier);
+    }
+
+    fn insert_local_function(&mut self, function: &mut FunctionAssignment) {
+        self.add(function.get_name());
+    }
+}
+
+impl NodeProcessor for CollectGlobalsProcessor {
+    fn process_variable_expression(&mut self, variable: &mut Identifier) {
+        if !self.is_declared(variable.get_name()) {
+            self.globals.insert(variable.get_name().clone());
+        }
+    }
+
+    fn process_type_field(&mut self, type_field: &mut TypeField) {
+        let namespace = type_field.get_namespace().get_name();
+        if !self.is_declared(namespace) {
+            self.globals.insert(namespace.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        process::{NodeVisitor, ScopeVisitor},
+        Parser,
+    };
+
+    use super::*;
+
+    fn extract_globals(code: &str) -> Vec<String> {
+        let mut processor = CollectGlobalsProcessor::new();
+
+        let mut block = Parser::default()
+            .parse(code)
+            .expect("expected code should parse");
+
+        ScopeVisitor::visit_block(&mut block, &mut processor);
+
+        let mut globals = processor.into_globals().collect::<Vec<_>>();
+        globals.sort();
+        globals
+    }
+
+    #[test]
+    fn catch_global_variable_in_module_scope() {
+        insta::assert_debug_snapshot!(extract_globals(r#"
+local g = game
+return g
+        "#), @r###"
+        [
+            "game",
+        ]
+        "###);
+    }
+
+    #[test]
+    fn catch_global_variable_within_function_scope() {
+        insta::assert_debug_snapshot!(extract_globals(r#"
+local function example()
+    return unpack(game:GetService("Players"):GetPlayers())
+end
+
+return { example = example }
+        "#), @r###"
+        [
+            "game",
+            "unpack",
+        ]
+        "###);
+    }
+}

--- a/src/process/processors/mod.rs
+++ b/src/process/processors/mod.rs
@@ -1,7 +1,9 @@
 //! A collection of utility processors that can be used when creating rules.
 
+mod collect_globals;
 mod find_identifier;
 mod find_usage;
 
+pub use collect_globals::*;
 pub use find_identifier::*;
 pub(crate) use find_usage::*;

--- a/src/rules/rename_variables/mod.rs
+++ b/src/rules/rename_variables/mod.rs
@@ -5,6 +5,7 @@ mod rename_processor;
 use rename_processor::RenameProcessor;
 
 use crate::nodes::Block;
+use crate::process::processors::CollectGlobalsProcessor;
 use crate::process::utils::is_valid_identifier;
 use crate::process::{DefaultVisitor, NodeVisitor, ScopeVisitor};
 use crate::rules::{
@@ -23,6 +24,7 @@ pub struct RenameVariables {
     metadata: RuleMetadata,
     globals: Vec<String>,
     include_functions: bool,
+    detect_globals: bool,
 }
 
 impl RenameVariables {
@@ -31,11 +33,22 @@ impl RenameVariables {
             metadata: RuleMetadata::default(),
             globals: Vec::from_iter(iter),
             include_functions: false,
+            detect_globals: true,
         }
     }
 
     pub fn with_function_names(mut self) -> Self {
         self.include_functions = true;
+        self
+    }
+
+    pub fn enable_global_detection(mut self) -> Self {
+        self.detect_globals = true;
+        self
+    }
+
+    pub fn disable_global_detection(mut self) -> Self {
+        self.detect_globals = false;
         self
     }
 
@@ -105,8 +118,17 @@ impl FlawlessRule for RenameVariables {
             collect_functions.into()
         };
 
+        let mut find_globals = CollectGlobalsProcessor::new();
+        if self.detect_globals {
+            ScopeVisitor::visit_block(block, &mut find_globals);
+        };
+
         let mut processor = RenameProcessor::new(
-            self.globals.clone().into_iter().chain(avoid_identifiers),
+            self.globals
+                .clone()
+                .into_iter()
+                .chain(avoid_identifiers)
+                .chain(find_globals.into_globals()),
             self.include_functions,
         );
         ScopeVisitor::visit_block(block, &mut processor);
@@ -122,6 +144,9 @@ impl RuleConfiguration for RenameVariables {
                 }
                 "include_functions" => {
                     self.include_functions = value.expect_bool(&key)?;
+                }
+                "detect_globals" => {
+                    self.detect_globals = value.expect_bool(&key)?;
                 }
                 _ => return Err(RuleConfigurationError::UnexpectedProperty(key)),
             }
@@ -149,6 +174,13 @@ impl RuleConfiguration for RenameVariables {
             properties.insert(
                 "include_functions".to_owned(),
                 RulePropertyValue::Boolean(self.include_functions),
+            );
+        }
+
+        if !self.detect_globals {
+            properties.insert(
+                "detect_globals".to_owned(),
+                RulePropertyValue::Boolean(self.detect_globals),
             );
         }
 

--- a/src/rules/rename_variables/mod.rs
+++ b/src/rules/rename_variables/mod.rs
@@ -118,7 +118,7 @@ impl FlawlessRule for RenameVariables {
             collect_functions.into()
         };
 
-        let mut find_globals = CollectGlobalsProcessor::new();
+        let mut find_globals = CollectGlobalsProcessor::default();
         if self.detect_globals {
             ScopeVisitor::visit_block(block, &mut find_globals);
         };

--- a/src/rules/rename_variables/rename_processor.rs
+++ b/src/rules/rename_variables/rename_processor.rs
@@ -162,14 +162,17 @@ impl NodeProcessor for RenameProcessor {
     fn process_variable_expression(&mut self, variable: &mut Identifier) {
         if let Some(obfuscated_name) = self.get_obfuscated_name(variable.get_name()) {
             variable.set_name(obfuscated_name);
+        } else {
+            self.avoid_identifier.insert(variable.get_name().clone());
         }
     }
 
     fn process_type_field(&mut self, type_field: &mut TypeField) {
-        if let Some(obfuscated_name) =
-            self.get_obfuscated_name(type_field.get_namespace().get_name())
-        {
+        let namespace = type_field.get_namespace().get_name();
+        if let Some(obfuscated_name) = self.get_obfuscated_name(namespace) {
             type_field.mutate_namespace().set_name(obfuscated_name);
+        } else {
+            self.avoid_identifier.insert(namespace.clone());
         }
     }
 }

--- a/tests/rule_tests/rename_variables.rs
+++ b/tests/rule_tests/rename_variables.rs
@@ -50,6 +50,8 @@ test_rule!(
     reexported_type_field("local types = require('./types') export type Oof = types.Oof") => "local a = require('./types') export type Oof = a.Oof",
     type_variable_type_field("local React = require('@pkg/@jsdotlua/react') type Props = { children: React.ReactNode }")
         => "local a = require('@pkg/@jsdotlua/react') type Props = { children: a.ReactNode }",
+    local_function_name_avoid_seen_global("a = true local function foo() end return a, foo") => "a = true local function b() end return a, b",
+    local_function_name_avoid_future_global("local function foo() end return a, foo") => "local function b() end return a, b",
 );
 
 test_rule!(


### PR DESCRIPTION
Closes #336 
Closes #319

Add a new parameter for the `rename_variables` rule so that globals can be detected automatically and then avoided in the renaming pass.

- [x] add entry to the changelog
